### PR TITLE
Handle FailActions

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -557,15 +557,27 @@ static void preAction(const nlohmann::json& json, const string& file)
                              string("\" > /sys/bus/i2c/drivers/at24/bind");
             cout << bindCmd << endl;
             executeCmd(bindCmd);
-        }
 
-        // Check if device showed up (test for file)
-        if (!fs::exists(file))
+            // Check if device showed up (test for file)
+            if (!fs::exists(file))
+            {
+                cerr << "EEPROM " << file
+                     << " does not exist. Take failure action" << endl;
+                // If not, then take failure postAction
+                executePostFailAction(json, file);
+            }
+        }
+        else
         {
-            cout << "EEPROM " << file << " does not exist. Take failure action"
-                 << endl;
-            // If not, then take failure postAction
+            // missing required informations
+            cerr
+                << "VPD inventory JSON missing basic informations of preAction "
+                   "for this FRU : ["
+                << file << "]. Executing executePostFailAction." << endl;
+
+            // Take failure postAction
             executePostFailAction(json, file);
+            return;
         }
     }
     else

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -729,6 +729,9 @@ std::optional<bool> isPresent(const nlohmann::json& json, const string& file)
 
                 if (!presenceLine)
                 {
+                    cerr << "Couldn't find the presence line for - "
+                         << presPinName << endl;
+
                     throw runtime_error(
                         "Couldn't find the presence line for the "
                         "GPIO. Skipping this GPIO action.");
@@ -756,8 +759,22 @@ std::optional<bool> isPresent(const nlohmann::json& json, const string& file)
                 }
 
                 logGpioPel(errMsg, i2cBusAddr);
+                // Take failure postAction
+                executePostFailAction(json, file);
                 return false;
             }
+        }
+        else
+        {
+            // missing required informations
+            cerr << "VPD inventory JSON missing basic informations of presence "
+                    "for this FRU : ["
+                 << file << "]. Executing executePostFailAction." << endl;
+
+            // Take failure postAction
+            executePostFailAction(json, file);
+
+            return false;
         }
     }
     return std::optional<bool>{};
@@ -792,6 +809,8 @@ bool executePreAction(const nlohmann::json& json, const string& file)
 
                 if (!outputLine)
                 {
+                    cerr << "Couldn't find the line for output pin - "
+                         << pinName << endl;
                     throw runtime_error(
                         "Couldn't find output line for the GPIO. "
                         "Skipping this GPIO action.");
@@ -815,8 +834,25 @@ bool executePreAction(const nlohmann::json& json, const string& file)
                 }
 
                 logGpioPel(errMsg, i2cBusAddr);
+
+                // Take failure postAction
+                executePostFailAction(json, file);
+
                 return false;
             }
+        }
+        else
+        {
+            // missing required informations
+            cerr
+                << "VPD inventory JSON missing basic informations of preAction "
+                   "for this FRU : ["
+                << file << "]. Executing executePostFailAction." << endl;
+
+            // Take failure postAction
+            executePostFailAction(json, file);
+
+            return false;
         }
     }
     return true;


### PR DESCRIPTION
Take post failure action-
if presence GPIO pin couldn't be read
or it says FRU not attached to the slot
or corresponding expander GPIO pin couldn't be updated.

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: Iff203d9a9eccc95c821e196b3d45e5f6bbd7ed6b