### PR TITLE
Identify cable and flett cards

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -866,6 +866,7 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
     inventory::InterfaceMap interfaces;
     inventory::ObjectMap objects;
     inventory::PropertyMap prop;
+    string ccinFromVpd;
 
     // map to hold all the keywords whose value has been changed at standby
     vector<RestoredEeproms> updatedEeproms = {};
@@ -873,6 +874,10 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
     bool isSystemVpd = (filePath == systemVpdFilePath);
     if constexpr (is_same<T, Parsed>::value)
     {
+        ccinFromVpd = getKwVal(vpdMap, "VINI", "CC");
+        transform(ccinFromVpd.begin(), ccinFromVpd.end(), ccinFromVpd.begin(),
+                  ::toupper);
+
         if (isSystemVpd)
         {
             std::vector<std::string> interfaces = {motherBoardInterface};
@@ -917,6 +922,26 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
     {
         const auto& objectPath = item["inventoryPath"];
         sdbusplus::message::object_path object(objectPath);
+
+        vector<string> ccinList;
+        if (item.find("ccin") != item.end())
+        {
+            for (const auto& cc : item["ccin"])
+            {
+                string ccin = cc;
+                transform(ccin.begin(), ccin.end(), ccin.begin(), ::toupper);
+                ccinList.push_back(ccin);
+            }
+        }
+
+        if (!ccinFromVpd.empty() && !ccinList.empty() &&
+            (find(ccinList.begin(), ccinList.end(), ccinFromVpd) ==
+             ccinList.end()))
+        {
+            cout << "CCIN " << ccinFromVpd << " not found, skip exposing port "
+                 << item["inventoryPath"] << "\n";
+            continue;
+        }
 
         if (isSystemVpd)
         {

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -938,8 +938,6 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
             (find(ccinList.begin(), ccinList.end(), ccinFromVpd) ==
              ccinList.end()))
         {
-            cout << "CCIN " << ccinFromVpd << " not found, skip exposing port "
-                 << item["inventoryPath"] << "\n";
             continue;
         }
 


### PR DESCRIPTION
Some pcieslots support both cable and flett cards. To expose
the ports corresponding to the card a list of CCINs is added
to each port's inventory path in the VPD json files. Merging
this commit will expose ports that belongs to the card.

Testing:
Verified the ports corresponding to the installed card are exposed.
Here is an example output from
'busctl tree xyz.openbmc_project.Inventory.Manager':
/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10
    └─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10
    ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1
    ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2
    ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3
    └─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector4

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>