### PR TITLE
Update keyword bug fix

### DIFF
--- a/vpd-manager/editor_impl.cpp
+++ b/vpd-manager/editor_impl.cpp
@@ -633,9 +633,6 @@ void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
 
                 // update the data to the file
                 updateData(kwdData);
-                std::cout << "Sleep started, try to reboot" << std::endl;
-                sleep(5);
-                std::cout << "Sleep end" << std::endl;
 
                 // update the ECC data for the record once data has been updated
                 updateRecordECC();


### PR DESCRIPTION
Sleep was used in update keyword api for testing some scenario.
It was a test code and was not supposed to be merged.
The commit fix that by removing sleep from the api.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>