### PR TITLE
Update Asset Tag On Factory Resets

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -593,6 +593,31 @@ static void preAction(const nlohmann::json& json, const string& file)
 }
 
 /**
+ * @brief Fills the Decorator.AssetTag property into the interfaces map
+ *
+ * This function should only be called in cases where we did not find a JSON
+ * symlink. A missing symlink in /var/lib will be considered as a factory reset
+ * and this function will be used to default the AssetTag property.
+ *
+ * @param interfaces A possibly pre-populated map of inetrfaces to properties.
+ * @param vpdMap A VPD map of the system VPD data.
+ */
+static void fillAssetTag(inventory::InterfaceMap& interfaces,
+                         const Parsed& vpdMap)
+{
+    // Read the system serial number and MTM
+    // Default asset tag is Server-MTM-System Serial
+    inventory::Interface assetIntf{
+        "xyz.openbmc_project.Inventory.Decorator.AssetTag"};
+    inventory::PropertyMap assetTagProps;
+    std::string defaultAssetTag =
+        std::string{"Server-"} + getKwVal(vpdMap, "VSYS", "TM") +
+        std::string{"-"} + getKwVal(vpdMap, "VSYS", "SE");
+    assetTagProps.emplace("AssetTag", defaultAssetTag);
+    insertOrMerge(interfaces, assetIntf, std::move(assetTagProps));
+}
+
+/**
  * @brief Set certain one time properties in the inventory
  * Use this function to insert the Functional and Enabled properties into the
  * inventory map. This function first checks if the object in question already
@@ -1180,6 +1205,8 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
         }
     }
 
+    auto processFactoryReset = false;
+
     if (isSystemVpd)
     {
         string systemJsonName{};
@@ -1191,6 +1218,9 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
 
         fs::path target = systemJsonName;
         fs::path link = INVENTORY_JSON_SYM_LINK;
+
+        // If the symlink does not exist, we treat that as a factory reset
+        processFactoryReset = !fs::exists(INVENTORY_JSON_SYM_LINK);
 
         // Create the directory for hosting the symlink
         fs::create_directories(VPD_FILES_PATH);
@@ -1295,6 +1325,15 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
         inventory::PropertyMap presProp;
         presProp.emplace("Present", true);
         insertOrMerge(interfaces, invItemIntf, move(presProp));
+
+        if constexpr (is_same<T, Parsed>::value)
+        {
+            // Restore asset tag, if needed
+            if (processFactoryReset && objectPath == "/system")
+            {
+                fillAssetTag(interfaces, vpdMap);
+            }
+        }
 
         objects.emplace(move(object), move(interfaces));
     }


### PR DESCRIPTION
The default asset tag of the system is of the form
"Server-<MTM>-<System serial>". This commit restores the default
asset tag into the Decorator.AssetTag interface when the system VPD
service detects we are booting out of a factory reset.

This asset tag is thereafter used to set the pvm_system_name
BIOS attribute.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: I415d58ca2253f2e6fc3a67746d5e9305403a4988