### PR TITLE
Set presence for embedded non-synthesized frus

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -705,9 +705,16 @@ inventory::ObjectMap primeInventory(const nlohmann::json& jsObject,
                 !itemEEPROM.value("noprime", false))
             {
                 inventory::PropertyMap presProp;
-                presProp.emplace("Present", false);
-                interfaces.emplace("xyz.openbmc_project.Inventory.Item",
-                                   presProp);
+
+                // Do not populate Present property for frus whose
+                // synthesized=true. synthesized=true says the fru is owned by
+                // some other component and not by vpd.
+                if (!itemEEPROM.value("synthesized", false))
+                {
+                    presProp.emplace("Present", false);
+                    interfaces.emplace("xyz.openbmc_project.Inventory.Item",
+                                       presProp);
+                }
                 setOneTimeProperties(object, interfaces);
                 if (itemEEPROM.find("extraInterfaces") != itemEEPROM.end())
                 {
@@ -1362,9 +1369,25 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
                 }
             }
         }
-        inventory::PropertyMap presProp;
-        presProp.emplace("Present", true);
-        insertOrMerge(interfaces, invItemIntf, move(presProp));
+
+        // embedded property(true or false) says whether the subfru is embedded
+        // into the parent fru (or) not. VPD sets Present property only for
+        // embedded frus. If the subfru is not an embedded FRU, the subfru may
+        // or may not be physically present. Those non embedded frus will always
+        // have Present=false irrespective of its physical presence or absence.
+        // Eg: nvme drive in nvme slot is not an embedded FRU. So don't set
+        // Present to true for such sub frus.
+        // Eg: ethernet port is embedded into bmc card. So set Present to true
+        // for such sub frus. Also donot populate present property for embedded
+        // subfru which is synthesized. Currently there is no subfru which are
+        // both embedded and synthesized. But still the case is handled here.
+        if ((item.value("embedded", true)) &&
+            (!item.value("synthesized", false)))
+        {
+            inventory::PropertyMap presProp;
+            presProp.emplace("Present", true);
+            insertOrMerge(interfaces, invItemIntf, move(presProp));
+        }
 
         if constexpr (is_same<T, Parsed>::value)
         {


### PR DESCRIPTION
This commit makes ibm-vpd-parser app to set the Present
property for embedded non-synthesized subfrus and skip
populating Present property for synthesized frus/subfrus
during priming the inventory.

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>
Change-Id: I21059f6a3790a41aee90f51338fa48968d7f5246