### PR TITLE
System vpd restore list modification

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -43,9 +43,10 @@ using namespace phosphor::logging;
 // The list of keywords for VSYS record is as per the S0 system. Should
 // be updated for another type of systems
 static const std::unordered_map<std::string, std::vector<std::string>>
-    svpdKwdMap{{"VSYS", {"BR", "TM", "SE", "SU", "RB", "WN"}},
+    svpdKwdMap{{"VSYS", {"BR", "TM", "SE", "SU", "RB", "WN", "RG"}},
                {"VCEN", {"FC", "SE"}},
-               {"LXR0", {"LX"}}};
+               {"LXR0", {"LX"}},
+               {"UTIL", {"D0"}}};
 
 /**
  * @brief Returns the power state for chassis0
@@ -1024,9 +1025,23 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                     const string& busValue = readBusProperty(
                         objectPath, ipzVpdInf + recordName, keyword);
 
-                    if (busValue.find_first_not_of(' ') != string::npos)
+                    std::string defaultValue{' '};
+
+                    // Explicit check for D0 is required as this keyword will
+                    // never be blank and 0x00 should be treated as no value in
+                    // this case.
+                    if (recordName == "UTIL" && keyword == "D0")
                     {
-                        if (kwdValue.find_first_not_of(' ') != string::npos)
+                        // default value of kwd D0 is 0x00. This kwd will never
+                        // be blank.
+                        defaultValue = '\0';
+                    }
+
+                    if (busValue.find_first_not_of(defaultValue) !=
+                        string::npos)
+                    {
+                        if (kwdValue.find_first_not_of(defaultValue) !=
+                            string::npos)
                         {
                             // both the data are present, check for mismatch
                             if (busValue != kwdValue)
@@ -1078,7 +1093,8 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                         Binary busData(busValue.begin(), busValue.end());
                         kwdValue = busValue;
                     }
-                    else if (kwdValue.find_first_not_of(' ') == string::npos)
+                    else if (kwdValue.find_first_not_of(defaultValue) ==
+                             string::npos)
                     {
                         string errMsg = "VPD is blank on both cache and "
                                         "hardware for record: ";


### PR DESCRIPTION
New record keyword pair added in the list of system
vpd restore map.

VSYS/RG - Field core override.
UTIL/DO - AMM(memory mirroring) setting persistently in
the backplane VPD.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: I8a7513dcdc48ae79137faa945ab0db91b5bdf220