### PR TITLE
update PEL description

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -942,12 +942,33 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                                 errMsg += " and keyword: ";
                                 errMsg += keyword;
 
+                                std::ostringstream busStream;
+                                for (uint16_t byte : busValue)
+                                {
+                                    busStream << std::setfill('0')
+                                              << std::setw(2) << std::hex
+                                              << "0x" << byte << " ";
+                                }
+
+                                std::ostringstream vpdStream;
+                                for (uint16_t byte : kwdValue)
+                                {
+                                    vpdStream << std::setfill('0')
+                                              << std::setw(2) << std::hex
+                                              << "0x" << byte << " ";
+                                }
+
                                 // data mismatch
                                 PelAdditionalData additionalData;
                                 additionalData.emplace("CALLOUT_INVENTORY_PATH",
                                                        objectPath);
 
                                 additionalData.emplace("DESCRIPTION", errMsg);
+                                additionalData.emplace("Value on Cache: ",
+                                                       busStream.str());
+                                additionalData.emplace(
+                                    "Value read from EEPROM: ",
+                                    vpdStream.str());
 
                                 createPEL(additionalData, PelSeverity::WARNING,
                                           errIntfForInvalidVPD);


### PR DESCRIPTION
The commit updates PEL description to provide keyword value
in case there is a mismatch between VPD read from cache and
VPD read from EEPROM while restoring system VPD.

Sample User data in PEL:
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_INVENTORY_PATH": "/system/chassis/motherboard",
    "DESCRIPTION": "VPD data mismatch on cache and hardware
     for record: VSYS and keyword: WN",
    "Value on Cache: ": "0x43 0x30 0x35 0x30 0x37 0x36 0x30
     0x42 0x39 0x35 0x32 0x46 ",
    "Value read from EEPROM: " "0x43 0x30 0x35 0x32 0x37 0x36
     0x30 0x42 0x39 0x35 0x32 0x46 "
},


Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>