### PR TITLE
Skip restoring for mismatched vpd

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -84,6 +84,8 @@ constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
 constexpr auto loggerCreateInterface = "xyz.openbmc_project.Logging.Create";
 constexpr auto errIntfForBlankSystemVPD = "com.ibm.VPD.Error.BlankSystemVPD";
 constexpr auto errIntfForInvalidVPD = "com.ibm.VPD.Error.InvalidVPD";
+constexpr auto errIntfForSystemVPDMismatch =
+    "com.ibm.VPD.Error.SystemVPDMismatch";
 constexpr auto errIntfForStreamFail = "com.ibm.VPD.Error.InavlidEepromPath";
 constexpr auto errIntfForEccCheckFail = "com.ibm.VPD.Error.EccCheckFailed";
 constexpr auto errIntfForJsonFailure = "com.ibm.VPD.Error.InvalidJson";

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1004,20 +1004,17 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                                 additionalData.emplace("DESCRIPTION", errMsg);
 
                                 createPEL(additionalData, PelSeverity::WARNING,
-                                          errIntfForInvalidVPD);
+                                          errIntfForSystemVPDMismatch);
                             }
                         }
-                        else
-                        {
-                            // implies hardware data is blank
-                            // update the map
-                            Binary busData(busValue.begin(), busValue.end());
 
-                            // update the map as well, so that cache data is not
-                            // updated as blank while populating VPD map on Dbus
-                            // in populateDBus Api
-                            kwdValue = busValue;
-                        }
+                        // If cache data is not blank, then irrespective of
+                        // hardware data(blank or other than cache), copy the
+                        // cache data to vpd map as we don't need to change the
+                        // cache data in either case in the process of
+                        // restoring system vpd.
+                        Binary busData(busValue.begin(), busValue.end());
+                        kwdValue = busValue;
                     }
                     else if (kwdValue.find_first_not_of(' ') == string::npos)
                     {


### PR DESCRIPTION
The commit skips restoring system vpd on cahce in case
there is a mismatch of vpd read from hardware and already
available on cache.
It also defines a new interface to address the error.

Needs the following commit which defines the interface:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-logging/+/53133

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: Ice54ac3057cb063ab496fa6c75c0fd96fbf195f1