### PR TITLE
fix performVPDRecollection flow

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -274,7 +274,7 @@ void Manager::performVPDRecollection()
                 // pass to ensure bind/unbind of data.
                 // preAction execution failed. should not call bind/unbind.
                 log<level::ERR>("Pre-Action execution failed for the FRU");
-                return;
+                continue;
             }
             prePostActionRequired = true;
         }
@@ -293,7 +293,6 @@ void Manager::performVPDRecollection()
                 executePostFailAction(jsonFile, item);
             }
         }
-        return;
     }
 }
 


### PR DESCRIPTION
The commit fixes the implementation of performVPDRecollection to
process all the FRUs marked as replacable at standby, irrespective
of any error in performing pre/post action for any FRU in case
required.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>