### PR TITLE
PEL: Check Presence Before Error Logging

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1618,6 +1618,12 @@ int main(int argc, char** argv)
                  << "]'s VPD is not valid on PASS1 planar.Ignoring.\n";
             rc = 0;
         }
+        else if (!(isPresent(js, file).value_or(true)))
+        {
+            cout << "FRU at: " << file
+                 << " is not detected present. Ignore parser error.\n";
+            rc = 0;
+        }
         else
         {
             string errorMsg =

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <optional>
 
 using namespace std;
 
@@ -262,7 +263,24 @@ string getPrintableValue(const Binary& vec);
 string byteArrayToHexString(const Binary& vec);
 
 /**
- * @brief Performs any pre-action needed to get the FRU setup for collection.
+ * @brief Return presence of the FRU.
+ *
+ * This API returns the presence information of the FRU corresponding to the
+ * given EEPROM. If the JSON contains no information about presence detect, this
+ * will return an empty optional. Else it will get the presence GPIO information
+ * from the JSON and return the appropriate present status.
+ * In case of GPIO find/read errors, it will return false.
+ *
+ * @param[in] json - The VPD JSON
+ * @param[in] file - EEPROM file path
+ * @return Empty optional if there is no presence info. Else returns presence
+ * based on the GPIO read.
+ */
+std::optional<bool> isPresent(const nlohmann::json& json, const string& file);
+
+/**
+ * @brief Performs any pre-action needed to get the FRU setup for
+ * collection.
  *
  * @param[in] json - json object
  * @param[in] file - eeprom file path


### PR DESCRIPTION
In case of VPD parsing exceptions, check if the FRU presence is false.
If it is, then ignore any parser errors.

This helps with cases where a card with a VPD we don't recognize
shows up at the same address, but witout the presence detect.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Ia57dec455f37db52c480b9dbbb23b3cea2ec0f14