### PR TITLE
manager: Fix Core Dump in Redundant EEPROM Writes

### DIFF
--- a/vpd-manager/editor_impl.cpp
+++ b/vpd-manager/editor_impl.cpp
@@ -575,7 +575,8 @@ void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
 
         vpdFile = completeVPDFile;
 
-        if (objPath.empty())
+        if (objPath.empty() &&
+            jsonFile["frus"].find(vpdFilePath) != jsonFile["frus"].end())
         {
             objPath = jsonFile["frus"][vpdFilePath][0]["inventoryPath"]
                           .get_ref<const nlohmann::json::string_t&>();

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -387,7 +387,7 @@ void Manager::writeKeyword(const sdbusplus::message::object_path path,
         if (!std::get<1>(frus.find(objPath)->second).empty())
         {
             EditorImpl edit(std::get<1>(frus.find(objPath)->second), jsonFile,
-                            recordName, keyword);
+                            recordName, keyword, objPath);
             edit.updateKeyword(value, offset, false);
         }
 


### PR DESCRIPTION
Some recent changes introduced a regression in the module
VPD write when updating redundant EEPROMs.

This commit fixes the bad JSON access that was causing the core dump.

Tested:
I tested various VPD reads and writes on module as well as non-module
FRUs and they all worked fine.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: I9276dda6806612ac2db872c1290531cd4bffa176