### PR TITLE
Code fix to handle Dbus failure

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -193,8 +193,8 @@ void createPEL(const std::map<std::string, std::string>& additionalData,
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        throw std::runtime_error(
-            "Error in invoking D-Bus logging create interface to register PEL");
+        std::cerr << "Dbus call to phosphor-logging Create failed. Reason:"
+                  << e.what();
     }
 }
 

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -456,6 +456,9 @@ void Manager::performVPDRecollection()
 
 void Manager::collectFRUVPD(const sdbusplus::message::object_path path)
 {
+    std::cout << "Manager called to collect vpd for fru: " << std::string{path}
+              << std::endl;
+
     using InvalidArgument =
         sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
     using Argument = xyz::openbmc_project::Common::InvalidArgument;
@@ -601,6 +604,9 @@ void Manager::triggerVpdCollection(const nlohmann::json& singleFru,
 
 void Manager::deleteFRUVPD(const sdbusplus::message::object_path path)
 {
+    std::cout << "Manager called to delete vpd for fru: " << std::string{path}
+              << std::endl;
+
     using InvalidArgument =
         sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
     using Argument = xyz::openbmc_project::Common::InvalidArgument;


### PR DESCRIPTION
The commit implement changes to catch and log error instead
of re throwing a run time exception in case there is any Dbus
failure while calling phosphor-logging service.

It was required as there is no need to re throw runtime error
in that case.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: Ic62ee3d37e6dcb900fd3bec534eec63863ce956e