### PR TITLE
Handle ECC update

### DIFF
--- a/test/vpd-manager-test/editor_test.cpp
+++ b/test/vpd-manager-test/editor_test.cpp
@@ -161,14 +161,13 @@ TEST_F(vpdManagerEditorTest, UpdateKwd_Success)
 
     try
     {
-        // All valid data
+        // All valid data, but can't update with dummy ECC code
         EditorImpl edit("VINI", "SN", std::move(vpd));
         edit.updateKeyword(dataToUodate, 0, true);
     }
     catch (const std::runtime_error& e)
     {
-        EXPECT_EQ(std::string(e.what()),
-                  std::string("Data updated successfully"));
+        EXPECT_EQ(std::string(e.what()), std::string("Ecc update failed"));
     }
 }
 

--- a/vpdecc/vpdecc.c
+++ b/vpdecc/vpdecc.c
@@ -5,9 +5,7 @@
 int vpdecc_create_ecc(const unsigned char* data, size_t data_length,
                       unsigned char* ecc, size_t* ecc_buffersize)
 {
-    int i, vRet = 0;
-
-    memset(ecc, 0, *ecc_buffersize);
+    int i, vRet = -1;
 
     return vRet;
 }


### PR DESCRIPTION
By default openpower-vpd-parser contains dummy code of ecc_create
which writes 0s to the vpd-ecc. And this corrupts the ECC.

This commit will not allow the user to update any record-kwd-data
with dummy ecc_create code as it returns -1. If want to update any vpd
data then build your image with vpdecc functions implementation.

Test-
when tried to update the keyword-
busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword ossay  "/system/chassis/motherboard" "VINI" "PN" 1 65
ERROR: ECC update failed

And another terminal output-
root@rainier:/tmp# ./vpd-manager
Error: Couldn't update the ECC

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: I3fbb9ddce4b3545e10957eec983437b08b4a4e18