### PR TITLE
Check for essential FRUs

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -94,6 +94,7 @@ constexpr auto errIntfForJsonFailure = "com.ibm.VPD.Error.InvalidJson";
 constexpr auto errIntfForBusFailure = "com.ibm.VPD.Error.DbusFailure";
 constexpr auto errIntfForInvalidSystemType =
     "com.ibm.VPD.Error.UnknownSytemType";
+constexpr auto errIntfForEssentialFru = "com.ibm.VPD.Error.RequiredFRUMissing";
 constexpr auto errIntfForGpioError = "com.ibm.VPD.Error.GPIOError";
 constexpr auto motherBoardInterface =
     "xyz.openbmc_project.Inventory.Item.Board.Motherboard";

--- a/const.hpp
+++ b/const.hpp
@@ -81,6 +81,7 @@ constexpr auto offsetJsonDirectory = "/var/lib/vpd/";
 constexpr auto mapperObjectPath = "/xyz/openbmc_project/object_mapper";
 constexpr auto mapperInterface = "xyz.openbmc_project.ObjectMapper";
 constexpr auto mapperDestination = "xyz.openbmc_project.ObjectMapper";
+constexpr auto loggerService = "xyz.openbmc_project.Logging";
 constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
 constexpr auto loggerCreateInterface = "xyz.openbmc_project.Logging.Create";
 constexpr auto errIntfForBlankSystemVPD = "com.ibm.VPD.Error.BlankSystemVPD";

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -36,18 +36,6 @@ using namespace common::utility;
 using Severity = openpower::vpd::constants::PelSeverity;
 namespace fs = std::filesystem;
 
-// mapping of severity enum to severity interface
-static std::unordered_map<Severity, std::string> sevMap = {
-    {Severity::INFORMATIONAL,
-     "xyz.openbmc_project.Logging.Entry.Level.Informational"},
-    {Severity::DEBUG, "xyz.openbmc_project.Logging.Entry.Level.Debug"},
-    {Severity::NOTICE, "xyz.openbmc_project.Logging.Entry.Level.Notice"},
-    {Severity::WARNING, "xyz.openbmc_project.Logging.Entry.Level.Warning"},
-    {Severity::CRITICAL, "xyz.openbmc_project.Logging.Entry.Level.Critical"},
-    {Severity::EMERGENCY, "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
-    {Severity::ERROR, "xyz.openbmc_project.Logging.Entry.Level.Error"},
-    {Severity::ALERT, "xyz.openbmc_project.Logging.Entry.Level.Alert"}};
-
 namespace inventory
 {
 

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -36,6 +36,18 @@ using namespace common::utility;
 using Severity = openpower::vpd::constants::PelSeverity;
 namespace fs = std::filesystem;
 
+// mapping of severity enum to severity interface
+static std::unordered_map<Severity, std::string> sevMap = {
+    {Severity::INFORMATIONAL,
+     "xyz.openbmc_project.Logging.Entry.Level.Informational"},
+    {Severity::DEBUG, "xyz.openbmc_project.Logging.Entry.Level.Debug"},
+    {Severity::NOTICE, "xyz.openbmc_project.Logging.Entry.Level.Notice"},
+    {Severity::WARNING, "xyz.openbmc_project.Logging.Entry.Level.Warning"},
+    {Severity::CRITICAL, "xyz.openbmc_project.Logging.Entry.Level.Critical"},
+    {Severity::EMERGENCY, "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
+    {Severity::ERROR, "xyz.openbmc_project.Logging.Entry.Level.Error"},
+    {Severity::ALERT, "xyz.openbmc_project.Logging.Entry.Level.Alert"}};
+
 namespace inventory
 {
 
@@ -638,29 +650,6 @@ string getPrintableValue(const Binary& vec)
     return str;
 }
 
-/*
- * @brief Log PEL for GPIO exception
- *
- * @param[in] gpioErr gpioError type exception
- * @param[in] i2cBusAddr I2C bus and address
- */
-void logGpioPel(const string& gpioErr, const string& i2cBusAddr)
-{
-    // Get the IIC details
-    vector<string> i2cReg;
-    boost::split(i2cReg, i2cBusAddr, boost::is_any_of("-"));
-
-    PelAdditionalData additionalData{};
-    if (i2cReg.size() == 2)
-    {
-        additionalData.emplace("CALLOUT_IIC_BUS", i2cReg[0]);
-        additionalData.emplace("CALLOUT_IIC_ADDR", "0x" + i2cReg[1]);
-    }
-
-    additionalData.emplace("DESCRIPTION", gpioErr);
-    createPEL(additionalData, PelSeverity::WARNING, errIntfForGpioError);
-}
-
 void executePostFailAction(const nlohmann::json& json, const string& file)
 {
     if ((json["frus"][file].at(0)).find("postActionFail") ==
@@ -714,9 +703,12 @@ void executePostFailAction(const nlohmann::json& json, const string& file)
         {
             i2cBusAddr =
                 json["frus"][file].at(0)["postActionFail"]["gpioI2CAddress"];
+            errMsg += " i2cBusAddress: " + i2cBusAddr;
         }
 
-        logGpioPel(errMsg, i2cBusAddr);
+        PelAdditionalData additionalData{};
+        additionalData.emplace("DESCRIPTION", errMsg);
+        createPEL(additionalData, PelSeverity::WARNING, errIntfForGpioError);
     }
 
     return;
@@ -768,9 +760,14 @@ std::optional<bool> isPresent(const nlohmann::json& json, const string& file)
                 {
                     i2cBusAddr =
                         json["frus"][file].at(0)["presence"]["gpioI2CAddress"];
+                    errMsg += " i2cBusAddress: " + i2cBusAddr;
                 }
 
-                logGpioPel(errMsg, i2cBusAddr);
+                PelAdditionalData additionalData{};
+                additionalData.emplace("DESCRIPTION", errMsg);
+                createPEL(additionalData, PelSeverity::WARNING,
+                          errIntfForGpioError);
+
                 // Take failure postAction
                 executePostFailAction(json, file);
                 return false;
@@ -843,9 +840,13 @@ bool executePreAction(const nlohmann::json& json, const string& file)
                 {
                     i2cBusAddr =
                         json["frus"][file].at(0)["preAction"]["gpioI2CAddress"];
+                    errMsg += " i2cBusAddress: " + i2cBusAddr;
                 }
 
-                logGpioPel(errMsg, i2cBusAddr);
+                PelAdditionalData additionalData{};
+                additionalData.emplace("DESCRIPTION", errMsg);
+                createPEL(additionalData, PelSeverity::WARNING,
+                          errIntfForGpioError);
 
                 // Take failure postAction
                 executePostFailAction(json, file);

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -15,6 +15,25 @@ namespace openpower
 namespace vpd
 {
 
+// mapping of severity enum to severity interface
+static std::unordered_map<constants::PelSeverity, std::string> sevMap = {
+    {constants::PelSeverity::INFORMATIONAL,
+     "xyz.openbmc_project.Logging.Entry.Level.Informational"},
+    {constants::PelSeverity::DEBUG,
+     "xyz.openbmc_project.Logging.Entry.Level.Debug"},
+    {constants::PelSeverity::NOTICE,
+     "xyz.openbmc_project.Logging.Entry.Level.Notice"},
+    {constants::PelSeverity::WARNING,
+     "xyz.openbmc_project.Logging.Entry.Level.Warning"},
+    {constants::PelSeverity::CRITICAL,
+     "xyz.openbmc_project.Logging.Entry.Level.Critical"},
+    {constants::PelSeverity::EMERGENCY,
+     "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
+    {constants::PelSeverity::ERROR,
+     "xyz.openbmc_project.Logging.Entry.Level.Error"},
+    {constants::PelSeverity::ALERT,
+     "xyz.openbmc_project.Logging.Entry.Level.Alert"}};
+
 // Map to hold record, kwd pair which can be re-stored at standby.
 // The list of keywords for VSYS record is as per the S0 system. Should
 // be updated for another type of systems

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -15,25 +15,6 @@ namespace openpower
 namespace vpd
 {
 
-// mapping of severity enum to severity interface
-static std::unordered_map<constants::PelSeverity, std::string> sevMap = {
-    {constants::PelSeverity::INFORMATIONAL,
-     "xyz.openbmc_project.Logging.Entry.Level.Informational"},
-    {constants::PelSeverity::DEBUG,
-     "xyz.openbmc_project.Logging.Entry.Level.Debug"},
-    {constants::PelSeverity::NOTICE,
-     "xyz.openbmc_project.Logging.Entry.Level.Notice"},
-    {constants::PelSeverity::WARNING,
-     "xyz.openbmc_project.Logging.Entry.Level.Warning"},
-    {constants::PelSeverity::CRITICAL,
-     "xyz.openbmc_project.Logging.Entry.Level.Critical"},
-    {constants::PelSeverity::EMERGENCY,
-     "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
-    {constants::PelSeverity::ERROR,
-     "xyz.openbmc_project.Logging.Entry.Level.Error"},
-    {constants::PelSeverity::ALERT,
-     "xyz.openbmc_project.Logging.Entry.Level.Alert"}};
-
 // Map to hold record, kwd pair which can be re-stored at standby.
 // The list of keywords for VSYS record is as per the S0 system. Should
 // be updated for another type of systems

--- a/types.hpp
+++ b/types.hpp
@@ -61,6 +61,7 @@ using MapperResponse =
     std::map<Path, std::map<Service, std::vector<Interface>>>;
 using RestoredEeproms = std::tuple<Path, std::string, Keyword, Binary>;
 using ReplaceableFrus = std::vector<VPDfilepath>;
+using EssentialFrus = std::vector<Path>;
 } // namespace inventory
 
 } // namespace vpd

--- a/vpd-manager/editor_impl.cpp
+++ b/vpd-manager/editor_impl.cpp
@@ -511,7 +511,6 @@ static void enableRebootGuard()
             "org.freedesktop.systemd1.Manager", "StartUnit");
         method.append("reboot-guard-enable.service", "replace");
         bus.call_noreply(method);
-        std::cout << "Disabled reboot" << std::endl;
     }
     catch (const sdbusplus::exception::exception& e)
     {
@@ -533,7 +532,6 @@ static void disableRebootGuard()
             "org.freedesktop.systemd1.Manager", "StartUnit");
         method.append("reboot-guard-disable.service", "replace");
         bus.call_noreply(method);
-        std::cout << "Enabled reboot" << std::endl;
     }
     catch (const sdbusplus::exception::exception& e)
     {
@@ -579,18 +577,8 @@ void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
 
         if (objPath.empty())
         {
-            // this should not fail as we have already read the vpdFilePath
-            // above.
-            if (jsonFile.contains(vpdFilePath))
-            {
-                objPath = jsonFile[vpdFilePath][0]["inventoryPath"]
-                              .get_ref<const nlohmann::json::string_t&>();
-            }
-            else
-            {
-                throw std::runtime_error(
-                    "Json does not contain given vpd file path");
-            }
+            objPath = jsonFile["frus"][vpdFilePath][0]["inventoryPath"]
+                          .get_ref<const nlohmann::json::string_t&>();
         }
 
 #else
@@ -644,7 +632,6 @@ void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
                     updateCache();
 #endif
                 }
-                std::cout << "Sleep started" << std::endl;
             }
             catch (const std::exception& e)
             {

--- a/vpd-manager/manager.hpp
+++ b/vpd-manager/manager.hpp
@@ -180,6 +180,17 @@ class Manager : public ServerObject<ManagerIface>
      */
     void restoreSystemVpd();
 
+    /**
+     * @brief API to create async PEL entry
+     * @param[in] additionalData - Map holding the additional data
+     * @param[in] sev - Severity
+     * @param[in] errIntf - error interface
+     */
+    void
+        createAsyncPel(const std::map<std::string, std::string>& additionalData,
+                       const constants::PelSeverity& sev,
+                       const std::string& errIntf);
+
     /** @brief Persistent sdbusplus DBus bus connection. */
     sdbusplus::bus::bus _bus;
 

--- a/vpd-manager/manager.hpp
+++ b/vpd-manager/manager.hpp
@@ -49,7 +49,10 @@ class Manager : public ServerObject<ManagerIface>
     Manager(const Manager&) = delete;
     Manager& operator=(const Manager&) = delete;
     Manager(Manager&&) = delete;
-    ~Manager() = default;
+    ~Manager()
+    {
+        sd_bus_unref(sdBus);
+    }
 
     /** @brief Constructor to put object onto bus at a dbus path.
      *  @param[in] bus - Bus connection.
@@ -181,15 +184,11 @@ class Manager : public ServerObject<ManagerIface>
     void restoreSystemVpd();
 
     /**
-     * @brief API to create async PEL entry
-     * @param[in] additionalData - Map holding the additional data
-     * @param[in] sev - Severity
-     * @param[in] errIntf - error interface
+     * @brief Check for essential fru in the system.
+     * The api check for the presence of FRUs marked as essential and logs PEL
+     * in case they are missing.
      */
-    void
-        createAsyncPel(const std::map<std::string, std::string>& additionalData,
-                       const constants::PelSeverity& sev,
-                       const std::string& errIntf);
+    void checkEssentialFrus();
 
     /** @brief Persistent sdbusplus DBus bus connection. */
     sdbusplus::bus::bus _bus;
@@ -209,6 +208,12 @@ class Manager : public ServerObject<ManagerIface>
 
     // map to hold FRUs which can be replaced at standby
     inventory::ReplaceableFrus replaceableFrus;
+
+    // List of FRUs marked as essential in the system.
+    inventory::EssentialFrus essentialFrus;
+
+    // sd-bus
+    sd_bus* sdBus = nullptr;
 };
 
 } // namespace manager


### PR DESCRIPTION
Some FRUs are marked as essential in the inventory JSON, which
implies that those FRUs should be present in the system at
power on.

The commit checks for presence of those FRUs when the system is
powered on.
In case any FRU in the list is found missing, appropriate
PEL is logged.

Test steps(rainier):
Check for present property for fru path
/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth

if it is false then proceed else set the property to false using
busctl set-property command.

execute obmcutil poweron
PEL should be logged for missing essential fru.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>