### PR TITLE
vpd-manager bug fix

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -522,7 +522,7 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path path)
                               Argument::ARGUMENT_VALUE(objPath.c_str()));
     }
 
-    inventory::Path& vpdFilePath = std::get<0>(frus.find(path)->second);
+    inventory::Path& vpdFilePath = std::get<0>(frus.find(objPath)->second);
 
     string chipAddress =
         jsonFile["frus"][vpdFilePath].at(0).value("pcaChipAddress", "");


### PR DESCRIPTION
Code was fixed under deleteFru api to use the correct form
of object path to fetch "vpdFilePath" which in turn prevents
vpd-manager to core dump when "vpdFilePath" was being
de-referenced.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>