### PR TITLE
Fix BIOS Restore Of pvm_clear_nvram

### DIFF
--- a/vpd-manager/bios_handler.cpp
+++ b/vpd-manager/bios_handler.cpp
@@ -662,7 +662,7 @@ void BiosHandler::restoreBIOSAttribs()
 
     auto clearNVRAMInVPD =
         readBusProperty(SYSTEM_OBJECT, "com.ibm.ipzvpd.UTIL", "D1");
-    saveCreateDefaultLparToBIOS(clearNVRAMInVPD, clearNVRAMInBIOS);
+    saveClearNVRAMToBIOS(clearNVRAMInVPD, clearNVRAMInBIOS);
 
     // Start listener now that we have done the restore
     listenBiosAttribs();


### PR DESCRIPTION
A copy-paste error was causing us to never sync pvm_clear_nvram
from VPD to the BIOS attribute. This commit fixes that.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Icd8ee8edb4cd05811c8b47ba6fd82c10f11f7671