### PR TITLE
Everest: Ignore error if PCIe on low pass

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -479,23 +479,51 @@ static bool isThisPcieOnPass1planar(const nlohmann::json& js,
 
     if (isThisPCIeDev)
     {
-        // Collect SystemType to know if it is PASS1 planar.
+        // Collect HW version and SystemType to know if it is PASS1 planar.
         auto bus = sdbusplus::bus::new_default();
-        auto properties = bus.new_method_call(
+        auto property1 = bus.new_method_call(
             INVENTORY_MANAGER_SERVICE,
             "/xyz/openbmc_project/inventory/system/chassis/motherboard",
             "org.freedesktop.DBus.Properties", "Get");
-        properties.append("com.ibm.ipzvpd.VINI");
-        properties.append("HW");
-        auto result = bus.call(properties);
+        property1.append("com.ibm.ipzvpd.VINI");
+        property1.append("HW");
+        auto result1 = bus.call(property1);
+        inventory::Value hwVal;
+        result1.read(hwVal);
 
-        inventory::Value val;
-        result.read(val);
-        if (auto pVal = get_if<Binary>(&val))
+        // SystemType
+        auto property2 = bus.new_method_call(
+            INVENTORY_MANAGER_SERVICE,
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard",
+            "org.freedesktop.DBus.Properties", "Get");
+        property2.append("com.ibm.ipzvpd.VSBP");
+        property2.append("IM");
+        auto result2 = bus.call(property2);
+        inventory::Value imVal;
+        result2.read(imVal);
+
+        auto pVal1 = get_if<Binary>(&hwVal);
+        auto pVal2 = get_if<Binary>(&imVal);
+
+        if (pVal1 && pVal2)
         {
-            auto hwVersion = *pVal;
-            if (hwVersion[1] < 2)
+            auto hwVersion = *pVal1;
+            auto systemType = *pVal2;
+
+            // IM kw for Everest
+            Binary everestSystem{80, 00, 48, 00};
+
+            if (systemType == everestSystem)
+            {
+                if (hwVersion[1] < 21)
+                {
+                    isPASS1 = true;
+                }
+            }
+            else if (hwVersion[1] < 2)
+            {
                 isPASS1 = true;
+            }
         }
     }
 


### PR DESCRIPTION
This commit modified isThisPcieOnPass1Planar,
as Everest has different set of HW versions for PASS1 planar.

Test:
Verified this patch on Everest and Rainier-

Trigger parser for one of the existing pcie_card-
root@ever6bmc:/tmp# ./ibm-read-vpd -f /sys/bus/i2c/drivers/at24/17-0050/eeprom
DBG:hwVersion-010
DBG:systemType-800480
DBG: It is Everest and Low PASS
DBG: Yes, This is a PCIe on PASS1 planar, ignore this error(if any).
root@ever6bmc:/tmp#

root@rain104bmc:/tmp# ./ibm-read-vpd -f /sys/bus/i2c/drivers/at24/11-0050/eeprom
DBG:hwVersion-01
DBG:systemType-800161
DBG: It is Rainier and Low PASS
DBG: Yes, This is a PCIe on PASS1 planar, ignore error(if any).
root@rain104bmc:/tmp#

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: Iff44c4b6bf83d595470df635c069146484f091b8