### PR TITLE
Modify get system json

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -55,6 +55,7 @@ static constexpr auto RAINIER_4U = "50001000.json";
 static constexpr auto RAINIER_4U_V2 = "50001000_v2.json";
 static constexpr auto RAINIER_1S4U = "50001002.json";
 static constexpr auto EVEREST = "50003000.json";
+static constexpr auto EVEREST_V2 = "50003000_v2.json";
 
 constexpr uint8_t KW_VPD_START_TAG = 0x82;
 constexpr uint8_t KW_VPD_END_TAG = 0x78;

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -818,7 +818,8 @@ void setDevTreeEnv(const string& systemType)
         {RAINIER_4U, "conf-aspeed-bmc-ibm-rainier-4u-p1.dtb"},
         {RAINIER_4U_V2, "conf-aspeed-bmc-ibm-rainier-4u.dtb"},
         {RAINIER_1S4U, "conf-aspeed-bmc-ibm-rainier-1s4u.dtb"},
-        {EVEREST, "conf-aspeed-bmc-ibm-everest.dtb"}};
+        {EVEREST, "conf-aspeed-bmc-ibm-everest.dtb"},
+        {EVEREST_V2, "conf-aspeed-bmc-ibm-everest.dtb"}};
 
     if (deviceTreeSystemTypeMap.find(systemType) !=
         deviceTreeSystemTypeMap.end())

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -398,8 +398,11 @@ string getSystemsJson(const Parsed& vpdMap)
     {
         auto js = json::parse(systemJson);
 
-        const string hwKeyword = getHW(vpdMap);
+        string hwKeyword = getHW(vpdMap);
         const string imKeyword = getIM(vpdMap);
+
+        transform(hwKeyword.begin(), hwKeyword.end(), hwKeyword.begin(),
+                  ::toupper);
 
         if (js.find("system") == js.end())
         {
@@ -416,9 +419,30 @@ string getSystemsJson(const Parsed& vpdMap)
 
         if ((js["system"][imKeyword].find("constraint") !=
              js["system"][imKeyword].end()) &&
-            (hwKeyword == js["system"][imKeyword]["constraint"]["HW"]))
+            js["system"][imKeyword]["constraint"].find("HW") !=
+                js["system"][imKeyword]["constraint"].end())
         {
-            jsonName = js["system"][imKeyword]["constraint"]["json"];
+            // collect hw versions from json, and check hwKeyword  is part of it
+            // if hwKeyword is found there then load respective json
+            // otherwise load default one.
+            for (const auto& hwVersion :
+                 js["system"][imKeyword]["constraint"]["HW"])
+            {
+                string hw = hwVersion;
+                transform(hw.begin(), hw.end(), hw.begin(), ::toupper);
+
+                if (hw == hwKeyword)
+                {
+                    jsonName = js["system"][imKeyword]["constraint"]["json"];
+                    break;
+                }
+            }
+
+            if (jsonName.empty() && js["system"][imKeyword].find("default") !=
+                                        js["system"][imKeyword].end())
+            {
+                jsonName = js["system"][imKeyword]["default"];
+            }
         }
         else if (js["system"][imKeyword].find("default") !=
                  js["system"][imKeyword].end())


### PR DESCRIPTION
We have some change in system json to support Everest Pass2 jsons.
To fetch that json we got some changes in vpd-parser also.

Test- Tested on Ever10 PASS2 system-
./ibm-read-vpd -f /sys/bus/i2c/drivers/at24/8-0050/eeprom

DBG:processing for IM - 50003000
DBG:HW from vpd - 0015
DBG:hw versions are-
DBG:"000A"
DBG:"000B"
DBG:"000C"
DBG:"0014"
DBG: hwKw not found in hw version set
DBG: json name- 50003000_v2.json

DBG:processing for IM - 50003000
DBG:HW from vpd - 0015
….
DBG: json name- 50003000_v2.json
DBG: systemType- 50003000_v2.json DeviceTree - conf-aspeed-bmc-ibm-everest.dtb

root@ever10bmc:/tmp# ls -ltr /var/lib/vpd/vpd_inventory.json
lrwxrwxrwx    1 root     root            31 May  6 11:30 /var/lib/vpd/vpd_inventory.json -> /usr/share/vpd/50003000_v2.json

==========================================================

Changed HW value using vpd-tool, to pickup PASS1 json-

./ibm-read-vpd -f /sys/bus/i2c/drivers/at24/8-0050/eeprom

DBG:processing for IM - 50003000
DBG:HW from vpd - 000A
DBG:hw versions are-
DBG:"000A"
DBG: hwKw matched in hw version set
DBG: json name- 50003000.json

DBG:processing for IM - 50003000
DBG:HW from vpd - 000A
. . . .
DBG: json name- 50003000.json
DBG: systemType- 50003000.json DeviceTree - conf-aspeed-bmc-ibm-everest.dtb

root@ever10bmc:/tmp# ls -ltr /var/lib/vpd/vpd_inventory.json
lrwxrwxrwx    1 root     root            28 May  6 12:07 /var/lib/vpd/vpd_inventory.json -> /usr/share/vpd/50003000.json

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: I5301a47bff12d25f844e176be34bcb0edf722665