### PR TITLE
VPD ECC shared library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,18 @@ phosphor_logging = dependency('phosphor-logging',
 
 sdbusplus = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
 
+libvpdecc_src = files(
+    'vpdecc/vpdecc.c',
+    'vpdecc/vpdecc_support.c'
+)
+
+libvpdecc = shared_library(
+    'vpdecc',
+    libvpdecc_src,
+    version: meson.project_version(),
+    install: true,
+)
+
 if not build_tests.disabled()
     subdir('test')
 endif
@@ -100,7 +112,6 @@ common_SOURCES =['common_utility.cpp',
                  'vpd-parser/memory_vpd_parser.cpp',
                  'vpd-parser/keyword_vpd_parser.cpp',
                  'vpd-parser/ipz_parser.cpp', 'impl.cpp', 'ibm_vpd_utils.cpp',
-                 'vpdecc/vpdecc.c', 'vpdecc/vpdecc_support.c'
 ]
 
 if get_option('ibm-parser').enabled()
@@ -116,6 +127,7 @@ if get_option('ibm-parser').enabled()
                                         phosphor_logging,
                                         libgpiodcxx,
                                 ],
+                                link_with : libvpdecc,
                                 include_directories : 'vpd-parser/',
                                 install: true,
                                 cpp_args : '-DIPZ_PARSER'
@@ -135,6 +147,7 @@ if get_option('ibm-parser').enabled()
                                    sdbusplus,
                                    libgpiodcxx
                                    ],
+                                 link_with : libvpdecc,
                                  install: true,
                                  include_directories : vpd_tool_INCLUDE
                                  )

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,8 +26,6 @@ vpd_test = ['store/store.cpp',
 ]
 
 application_src =['../impl.cpp',
-                   '../vpdecc/vpdecc.c',
-                   '../vpdecc/vpdecc_support.c',
                    '../vpd-parser/ipz_parser.cpp',
                    '../ibm_vpd_utils.cpp',
                    '../common_utility.cpp',
@@ -47,7 +45,8 @@ foreach t : vpd_test
     c_args: ['-Wno-unused-parameter',
       '-Wno-unused-variable'],
     dependencies: dependecy_list,
-    include_directories: configuration_inc
+    include_directories: configuration_inc,
+    link_with : libvpdecc,
     ),
     workdir: meson.current_source_dir())
 endforeach

--- a/vpd-manager/meson.build
+++ b/vpd-manager/meson.build
@@ -15,8 +15,6 @@ vpd_manager_SOURCES =['manager_main.cpp',
                       '../vpd-parser/ipz_parser.cpp',
                       '../ibm_vpd_utils.cpp',
                       '../common_utility.cpp',
-                      '../vpdecc/vpdecc.c',
-                      '../vpdecc/vpdecc_support.c',
                       '../vpd-parser//keyword_vpd_parser.cpp',
                       '../vpd-parser/memory_vpd_parser.cpp',
                       '../vpd-parser/parser_factory.cpp'
@@ -37,5 +35,6 @@ vpd_manager_exe = executable(
                  dependencies : [
                                 vpd_manager_dependencies,
                                 ],
+                 link_with : libvpdecc,
                  install : true
                 )


### PR DESCRIPTION
This commit makes the VPD ECC source into a shared library
and links the shared library with other executables which
are dependant on VPD ECC.

Since the ECC source file is confidential, we need to share the
ECC as a shared library to the IBM Power customers.

Test:
Tested on simics:
1. Corrupted the vpd data.
root@p10bmc:/usr/lib# dd if=/dev/zero of=/sys/bus/i2c/drivers/at24/7-0050/eeprom bs=1 count=2 seek=184
2+0 records in
2+0 records out

root@p10bmc:/usr/lib# ibm-read-vpd --file /sys/bus/i2c/drivers/at24/7-0050/eeprom
ERROR: ECC check did not pass for the Record:VINI

2. VPD Parser parsed successfully for a valid vpd
root@p10bmc:/usr/lib# ibm-read-vpd --file /sys/bus/i2c/drivers/at24/7-0050/eeprom
<no error>

3.ECC Code worked fine with VPD-Manager
root@p10bmc:/usr/lib# vpd-tool -w -O /system/chassis/motherboard/base_op_panel_blyth -R VINI -K PN -V "PN34"
root@p10bmc:/usr/lib# ibm-read-vpd --file /sys/bus/i2c/drivers/at24/7-0050/eeprom
root@p10bmc:/usr/lib#
root@p10bmc:/usr/lib#
root@p10bmc:/usr/lib# vpd-tool -w -O /system/chassis/motherboard/base_op_panel_blyth -R VINI -K PN -V "PN12"
root@p10bmc:/usr/lib# ibm-read-vpd --file /sys/bus/i2c/drivers/at24/7-0050/eeprom

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>
Change-Id: I72306b06ca8724193ef5ef05a0659467994a154d