### PR TITLE
Add support for VNDR Records

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -8,6 +8,7 @@ namespace vpd
 /** @brief OpenPOWER VPD records we're interested in */
 enum class Record
 {
+    VNDR, /**< Vendor-specific data information */
     VINI, /**< Initial information, common to all OpenPOWER FRUs */
     OPFR, /**< OpenPOWER FRU information, common to all OpenPOWER FRUs */
     OSYS  /**< Information specific to a system board */
@@ -19,6 +20,12 @@ enum class Record
  */
 template <Record R>
 constexpr const char* getRecord() = delete;
+
+template <>
+constexpr const char* getRecord<Record::VNDR>()
+{
+    return "VNDR";
+}
 
 template <>
 constexpr const char* getRecord<Record::VINI>()
@@ -55,6 +62,7 @@ enum class Keyword
     MM, /**< FRU model */
     UD, /**< System UUID */
     VS, /**< OpenPower serial number */
+    IN, /**< Vendor defines the data */
     VP  /**< OpenPower part number */
 };
 
@@ -129,6 +137,12 @@ template <>
 constexpr const char* getKeyword<Keyword::VS>()
 {
     return "VS";
+}
+
+template <>
+constexpr const char* getKeyword<Keyword::IN>()
+{
+    return "IN";
 }
 
 template <>

--- a/impl.cpp
+++ b/impl.cpp
@@ -19,7 +19,7 @@ namespace parser
 {
 
 static const std::unordered_map<std::string, Record> supportedRecords = {
-    {"VINI", Record::VINI}, {"OPFR", Record::OPFR}, {"OSYS", Record::OSYS}};
+    {"VINI", Record::VINI}, {"OPFR", Record::OPFR}, {"VNDR", Record::VNDR}, {"OSYS", Record::OSYS}};
 
 static constexpr auto MAC_ADDRESS_LEN_BYTES = 6;
 static constexpr auto LAST_KW = "PF";
@@ -51,6 +51,7 @@ static const std::unordered_map<std::string, internal::KeywordInfo>
         {"UD", std::make_tuple(record::Keyword::UD, keyword::Encoding::UD)},
         {"VP", std::make_tuple(record::Keyword::VP, keyword::Encoding::ASCII)},
         {"VS", std::make_tuple(record::Keyword::VS, keyword::Encoding::ASCII)},
+        {"IN", std::make_tuple(record::Keyword::IN, keyword::Encoding::ASCII)},
 };
 
 namespace


### PR DESCRIPTION
The vendor data (VNDR) record is for vendor-specific data and add
support for the IN keyword such as 4F454D.

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>