### PR TITLE
Add 2nd MAC address for 2nd NIC

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -143,11 +143,13 @@ constexpr const char* getKeyword<Keyword::VP>()
  *
  *  BMC       The VPD on the BMC planar, for eg
  *  ETHERNET  The ethernet card on the BMC
+ *  ETHERNET1 The 2nd ethernet card on the BMC
  */
 enum Fru
 {
     BMC,
-    ETHERNET
+    ETHERNET,
+    ETHERNET1
 };
 
 } // namespace vpd

--- a/write.cpp
+++ b/write.cpp
@@ -13,8 +13,11 @@ namespace vpd
 namespace inventory
 {
 
+// Some systems have two MAC addresses
 static const std::unordered_map<std::string, Fru> supportedFrus = {
-    {"BMC", Fru::BMC}, {"ETHERNET", Fru::ETHERNET}};
+    {"BMC", Fru::BMC},
+    {"ETHERNET", Fru::ETHERNET},
+    {"ETHERNET1", Fru::ETHERNET1}};
 
 void write(const std::string& type, const Store& vpdStore,
            const std::string& path)
@@ -43,6 +46,12 @@ void write(const std::string& type, const Store& vpdStore,
             case Fru::ETHERNET:
             {
                 writeFru<Fru::ETHERNET>(vpdStore, path);
+                break;
+            }
+
+            case Fru::ETHERNET1:
+            {
+                writeFru<Fru::ETHERNET1>(vpdStore, path);
                 break;
             }
 

--- a/writefru.yaml
+++ b/writefru.yaml
@@ -14,3 +14,9 @@ ETHERNET:
         VINI,B1: MACAddress
         OPFR,B1: MACAddress
     xyz.openbmc_project.Inventory.Item.Ethernet:
+
+ETHERNET1:
+    xyz.openbmc_project.Inventory.Item.NetworkInterface:
+        VINI,B1: MACAddress
+        OPFR,B1: MACAddress
+    xyz.openbmc_project.Inventory.Item.Ethernet:


### PR DESCRIPTION
In somes systms, there are 2 MAC addresses for 2 NICs like mihawk. In
order to support system like Mihawk, add another FRU ETHERNET1 to get
the 2nd NIC's MAC address.

Signed-off-by: Alvin Wang <alvinwang@msn.com>
Change-Id: I7c01e346af41e080ab3498c5d32ecdeb3d825e90