### PR TITLE
Update vpd read and write flow

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
                    std::istreambuf_iterator<char>());
 
         // Parse VPD
-        IpzVpdParser ipzParser(std::move(vpd));
+        IpzVpdParser ipzParser(std::move(vpd), (arguments.at("object")[0]));
         auto vpdStore = std::move(std::get<Store>(ipzParser.parse()));
 
         if (doDump)

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1469,7 +1469,8 @@ int main(int argc, char** argv)
         try
         {
             vpdVector = getVpdDataInVector(js, file);
-            ParserInterface* parser = ParserFactory::getParser(vpdVector);
+            ParserInterface* parser = ParserFactory::getParser(
+                vpdVector, (pimPath + baseFruInventoryPath));
             variant<KeywordVpdMap, Store> parseResult;
             parseResult = parser->parse();
 

--- a/impl.cpp
+++ b/impl.cpp
@@ -3,6 +3,7 @@
 #include "const.hpp"
 #include "defines.hpp"
 #include "ibm_vpd_utils.hpp"
+#include "types.hpp"
 #include "vpd_exceptions.hpp"
 
 #include <algorithm>
@@ -147,13 +148,14 @@ int Impl::recordEccCheck(Binary::const_iterator iterator) const
 
     if (eccLength == 0 || eccOffset == 0)
     {
-        throw(VpdEccException("Could not find ECC's offset or Length"));
+        throw(VpdEccException(
+            "Could not find ECC's offset or Length for Record:"));
     }
 
     if (recordOffset == 0 || recordLength == 0)
     {
-        throw(VpdDataException(
-            "Could not find VPD record offset or VPD record length"));
+        throw(VpdDataException("Could not find VPD record offset or VPD record "
+                               "length for Record:"));
     }
 
     auto vpdPtr = vpd.cbegin();
@@ -264,19 +266,41 @@ internal::OffsetList Impl::readPT(Binary::const_iterator iterator,
         offsets.push_back(offset);
 
 #ifdef IPZ_PARSER
-        // Verify the ECC for this Record
-        int rc = recordEccCheck(iterator);
+        std::string recordName(iteratorToRecName,
+                               iteratorToRecName + lengths::RECORD_NAME);
 
-        if (rc != eccStatus::SUCCESS)
+        try
         {
-            std::string recordName(iteratorToRecName,
-                                   iteratorToRecName + lengths::RECORD_NAME);
+            // Verify the ECC for this Record
+            int rc = recordEccCheck(iterator);
 
-            std::string errorMsg =
-                std::string("ERROR: ECC check did not pass for the Record:") +
-                recordName;
-            throw(VpdEccException(errorMsg));
+            if (rc != eccStatus::SUCCESS)
+            {
+                std::string errorMsg =
+                    std::string("ERROR: ECC check did not pass for the "
+                                "Record:");
+                throw(VpdEccException(errorMsg));
+            }
         }
+        catch (const VpdEccException& ex)
+        {
+            inventory::PelAdditionalData additionalData{};
+            additionalData.emplace("DESCRIPTION",
+                                   std::string{ex.what()} + recordName);
+            additionalData.emplace("CALLOUT_INVENTORY_PATH", inventoryPath);
+            createPEL(additionalData, PelSeverity::WARNING,
+                      errIntfForEccCheckFail);
+        }
+        catch (const VpdDataException& ex)
+        {
+            inventory::PelAdditionalData additionalData{};
+            additionalData.emplace("DESCRIPTION",
+                                   std::string{ex.what()} + recordName);
+            additionalData.emplace("CALLOUT_INVENTORY_PATH", inventoryPath);
+            createPEL(additionalData, PelSeverity::WARNING,
+                      errIntfForInvalidVPD);
+        }
+
 #endif
 
         // Jump record size, record length, ECC offset and ECC length

--- a/impl.hpp
+++ b/impl.hpp
@@ -67,8 +67,10 @@ class Impl
     /** @brief Construct an Impl
      *
      *  @param[in] vpdBuffer - Binary VPD
+     *  @param[in] path - To call out FRU in case of any PEL.
      */
-    explicit Impl(const Binary& vpdBuffer) : vpd(vpdBuffer), out{}
+    Impl(const Binary& vpdBuffer, const std::string& path) :
+        vpd(vpdBuffer), inventoryPath(path), out{}
     {
     }
 
@@ -158,6 +160,9 @@ class Impl
 
     /** @brief VPD in binary format */
     const Binary& vpd;
+
+    /** Inventory path to call out FRU if required */
+    const std::string inventoryPath;
 
     /** @brief parser output */
     Parsed out;

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,7 @@ if get_option('ibm-parser').enabled()
                                  vpd_tool_SOURCES,
                                  dependencies: [
                                    sdbusplus,
+                                   phosphor_logging,
                                    libgpiodcxx
                                    ],
                                  link_with : libvpdecc,

--- a/test/ipz_parser/parser.cpp
+++ b/test/ipz_parser/parser.cpp
@@ -37,7 +37,7 @@ TEST(IpzVpdParserApp, vpdGoodPath)
         0x00, 0x52, 0x54, 0x04};
 
     // call app for this vpd
-    parser::Impl p(std::move(vpd));
+    parser::Impl p(std::move(vpd), std::string{});
     Store vpdStore = p.run();
 
     static const std::string record = "VINI";
@@ -65,7 +65,7 @@ TEST(IpzVpdParserApp, vpdBadPathEmptyVPD)
     Binary vpd = {};
 
     // VPD is empty
-    parser::Impl p(std::move(vpd));
+    parser::Impl p(std::move(vpd), std::string{});
 
     // Expecting a throw here
     EXPECT_THROW(p.run(), std::runtime_error);
@@ -98,7 +98,7 @@ TEST(IpzVpdParserApp, vpdBadPathMissingHeader)
     // corrupt the VHDR
     vpd[17] = 0x00;
 
-    parser::Impl p(std::move(vpd));
+    parser::Impl p(std::move(vpd), std::string{});
 
     // Expecting a throw here
     EXPECT_THROW(p.run(), std::runtime_error);
@@ -131,7 +131,7 @@ TEST(IpzVpdParserApp, vpdBadPathMissingVTOC)
     // corrupt the VTOC
     vpd[61] = 0x00;
 
-    parser::Impl p(std::move(vpd));
+    parser::Impl p(std::move(vpd), std::string{});
 
     // Expecting a throw here
     EXPECT_THROW(p.run(), std::runtime_error);

--- a/vpd-manager/editor_impl.cpp
+++ b/vpd-manager/editor_impl.cpp
@@ -7,6 +7,9 @@
 #include "ipz_parser.hpp"
 #include "parser_factory.hpp"
 
+#include <phosphor-logging/elog-errors.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
 #include "vpdecc/vpdecc.h"
 
 using namespace openpower::vpd::parser::interface;
@@ -497,83 +500,180 @@ void EditorImpl::expandLocationCode(const std::string& locationCodeType)
     common::utility::callPIM(move(objects));
 }
 
+#ifndef ManagerTest
+static void enableRebootGuard()
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager", "StartUnit");
+        method.append("reboot-guard-enable.service", "replace");
+        bus.call_noreply(method);
+        std::cout << "Disabled reboot" << std::endl;
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        std::string errMsg =
+            "Bus call to enable BMC reboot failed for reason: ";
+        errMsg += e.what();
+
+        throw std::runtime_error(errMsg);
+    }
+}
+
+static void disableRebootGuard()
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager", "StartUnit");
+        method.append("reboot-guard-disable.service", "replace");
+        bus.call_noreply(method);
+        std::cout << "Enabled reboot" << std::endl;
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        using namespace phosphor::logging;
+        using InternalFailure =
+            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+        std::string errMsg =
+            "Bus call to disable BMC reboot failed for reason: ";
+        errMsg += e.what();
+
+        log<level::ERR>("Disable boot guard failed");
+        elog<InternalFailure>();
+
+        throw std::runtime_error(errMsg);
+    }
+}
+#endif
+
 void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
                                const bool& updCache)
 {
-    startOffset = offset;
+    try
+    {
+        startOffset = offset;
 #ifndef ManagerTest
-    // TODO: Figure out a better way to get max possible VPD size.
-    Binary completeVPDFile;
-    completeVPDFile.resize(65504);
-    vpdFileStream.open(vpdFilePath,
-                       std::ios::in | std::ios::out | std::ios::binary);
+        // Restrict BMC from rebooting when VPD is being written. This will
+        // prevent any data/ECC corruption in case BMC reboots while VPD update.
+        enableRebootGuard();
 
-    vpdFileStream.seekg(startOffset, ios_base::cur);
-    vpdFileStream.read(reinterpret_cast<char*>(&completeVPDFile[0]), 65504);
-    completeVPDFile.resize(vpdFileStream.gcount());
-    vpdFileStream.clear(std::ios_base::eofbit);
+        // TODO: Figure out a better way to get max possible VPD size.
+        Binary completeVPDFile;
+        completeVPDFile.resize(65504);
+        vpdFileStream.open(vpdFilePath,
+                           std::ios::in | std::ios::out | std::ios::binary);
 
-    vpdFile = completeVPDFile;
+        vpdFileStream.seekg(startOffset, ios_base::cur);
+        vpdFileStream.read(reinterpret_cast<char*>(&completeVPDFile[0]), 65504);
+        completeVPDFile.resize(vpdFileStream.gcount());
+        vpdFileStream.clear(std::ios_base::eofbit);
+
+        vpdFile = completeVPDFile;
+
+        if (objPath.empty())
+        {
+            // this should not fail as we have already read the vpdFilePath
+            // above.
+            if (jsonFile.contains(vpdFilePath))
+            {
+                objPath = jsonFile[vpdFilePath][0]["inventoryPath"]
+                              .get_ref<const nlohmann::json::string_t&>();
+            }
+            else
+            {
+                throw std::runtime_error(
+                    "Json does not contain given vpd file path");
+            }
+        }
 
 #else
 
-    Binary completeVPDFile = vpdFile;
+        Binary completeVPDFile = vpdFile;
 
 #endif
-    if (vpdFile.empty())
-    {
-        throw std::runtime_error("Invalid File");
-    }
-    auto iterator = vpdFile.cbegin();
-    std::advance(iterator, IPZ_DATA_START);
-
-    Byte vpdType = *iterator;
-    if (vpdType == KW_VAL_PAIR_START_TAG)
-    {
-        ParserInterface* Iparser = ParserFactory::getParser(completeVPDFile);
-        IpzVpdParser* ipzParser = dynamic_cast<IpzVpdParser*>(Iparser);
-
-        try
+        if (vpdFile.empty())
         {
-            if (ipzParser == nullptr)
-            {
-                throw std::runtime_error("Invalid cast");
-            }
-
-            ipzParser->processHeader();
-            delete ipzParser;
-            ipzParser = nullptr;
-            // ParserFactory::freeParser(Iparser);
-
-            // process VTOC for PTT rkwd
-            readVTOC();
-
-            // check record for keywrod
-            checkRecordForKwd();
-
-            // update the data to the file
-            updateData(kwdData);
-
-            // update the ECC data for the record once data has been updated
-            updateRecordECC();
-
-            if (updCache)
-            {
-#ifndef ManagerTest
-                // update the cache once data has been updated
-                updateCache();
-#endif
-            }
+            throw std::runtime_error("Invalid File");
         }
-        catch (const std::exception& e)
+        auto iterator = vpdFile.cbegin();
+        std::advance(iterator, IPZ_DATA_START);
+
+        Byte vpdType = *iterator;
+        if (vpdType == KW_VAL_PAIR_START_TAG)
         {
-            if (ipzParser != nullptr)
+            // objPath should be empty only in case of test run.
+            ParserInterface* Iparser =
+                ParserFactory::getParser(completeVPDFile, objPath);
+            IpzVpdParser* ipzParser = dynamic_cast<IpzVpdParser*>(Iparser);
+
+            try
             {
+                if (ipzParser == nullptr)
+                {
+                    throw std::runtime_error("Invalid cast");
+                }
+
+                ipzParser->processHeader();
                 delete ipzParser;
+                ipzParser = nullptr;
+                // ParserFactory::freeParser(Iparser);
+
+                // process VTOC for PTT rkwd
+                readVTOC();
+
+                // check record for keywrod
+                checkRecordForKwd();
+
+                // update the data to the file
+                updateData(kwdData);
+                std::cout << "Sleep started, try to reboot" << std::endl;
+                sleep(5);
+                std::cout << "Sleep end" << std::endl;
+
+                // update the ECC data for the record once data has been updated
+                updateRecordECC();
+
+                if (updCache)
+                {
+#ifndef ManagerTest
+                    // update the cache once data has been updated
+                    updateCache();
+#endif
+                }
+                std::cout << "Sleep started" << std::endl;
             }
-            throw std::runtime_error(e.what());
+            catch (const std::exception& e)
+            {
+                if (ipzParser != nullptr)
+                {
+                    delete ipzParser;
+                }
+                throw std::runtime_error(e.what());
+            }
+
+#ifndef ManagerTest
+            // Once VPD data and Ecc update is done, disable BMC boot guard.
+            disableRebootGuard();
+#endif
+
+            return;
         }
-        return;
+    }
+    catch (const std::exception& e)
+    {
+#ifndef ManagerTest
+        // Disable reboot guard.
+        disableRebootGuard();
+#endif
+
+        throw std::runtime_error(e.what());
     }
 }
 } // namespace editor

--- a/vpd-manager/editor_impl.hpp
+++ b/vpd-manager/editor_impl.hpp
@@ -175,7 +175,7 @@ class EditorImpl
     inventory::Path vpdFilePath;
 
     // inventory path of the vpd fru to update keyword
-    const inventory::Path objPath;
+    inventory::Path objPath{};
 
     // stream to perform operation on file
     std::fstream vpdFileStream;

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -125,7 +125,11 @@ void Manager::restoreSystemVpd()
     try
     {
         auto vpdVector = getVpdDataInVector(jsonFile, systemVpdFilePath);
-        parser = ParserFactory::getParser(vpdVector);
+        const auto& inventoryPath =
+            jsonFile[systemVpdFilePath][0]["inventoryPath"]
+                .get_ref<const nlohmann::json::string_t&>();
+
+        parser = ParserFactory::getParser(vpdVector, (pimPath + inventoryPath));
         auto parseResult = parser->parse();
 
         if (auto pVal = std::get_if<Store>(&parseResult))

--- a/vpd-parser/ipz_parser.cpp
+++ b/vpd-parser/ipz_parser.cpp
@@ -15,14 +15,14 @@ using namespace openpower::vpd::constants;
 
 std::variant<kwdVpdMap, Store> IpzVpdParser::parse()
 {
-    Impl p(vpd);
+    Impl p(vpd, inventoryPath);
     Store s = p.run();
     return s;
 }
 
 void IpzVpdParser::processHeader()
 {
-    Impl p(vpd);
+    Impl p(vpd, inventoryPath);
     p.checkVPDHeader();
 }
 

--- a/vpd-parser/ipz_parser.hpp
+++ b/vpd-parser/ipz_parser.hpp
@@ -32,7 +32,8 @@ class IpzVpdParser : public ParserInterface
     /**
      * @brief Constructor
      */
-    IpzVpdParser(const Binary& VpdVector) : vpd(VpdVector)
+    IpzVpdParser(const Binary& VpdVector, const std::string& path) :
+        vpd(VpdVector), inventoryPath(path)
     {
     }
 
@@ -59,6 +60,9 @@ class IpzVpdParser : public ParserInterface
 
   private:
     const Binary& vpd;
+
+    /*Inventory path of the FRU */
+    const std::string inventoryPath;
 }; // class IpzVpdParser
 
 } // namespace parser

--- a/vpd-parser/parser_factory.cpp
+++ b/vpd-parser/parser_factory.cpp
@@ -22,7 +22,9 @@ namespace parser
 {
 namespace factory
 {
-interface::ParserInterface* ParserFactory::getParser(const Binary& vpdVector)
+interface::ParserInterface*
+    ParserFactory::getParser(const Binary& vpdVector,
+                             const std::string& inventoryPath)
 {
     vpdType type = vpdTypeCheck(vpdVector);
 
@@ -30,7 +32,7 @@ interface::ParserInterface* ParserFactory::getParser(const Binary& vpdVector)
     {
         case IPZ_VPD:
         {
-            return new IpzVpdParser(vpdVector);
+            return new IpzVpdParser(vpdVector, inventoryPath);
         }
 
         case KEYWORD_VPD:

--- a/vpd-parser/parser_factory.hpp
+++ b/vpd-parser/parser_factory.hpp
@@ -30,9 +30,11 @@ class ParserFactory
     /**
      * @brief A method to get object of concrete parser class.
      * @param[in] - vpd file to check for the type.
+     * @param[in] - InventoryPath to call out FRU in case PEL is logged.
      * @return - Pointer to concrete parser class object.
      */
-    static interface::ParserInterface* getParser(const Binary& vpdVector);
+    static interface::ParserInterface*
+        getParser(const Binary& vpdVector, const std::string& inventoryPath);
 
     /**
      * @brief A method to delete the parser object.


### PR DESCRIPTION
The commit implement changes to log Pel and call out
FRU and record in case of any ECC failure while reading
the vpd data for the FRU and continue with the processing
of rest of the records.

In case of write, BMC reboot is blocked till the VPD is
updated. Doing this will restrict any data/Ecc corruption
due to BMC reboot while VPD data is being updated.

Tested:
Corrupted vpd for tpm_wilson then trigerred collection of
vpd for the FRU.
Pel was logged calling out the FRU

root@rain127bmc:~# ibm-read-vpd --file /sys/bus/i2c/drivers/at24/0-0051/eeprom
root@rain127bmc:~# peltool -a
[
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x4000",
    "Created at":               "06/10/2022 06:36:59",
    "Committed at":             "06/10/2022 06:36:59",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50002B35",
    "Entry Id":                 "0x50002B35",
    "BMC Event Log Id":         "10"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "0x2000",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "0x4000",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E43",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A VPD ecc exception occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554002",
    "Hex Word 2":               "00080255",
    "Hex Word 3":               "2E430010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Normal Hardware FRU",
            "Priority":         "Mandatory, replace all with this type as a unit",
            "Location Code":    "U78DB.ND0.WZS002U-P0-C22",
            "Part Number":      "02WF429",
            "CCIN":             "6B59",
            "Serial Number":    "Y131UF09S00H"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Reporting Machine Type":   "9105-42A",
    "Reporting Serial Number":  "13BE990",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1020.00-58.9",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554002_2E430010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Machine Type Model":       "9105-42A",
    "Serial Number":            "13BE990"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCState": "Ready",
    "BootState": "SecondaryProcInit",
    "ChassisState": "On",
    "FW Version ID": "fw1020.00-58.9-3-gb29698f8cf",
    "HostState": "Running",
    "System IM": "50001000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_INVENTORY_PATH": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tpm_wilson",
    "DESCRIPTION": "ERROR: ECC check did not pass for the Record:VINI"
}
}
]

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: Ie7c7fff5699d8b89d5aa0995f4074ccb3fdd6c37