### PR TITLE
CM: Bind the PCIe devices with LED driver

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -340,6 +340,18 @@ void Manager::performVPDRecollection()
                 // If not, then take failure postAction
                 executePostFailAction(jsonFile, item);
             }
+            else
+            {
+                // bind the LED driver
+                string chipAddr = singleFru.value("pcaChipAddress", "");
+                cout << "performVPDRecollection: Executing driver binding for "
+                        "chip "
+                        "address - "
+                     << chipAddr << endl;
+
+                executeCmd(createBindUnbindDriverCmnd(chipAddr, "i2c",
+                                                      "leds-pca955x", "/bind"));
+            }
         }
     }
 }
@@ -404,6 +416,17 @@ void Manager::collectFRUVPD(const sdbusplus::message::object_path path)
             {
                 // If not, then take failure postAction
                 executePostFailAction(jsonFile, vpdFilePath);
+            }
+            else
+            {
+                // bind the LED driver
+                string chipAddr = jsonFile["frus"][vpdFilePath].at(0).value(
+                    "pcaChipAddress", "");
+                cout << "Executing driver binding for chip address - "
+                     << chipAddr << endl;
+
+                executeCmd(createBindUnbindDriverCmnd(chipAddr, "i2c",
+                                                      "leds-pca955x", "/bind"));
             }
         }
         return;
@@ -498,6 +521,16 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path path)
         elog<InvalidArgument>(Argument::ARGUMENT_NAME("Object Path"),
                               Argument::ARGUMENT_VALUE(objPath.c_str()));
     }
+
+    inventory::Path& vpdFilePath = std::get<0>(frus.find(path)->second);
+
+    string chipAddress =
+        jsonFile["frus"][vpdFilePath].at(0).value("pcaChipAddress", "");
+
+    // Unbind the LED driver for this FRU
+    cout << "Unbinding device- " << chipAddress << endl;
+    executeCmd(createBindUnbindDriverCmnd(chipAddress, "i2c", "leds-pca955x",
+                                          "/unbind"));
 
     // if the FRU is not present then log error
     if (readBusProperty(objPath, "xyz.openbmc_project.Inventory.Item",


### PR DESCRIPTION
Bind the LED driver to the device if vpd collection done successfully
on adding the FRU to the system concurrently and unbind if FRU removed.
This binding will be required pca chip address which is defined in
inventory json for each cable card.

Test:
Tested on Rainier118

sh-5.1# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager  CollectFRUVPD  o  "/system/chassis/motherboard/pcieslot10/pcie_card10"
sh-5.1#
sh-5.1# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager  deleteFRUVPD  o  "/system/chassis/motherboard/pcieslot10/pcie_card10"
sh-5.1#
sh-5.1# i2cdetect -y 11
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:                         -- -- -- -- 0c -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- 1b -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- 4d -- --
50: UU -- -- 53 -- -- -- -- -- -- -- -- -- -- -- --
60: 60 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
sh-5.1# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager  CollectFRUVPD  o  "/system/chassis/motherboard/pcieslot10/pcie_card10"
sh-5.1# i2cdetect -y 11
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:                         -- -- -- -- 0c -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- 1b -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- 4d -- --
50: UU -- -- 53 -- -- -- -- -- -- -- -- -- -- -- --
60: UU -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
sh-5.1# exit
exit

===============================================================================================

Corresponding response from vpd-manager-
CollectFRUVPD :

-------------
Setting GPIO: SLOT10_PRSNT_EN_RSVD to 1
Executing driver binding for chip address - 11-0060
sh: line 1: echo: write error: Device or resource busy    <---------- When device already bound

deleteFRUVPD :
-------------
Unbinding device- 11-0060                                 <---- Unbind the device

CollectFRUVPD :
-------------
Setting GPIO: SLOT10_PRSNT_EN_RSVD to 1
Executing driver binding for chip address - 11-0060       <---Bind it again

===============================================================================================

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: I1d886d31e0e36c21d8b739c4b3d3e054ec876b6d