### PR TITLE
Fix Force Collect Bug

### DIFF
--- a/vpd_tool.cpp
+++ b/vpd_tool.cpp
@@ -141,6 +141,7 @@ int main(int argc, char** argv)
     catch (const exception& e)
     {
         cerr << e.what();
+        rc = -1;
     }
 
     return rc;

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -477,8 +477,8 @@ void VpdTool::forceReset(const nlohmann::basic_json<>& jsObject)
     returnCode = system(invManagerRestart.c_str());
     printReturnCode(returnCode);
 
-    string sysVpdStop = "systemctl stop system-vpd.service";
-    returnCode = system(sysVpdStop.c_str());
+    string sysVpdRestart = "systemctl restart system-vpd.service";
+    returnCode = system(sysVpdRestart.c_str());
     printReturnCode(returnCode);
 
     string udevAdd = "udevadm trigger -c add -s \"*nvmem*\" -v";


### PR DESCRIPTION
Force collection option in VPD tool needs to restart the
system vpd service in order to recollect system VPD.

This commit fixes a bug where the tool would call
`systemctl stop system-vpd.service` and replaces
it with `systemctl restart system-vpd.service`.

A stop is problematic because it also stops the
services that "Require" system vpd service. A restart
ensures that system vpd service and all services that
require it are also restarted.

Also ensure that any exception thrown when executing
the underlying VPD tool impl. results in a non-zero
rc to the shell.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Iacc364f29a3d8848dc5e43992f5a46e30a58af2f