### PR TITLE
fix for booting with correct dtb

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -368,6 +368,11 @@ const string getHW(const Parsed& vpdMap)
         }
     }
 
+    // The planar pass only comes from the LSB of the HW keyword,
+    // where as the MSB is used for other purposes such as signifying clock
+    // termination.
+    hwVal[0] = 0x00;
+
     ostringstream hwString;
     for (auto& i : hwVal)
     {


### PR DESCRIPTION
Correct dtb gets selected based on HW and IM values.
Due to HW value changed in system VPD, system is forced to boot
with default dtb.
This commit handles that error case.

Test:

./ibm-read-vpd -f /sys/bus/i2c/drivers/at24/8-0050/eeprom
DBG: after mask-02
DBG: and so systemType-50001001_0002
root@p10bmc:/tmp#

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: I5d4ae4a98815174130a156181aa0f1bd9c803cb2