### PR TITLE
Api for asyn call to create pel

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -81,6 +81,7 @@ constexpr auto offsetJsonDirectory = "/var/lib/vpd/";
 constexpr auto mapperObjectPath = "/xyz/openbmc_project/object_mapper";
 constexpr auto mapperInterface = "xyz.openbmc_project.ObjectMapper";
 constexpr auto mapperDestination = "xyz.openbmc_project.ObjectMapper";
+constexpr auto loggerService = "xyz.openbmc_project.Logging";
 constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
 constexpr auto loggerCreateInterface = "xyz.openbmc_project.Logging.Create";
 constexpr auto errIntfForBlankSystemVPD = "com.ibm.VPD.Error.BlankSystemVPD";

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -36,18 +36,6 @@ using namespace common::utility;
 using Severity = openpower::vpd::constants::PelSeverity;
 namespace fs = std::filesystem;
 
-// mapping of severity enum to severity interface
-static std::unordered_map<Severity, std::string> sevMap = {
-    {Severity::INFORMATIONAL,
-     "xyz.openbmc_project.Logging.Entry.Level.Informational"},
-    {Severity::DEBUG, "xyz.openbmc_project.Logging.Entry.Level.Debug"},
-    {Severity::NOTICE, "xyz.openbmc_project.Logging.Entry.Level.Notice"},
-    {Severity::WARNING, "xyz.openbmc_project.Logging.Entry.Level.Warning"},
-    {Severity::CRITICAL, "xyz.openbmc_project.Logging.Entry.Level.Critical"},
-    {Severity::EMERGENCY, "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
-    {Severity::ERROR, "xyz.openbmc_project.Logging.Entry.Level.Error"},
-    {Severity::ALERT, "xyz.openbmc_project.Logging.Entry.Level.Alert"}};
-
 namespace inventory
 {
 

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -15,6 +15,25 @@ namespace openpower
 namespace vpd
 {
 
+// mapping of severity enum to severity interface
+static std::unordered_map<constants::PelSeverity, std::string> sevMap = {
+    {constants::PelSeverity::INFORMATIONAL,
+     "xyz.openbmc_project.Logging.Entry.Level.Informational"},
+    {constants::PelSeverity::DEBUG,
+     "xyz.openbmc_project.Logging.Entry.Level.Debug"},
+    {constants::PelSeverity::NOTICE,
+     "xyz.openbmc_project.Logging.Entry.Level.Notice"},
+    {constants::PelSeverity::WARNING,
+     "xyz.openbmc_project.Logging.Entry.Level.Warning"},
+    {constants::PelSeverity::CRITICAL,
+     "xyz.openbmc_project.Logging.Entry.Level.Critical"},
+    {constants::PelSeverity::EMERGENCY,
+     "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
+    {constants::PelSeverity::ERROR,
+     "xyz.openbmc_project.Logging.Entry.Level.Error"},
+    {constants::PelSeverity::ALERT,
+     "xyz.openbmc_project.Logging.Entry.Level.Alert"}};
+
 // Map to hold record, kwd pair which can be re-stored at standby.
 // The list of keywords for VSYS record is as per the S0 system. Should
 // be updated for another type of systems

--- a/vpd-manager/manager.hpp
+++ b/vpd-manager/manager.hpp
@@ -180,6 +180,17 @@ class Manager : public ServerObject<ManagerIface>
      */
     void restoreSystemVpd();
 
+    /**
+     * @brief API to create async PEL entry
+     * @param[in] additionalData - Map holding the additional data
+     * @param[in] sev - Severity
+     * @param[in] errIntf - error interface
+     */
+    void
+        createAsyncPel(const std::map<std::string, std::string>& additionalData,
+                       const constants::PelSeverity& sev,
+                       const std::string& errIntf);
+
     /** @brief Persistent sdbusplus DBus bus connection. */
     sdbusplus::bus::bus _bus;
 


### PR DESCRIPTION
The commit introduces an api to make async dbus call to
"Create" under phosphor-logging which is used to create pel.

It was required as "Create" api was making vpd-manager call
incase any fru is called out using inventory path and in that
case any attempt of logging a pel from vpd-manager using a
synchronous call to "Create" was resulting in a deadlock.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>