### PR TITLE
Fix PCIe device check

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -465,12 +465,12 @@ static bool isThisPcieOnPass1planar(const nlohmann::json& js,
     // Check if it is a PCIE device
     if (js["frus"].find(file) != js["frus"].end())
     {
-        if ((js["frus"][file].find("extraInterfaces") !=
-             js["frus"][file].end()))
+        if ((js["frus"][file].at(0).find("extraInterfaces") !=
+             js["frus"][file].at(0).end()))
         {
-            if (js["frus"][file]["extraInterfaces"].find(
+            if (js["frus"][file].at(0)["extraInterfaces"].find(
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice") !=
-                js["frus"][file]["extraInterfaces"].end())
+                js["frus"][file].at(0)["extraInterfaces"].end())
             {
                 isThisPCIeDev = true;
             }


### PR DESCRIPTION
We check if the VPD that we failed to parse is for a PCIe card
and ignore any errors if it was on pass 1 hardware.

This fixes a bug where the code was not properly indexing into
the JSON array to figure out if the VPD belonged to a PCIe device.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: I15434a0a27a1b86b044be9d5b843422c8d2474ae