### PR TITLE
Fix factory reset with power ON

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1503,11 +1503,13 @@ int main(int argc, char** argv)
         baseFruInventoryPath = js["frus"][file][0]["inventoryPath"];
         // Check if we can read the VPD file based on the power state
         // We skip reading VPD when the power is ON in two scenarios:
-        // 1) The eeprom we are trying to read is that of the system VPD
-        // 2) The JSON tells us that the FRU EEPROM cannot be read when
-        // we are powered ON.
+        // 1) The eeprom we are trying to read is that of the system VPD and the
+        // JSON symlink is already setup (the symlink's existence tells us we
+        // are not coming out of a factory reset)
+        // 2) The JSON tells us that the FRU EEPROM cannot be
+        // read when we are powered ON.
         if (js["frus"][file].at(0).value("powerOffOnly", false) ||
-            (file == systemVpdFilePath))
+            (file == systemVpdFilePath && fs::exists(INVENTORY_JSON_SYM_LINK)))
         {
             if ("xyz.openbmc_project.State.Chassis.PowerState.On" ==
                 getPowerState())


### PR DESCRIPTION
This commit makes sure that we do not skip the system
VPD collection step after a factory reset from a powered ON
state.

Skipping system VPD collection when we are powered ON is needed
because we in general do not want to take pre/post actions
that might meddle with the host's usage of PCIe slots.

However, in case there is a BMC factory reset from such a state,
we lose our JSON symlink as well as all the VPD in D-Bus.

Although factory reset from a powered ON state should be disallowed,
it is still possible to do so from a Redfish client that is not the
BMC GUI.

Therefore, to restore the system VPD in such scenarios, don't skip
system VPD collection if we detect a factory reset has taken place.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Ifa8690b763aa0835b265b7d95e52ce60a3777b59