### PR TITLE
Code fix to handle Dbus failure

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -193,8 +193,8 @@ void createPEL(const std::map<std::string, std::string>& additionalData,
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        throw std::runtime_error(
-            "Error in invoking D-Bus logging create interface to register PEL");
+        std::cerr << "Dbus call to phosphor-logging Create failed. Reason:"
+                  << e.what();
     }
 }
 


### PR DESCRIPTION
The commit implement changes to catch and log error instead
of re throwing a run time exception in case there is any Dbus
failure while calling phosphor-logging service.

It was required as there is no need to re throw runtime error
in that case.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: Ic62ee3d37e6dcb900fd3bec534eec63863ce956e