### PR TITLE
manager: Sync AssetTag Property

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -44,6 +44,7 @@ void Manager::run()
     {
         processJSON();
         listenHostState();
+        listenAssetTag();
 
         auto event = sdeventplus::Event::get_default();
         GpioMonitor gpioMon1(jsonFile, event);
@@ -97,6 +98,49 @@ void Manager::hostStateCallBack(sdbusplus::message::message& msg)
             }
         }
         std::cerr << "Failed to read Host state" << std::endl;
+    }
+}
+
+void Manager::listenAssetTag()
+{
+    static std::shared_ptr<sdbusplus::bus::match::match> assetMatcher =
+        std::make_shared<sdbusplus::bus::match::match>(
+            _bus,
+            sdbusplus::bus::match::rules::propertiesChanged(
+                "/xyz/openbmc_project/inventory/system",
+                "xyz.openbmc_project.Inventory.Decorator.AssetTag"),
+            [this](sdbusplus::message::message& msg) {
+                assetTagCallback(msg);
+            });
+}
+
+void Manager::assetTagCallback(sdbusplus::message::message& msg)
+{
+    if (msg.is_method_error())
+    {
+        std::cerr << "Error in reading signal " << std::endl;
+    }
+
+    Path object;
+    PropertyMap propMap;
+    msg.read(object, propMap);
+    const auto itr = propMap.find("AssetTag");
+    if (itr != propMap.end())
+    {
+        if (auto assetTag = std::get_if<std::string>(&(itr->second)))
+        {
+            // Call Notify to persist the AssetTag
+            inventory::ObjectMap objectMap = {
+                {std::string{"/system"},
+                 {{"xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                   {{"AssetTag", *assetTag}}}}}};
+
+            common::utility::callPIM(std::move(objectMap));
+        }
+        else
+        {
+            std::cerr << "Failed to read asset tag" << std::endl;
+        }
     }
 }
 

--- a/vpd-manager/manager.hpp
+++ b/vpd-manager/manager.hpp
@@ -151,6 +151,16 @@ class Manager : public ServerObject<ManagerIface>
      */
     void hostStateCallBack(sdbusplus::message::message& msg);
 
+    /** @brief Api to register AssetTag property change.
+     * This api will register callback to listen for asset tag property change.
+     */
+    void listenAssetTag();
+
+    /** @brief Callback to listen for Asset tag change
+     *  @param[in] msg - callback message.
+     */
+    void assetTagCallback(sdbusplus::message::message& msg);
+
     /**
      * @brief An api to trigger vpd collection for a fru by bind/unbind of
      * driver.


### PR DESCRIPTION
The AssetTag property on the system inventory object is used to
hold the custom system name. This property is settable by the user via
Redfish and by the host via PLDM.

The Redfish server and PLDM daemon both use the
org.freedesktop.DBus.Properties Set method to set this on D-Bus.

However, this is not persisted by PIM, which only persists properties
that get set via  Notify call.

This commit adds a workaround to the VPD manager code to listen for
property changed events on the AssetTag property and relay it to a
Notify call so that the custom name is persisted.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: I8839fbb5f014949040d85b03ed13e22790438529