### PR TITLE
manager: Update BIOS Attributes only if needed

### DIFF
--- a/vpd-manager/bios_handler.cpp
+++ b/vpd-manager/bios_handler.cpp
@@ -238,13 +238,22 @@ std::string BiosHandler::readBIOSAMM()
     return ammVal;
 }
 
-void BiosHandler::saveFCOToBIOS(const std::string& fcoVal)
+void BiosHandler::saveFCOToBIOS(const std::string& fcoVal, int64_t fcoInBIOS)
 {
     if (fcoVal.size() != 4)
     {
         std::cerr << "Bad size for FCO in VPD: " << fcoVal.size() << std::endl;
         return;
     }
+
+    // Need to write?
+    if (fcoInBIOS == static_cast<int64_t>(fcoVal.at(3)))
+    {
+        std::cout << "Skip FCO BIOS write, value is already: " << fcoInBIOS
+                  << std::endl;
+        return;
+    }
+
     PendingBIOSAttrsType biosAttrs;
     biosAttrs.push_back(
         std::make_pair("hb_field_core_override",
@@ -262,7 +271,8 @@ void BiosHandler::saveFCOToBIOS(const std::string& fcoVal)
         biosAttrs);
 }
 
-void BiosHandler::saveAMMToBIOS(const std::string& ammVal)
+void BiosHandler::saveAMMToBIOS(const std::string& ammVal,
+                                const std::string& ammInBIOS)
 {
     if (ammVal.size() != 1)
     {
@@ -277,15 +287,24 @@ void BiosHandler::saveAMMToBIOS(const std::string& ammVal)
                   << static_cast<int>(ammVal.at(0)) << std::endl;
         return;
     }
-    PendingBIOSAttrsType biosAttrs;
-    biosAttrs.push_back(std::make_pair(
-        "hb_memory_mirror_mode",
-        std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
-                        "AttributeType.Enumeration",
-                        (ammVal.at(0) == 2) ? "Enabled" : "Disabled")));
 
-    std::cout << "Set hb_memory_mirror_mode to: "
-              << ((ammVal.at(0) == 2) ? "Enabled" : "Disabled") << std::endl;
+    // Need to write?
+    std::string toWrite = (ammVal.at(0) == 2) ? "Enabled" : "Disabled";
+    if (ammInBIOS == toWrite)
+    {
+        std::cout << "Skip AMM BIOS write, value is already: " << toWrite
+                  << std::endl;
+        return;
+    }
+
+    PendingBIOSAttrsType biosAttrs;
+    biosAttrs.push_back(
+        std::make_pair("hb_memory_mirror_mode",
+                       std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
+                                       "AttributeType.Enumeration",
+                                       toWrite)));
+
+    std::cout << "Set hb_memory_mirror_mode to: " << toWrite << std::endl;
 
     setBusProperty<PendingBIOSAttrsType>(
         "xyz.openbmc_project.BIOSConfigManager",
@@ -316,7 +335,7 @@ void BiosHandler::restoreBIOSAttribs()
     }
     else
     {
-        saveFCOToBIOS(fcoInVPD);
+        saveFCOToBIOS(fcoInVPD, fcoInBIOS);
     }
 
     if (ammInVPD.at(0) == 0)
@@ -325,7 +344,7 @@ void BiosHandler::restoreBIOSAttribs()
     }
     else
     {
-        saveAMMToBIOS(ammInVPD);
+        saveAMMToBIOS(ammInVPD, ammInBIOS);
     }
 
     // Start listener now that we have done the restore

--- a/vpd-manager/bios_handler.hpp
+++ b/vpd-manager/bios_handler.hpp
@@ -115,20 +115,24 @@ class BiosHandler
     /**
      * @brief Writes Memory mirror mode to BIOS
      *
-     * Writes to the hb_memory_mirror_mode BIOS attribute.
+     * Writes to the hb_memory_mirror_mode BIOS attribute, if the value is not
+     * already the same as we are trying to write.
      *
      * @param[in] ammVal - The mirror mode as read from VPD.
+     * @param[in] ammInBIOS - The mirror more in the BIOS table.
      */
-    void saveAMMToBIOS(const std::string& ammVal);
+    void saveAMMToBIOS(const std::string& ammVal, const std::string& ammInBIOS);
 
     /**
      * @brief Writes Field Core Override to BIOS
      *
-     * Writes to the hb_field_core_override BIOS attribute.
+     * Writes to the hb_field_core_override BIOS attribute, if the value is not
+     * already the same as we are trying to write.
      *
      * @param[in] fcoVal - The FCO value as read from VPD.
+     * @param[in] fcoInBIOS - The FCO value already in the BIOS table.
      */
-    void saveFCOToBIOS(const std::string& fcoVal);
+    void saveFCOToBIOS(const std::string& fcoVal, int64_t fcoInBIOS);
 
     /**
      * @brief Reads the hb_memory_mirror_mode attribute


### PR DESCRIPTION
This commit adds a check before updating the FCO and AMM
BIOS attributes. If the attributes are already the value that
we are trying to update, we skip the BIOS attribute update.

This helps eliminate unnecessary BIOS updates being sent to PHYP.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Icc771a9c024cedb248a0fa2e983f9eebdc76b2b6