### PR TITLE
Revert "pel: Set default severity to informational"

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1368,7 +1368,7 @@ int main(int argc, char** argv)
     std::string baseFruInventoryPath = {};
 
     // severity for PEL
-    PelSeverity pelSeverity = PelSeverity::INFORMATIONAL;
+    PelSeverity pelSeverity = PelSeverity::WARNING;
 
     try
     {


### PR DESCRIPTION
This reverts commit 712984f4360d61222bab565a77a40579e16af0d1.