### PR TITLE
Bug fix in update keyword & restore system vpd

### DIFF
--- a/vpd-manager/editor_impl.cpp
+++ b/vpd-manager/editor_impl.cpp
@@ -579,18 +579,8 @@ void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
 
         if (objPath.empty())
         {
-            // this should not fail as we have already read the vpdFilePath
-            // above.
-            if (jsonFile.contains(vpdFilePath))
-            {
-                objPath = jsonFile[vpdFilePath][0]["inventoryPath"]
-                              .get_ref<const nlohmann::json::string_t&>();
-            }
-            else
-            {
-                throw std::runtime_error(
-                    "Json does not contain given vpd file path");
-            }
+            objPath = jsonFile["frus"][vpdFilePath][0]["inventoryPath"]
+                          .get_ref<const nlohmann::json::string_t&>();
         }
 
 #else

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -126,7 +126,7 @@ void Manager::restoreSystemVpd()
     {
         auto vpdVector = getVpdDataInVector(jsonFile, systemVpdFilePath);
         const auto& inventoryPath =
-            jsonFile[systemVpdFilePath][0]["inventoryPath"]
+            jsonFile["frus"][systemVpdFilePath][0]["inventoryPath"]
                 .get_ref<const nlohmann::json::string_t&>();
 
         parser = ParserFactory::getParser(vpdVector, (pimPath + inventoryPath));


### PR DESCRIPTION
Bug in vpd-manager updateKeyword() and restoreSystemVPD():

The code queries the key vpdFilePath in the whole json object, rather
than quering vpdFilePath key in "frus" section in json.

This breaks the updateKeyword and restoreSystemVPD API execution.

Test:
Error found with the existing logic:

Jun 20 15:53:10 rain104bmc systemd[1]: Stopping IBM VPD Manager...
Jun 20 15:53:10 rain104bmc systemd[1]: com.ibm.VPD.Manager.service: Deactivated successfully.
Jun 20 15:53:10 rain104bmc systemd[1]: Stopped IBM VPD Manager.
Jun 20 15:53:10 rain104bmc systemd[1]: Starting IBM VPD Manager...
Jun 20 15:53:10 rain104bmc systemd[1]: Started IBM VPD Manager.
Jun 20 15:53:10 rain104bmc vpd-manager[1038]: Attempting system VPD restore
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Failed to restore system VPD due to exception: [json.exception.type_error.303] incompatible ReferenceType for get_ref, actual type is null
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Is PLDM running: 1
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Attempting BIOS attribute reset
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Skip FCO BIOS write, value is already: 0
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Skip AMM BIOS write, value is already: Disabled
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Skip Keep and Clear BIOS write, value is already: Disabled
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Skip Create default LPAR BIOS write, value is already: Disabled
Jun 20 15:53:11 rain104bmc vpd-manager[1038]: Skip Clear NVRAM BIOS write, value is already: Disabled

root@rain104bmc:/tmp# vpd-tool -w -H -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R VINI -K DR -V 0x64
Disabled reboot
Enabled reboot
Json does not contain given vpd file path

Tested with this fix and verified both updateKeyword() and restoreSystemVPD() via vpd-manager
works without any issues.

root@ever8bmc:~# systemctl status com.ibm.VPD.Manager
● com.ibm.VPD.Manager.service - IBM VPD Manager
     Loaded: loaded (/lib/systemd/system/com.ibm.VPD.Manager.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2022-06-21 04:25:26 UTC; 2h 12min ago
   Main PID: 2695 (vpd-manager)
     CGroup: /system.slice/com.ibm.VPD.Manager.service
             └─2695 /usr/bin/vpd-manager

Jun 21 04:25:26 ever8bmc systemd[1]: Starting IBM VPD Manager...
Jun 21 04:25:26 ever8bmc systemd[1]: Started IBM VPD Manager.
Jun 21 04:25:26 ever8bmc vpd-manager[2695]: Attempting system VPD restore
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Is PLDM running: 1
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Attempting BIOS attribute reset
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Skip FCO BIOS write, value is already: 0
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Skip AMM BIOS write, value is already: Enabled
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Skip Keep and Clear BIOS write, value is already: Disabled
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Skip Create default LPAR BIOS write, value is already: Disabled
Jun 21 04:25:28 ever8bmc vpd-manager[2695]: Skip Clear NVRAM BIOS write, value is already: Disabled

root@ever8bmc:/tmp# ./vpd-tool -w -H -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R VINI -K DR -V 0x64
Disabled reboot
Sleep started, try to reboot
Sleep end
Sleep started
Enabled reboot

Data updated successfully

000000e0  01 00 78 84 80 00 52 54  04 56 49 4e 49 44 52 10  |..x...RT.VINIDR.|
000000f0  64 59 53 54 45 4d 20 42  41 43 4b 50 4c 41 4e 45  |dYSTEM BACKPLANE|

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>
Change-Id: I256cd032feaeb1284fbfed8ed11010af47dc8539