### PR TITLE
Add support for B3 keyword

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -63,6 +63,7 @@ enum class Keyword
     UD, /**< System UUID */
     VS, /**< OpenPower serial number */
     IN, /**< Vendor defines the data */
+    B3, /**< Hardware characteristics description */
     VP  /**< OpenPower part number */
 };
 
@@ -143,6 +144,12 @@ template <>
 constexpr const char* getKeyword<Keyword::IN>()
 {
     return "IN";
+}
+
+template <>
+constexpr const char* getKeyword<Keyword::B3>()
+{
+    return "B3";
 }
 
 template <>

--- a/impl.cpp
+++ b/impl.cpp
@@ -52,6 +52,7 @@ static const std::unordered_map<std::string, internal::KeywordInfo>
         {"VP", std::make_tuple(record::Keyword::VP, keyword::Encoding::ASCII)},
         {"VS", std::make_tuple(record::Keyword::VS, keyword::Encoding::ASCII)},
         {"IN", std::make_tuple(record::Keyword::IN, keyword::Encoding::ASCII)},
+        {"B3", std::make_tuple(record::Keyword::B3, keyword::Encoding::ASCII)},
 };
 
 namespace


### PR DESCRIPTION
The keyword describes the hardware characteristics for a system or a
unique FRU. This keyword is used in the VINI record, such as ETH.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>