### PR TITLE
Fix call out inventory path in PEL

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1508,6 +1508,8 @@ int main(int argc, char** argv)
             if ((js["frus"].find(file) != js["frus"].end()) &&
                 (file == systemVpdFilePath))
             {
+                baseFruInventoryPath = js["frus"][file][0]["inventoryPath"];
+
                 // We need manager service active to process restoring of
                 // system VPD on hardware. So in case any system restore is
                 // required, update hardware in the second trigger of parser
@@ -1581,7 +1583,13 @@ int main(int argc, char** argv)
             return 0;
         }
 
-        baseFruInventoryPath = js["frus"][file][0]["inventoryPath"];
+        // In case of system VPD it will already be filled, Don't have to
+        // overwrite that.
+        if (baseFruInventoryPath.empty())
+        {
+            baseFruInventoryPath = js["frus"][file][0]["inventoryPath"];
+        }
+
         // Check if we can read the VPD file based on the power state
         // We skip reading VPD when the power is ON in two scenarios:
         // 1) The eeprom we are trying to read is that of the system VPD and the


### PR DESCRIPTION
The commit fix the issue where inventory path is logged as
blank in case there is any data or ecc exception for system
vpd parsing called via udev event.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: I0083837b2d12c3016199f6d5ab4d939049f3635d