### PR TITLE
Async request to create PEL

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -171,7 +171,52 @@ string readBusProperty(const string& obj, const string& inf, const string& prop)
 }
 
 void createPEL(const std::map<std::string, std::string>& additionalData,
-               const Severity& sev, const std::string& errIntf)
+               const Severity& sev, const std::string& errIntf, sd_bus* sdBus)
+{
+    // This pointer will be NULL in case the call is made from ibm-read-vpd. In
+    // that case a sync call will do.
+    if (sdBus == nullptr)
+    {
+        createSyncPEL(additionalData, sev, errIntf);
+    }
+    else
+    {
+        std::string errDescription{};
+        auto pos = additionalData.find("DESCRIPTION");
+        if (pos != additionalData.end())
+        {
+            errDescription = pos->second;
+        }
+        else
+        {
+            errDescription = "Description field missing in additional data";
+        }
+
+        std::string pelSeverity =
+            "xyz.openbmc_project.Logging.Entry.Level.Error";
+        auto itr = sevMap.find(sev);
+        if (itr != sevMap.end())
+        {
+            pelSeverity = itr->second;
+        }
+
+        // Implies this is a call from Manager. Hence we need to make an async
+        // call to avoid deadlock with Phosphor-logging.
+        auto rc = sd_bus_call_method_async(
+            sdBus, NULL, loggerService, loggerObjectPath, loggerCreateInterface,
+            "Create", NULL, NULL, "ssa{ss}", errIntf.c_str(),
+            pelSeverity.c_str(), 1, "DESCRIPTION", errDescription.c_str());
+
+        if (rc < 0)
+        {
+            log<level::ERR>("Error calling sd_bus_call_method_async",
+                            entry("RC=%d", rc), entry("MSG=%s", strerror(-rc)));
+        }
+    }
+}
+
+void createSyncPEL(const std::map<std::string, std::string>& additionalData,
+                   const Severity& sev, const std::string& errIntf)
 {
     try
     {
@@ -683,7 +728,7 @@ void executePostFailAction(const nlohmann::json& json, const string& file)
 
         if (!outputLine)
         {
-            throw runtime_error(
+            throw GpioException(
                 "Couldn't find output line for the GPIO. Skipping "
                 "this GPIO action.");
         }
@@ -706,9 +751,7 @@ void executePostFailAction(const nlohmann::json& json, const string& file)
             errMsg += " i2cBusAddress: " + i2cBusAddr;
         }
 
-        PelAdditionalData additionalData{};
-        additionalData.emplace("DESCRIPTION", errMsg);
-        createPEL(additionalData, PelSeverity::WARNING, errIntfForGpioError);
+        throw GpioException(e.what());
     }
 
     return;
@@ -736,7 +779,7 @@ std::optional<bool> isPresent(const nlohmann::json& json, const string& file)
                     cerr << "Couldn't find the presence line for - "
                          << presPinName << endl;
 
-                    throw runtime_error(
+                    throw GpioException(
                         "Couldn't find the presence line for the "
                         "GPIO. Skipping this GPIO action.");
                 }
@@ -763,14 +806,9 @@ std::optional<bool> isPresent(const nlohmann::json& json, const string& file)
                     errMsg += " i2cBusAddress: " + i2cBusAddr;
                 }
 
-                PelAdditionalData additionalData{};
-                additionalData.emplace("DESCRIPTION", errMsg);
-                createPEL(additionalData, PelSeverity::WARNING,
-                          errIntfForGpioError);
-
                 // Take failure postAction
                 executePostFailAction(json, file);
-                return false;
+                throw GpioException(errMsg);
             }
         }
         else
@@ -820,7 +858,7 @@ bool executePreAction(const nlohmann::json& json, const string& file)
                 {
                     cerr << "Couldn't find the line for output pin - "
                          << pinName << endl;
-                    throw runtime_error(
+                    throw GpioException(
                         "Couldn't find output line for the GPIO. "
                         "Skipping this GPIO action.");
                 }
@@ -843,15 +881,9 @@ bool executePreAction(const nlohmann::json& json, const string& file)
                     errMsg += " i2cBusAddress: " + i2cBusAddr;
                 }
 
-                PelAdditionalData additionalData{};
-                additionalData.emplace("DESCRIPTION", errMsg);
-                createPEL(additionalData, PelSeverity::WARNING,
-                          errIntfForGpioError);
-
                 // Take failure postAction
                 executePostFailAction(json, file);
-
-                return false;
+                throw GpioException(errMsg);
             }
         }
         else
@@ -864,7 +896,6 @@ bool executePreAction(const nlohmann::json& json, const string& file)
 
             // Take failure postAction
             executePostFailAction(json, file);
-
             return false;
         }
     }

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -78,12 +78,32 @@ string readBusProperty(const string& obj, const string& inf,
 
 /**
  * @brief API to create PEL entry
+ * The api makes synchronous call to phosphor-logging create api.
  * @param[in] additionalData - Map holding the additional data
  * @param[in] sev - Severity
  * @param[in] errIntf - error interface
  */
+void createSyncPEL(const std::map<std::string, std::string>& additionalData,
+                   const constants::PelSeverity& sev,
+                   const std::string& errIntf);
+
+/**
+ * @brief Api to create PEL.
+ * A wrapper api through which sync/async call to phosphor-logging create api
+ * can be made as and when required.
+ * sdBus as nullptr will result in sync call else async call will be made with
+ * just "DESCRIPTION" key/value pair in additional data.
+ * To make asyn call with more fields in additional data call
+ * "sd_bus_call_method_async" in place.
+ *
+ * @param[in] additionalData - Map of additional data.
+ * @param[in] sev - severity of the PEL.
+ * @param[in] errIntf - Error interface to be used in PEL.
+ * @param[in] sdBus - Pointer to Sd-Bus
+ */
 void createPEL(const std::map<std::string, std::string>& additionalData,
-               const constants::PelSeverity& sev, const std::string& errIntf);
+               const constants::PelSeverity& sev, const std::string& errIntf,
+               sd_bus* sdBus);
 
 /**
  * @brief getVpdFilePath

--- a/impl.cpp
+++ b/impl.cpp
@@ -289,7 +289,7 @@ internal::OffsetList Impl::readPT(Binary::const_iterator iterator,
                                    std::string{ex.what()} + recordName);
             additionalData.emplace("CALLOUT_INVENTORY_PATH", inventoryPath);
             createPEL(additionalData, PelSeverity::WARNING,
-                      errIntfForEccCheckFail);
+                      errIntfForEccCheckFail, nullptr);
         }
         catch (const VpdDataException& ex)
         {
@@ -298,7 +298,7 @@ internal::OffsetList Impl::readPT(Binary::const_iterator iterator,
                                    std::string{ex.what()} + recordName);
             additionalData.emplace("CALLOUT_INVENTORY_PATH", inventoryPath);
             createPEL(additionalData, PelSeverity::WARNING,
-                      errIntfForInvalidVPD);
+                      errIntfForInvalidVPD, nullptr);
         }
 
 #endif

--- a/vpd_exceptions.hpp
+++ b/vpd_exceptions.hpp
@@ -134,6 +134,30 @@ class VpdJsonException : public VPDException
 
 }; // class VpdJSonException
 
+/** @class GpioException
+ *  @brief This class extends Exceptions class and define
+ *  type for GPIO related exception in VPD
+ */
+class GpioException : public VPDException
+{
+  public:
+    // deleted methods
+    GpioException() = delete;
+    GpioException(const GpioException&) = delete;
+    GpioException(GpioException&&) = delete;
+    GpioException& operator=(const GpioException&) = delete;
+
+    // default destructor
+    ~GpioException() = default;
+
+    /** @brief constructor
+     *  @param[in] msg - string to define exception
+     */
+    explicit GpioException(const std::string& msg) : VPDException(msg)
+    {
+    }
+};
+
 } // namespace exceptions
 } // namespace vpd
 } // namespace openpower


### PR DESCRIPTION
To avoid any deadlocks between phosphor-logging and vpd-manager
service a wrapper around request to create PEL is created
which enables vpd-manager to make async requests to create PEL.

It also implements a new exception type to throw any GPIO
related exception. This was required to throw specific
exception.

Test:
Scenario 1:
While vpd-manager logs a pel with call out to an inventory
item.
It should be checked that both the services do not enter into
a deadlock situation.

Scenario 2:
Any third process is requesting to log PEL with call out
to an inventory item in a loop.
In the mean time vpd-manager also requests to log a PEL
with or without call out to inventory item.
All the pels should be logged correctly in the system.
No deadlock should appear.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: I0efaf6918e679ca94808fc70d747c843a50eaf78