### PR TITLE
Bug fix in initializing VPD with BIOS attribute

### DIFF
--- a/vpd-manager/bios_handler.cpp
+++ b/vpd-manager/bios_handler.cpp
@@ -187,7 +187,7 @@ void BiosHandler::saveFCOToVPD(int64_t fcoVal)
         return;
     }
 
-    if (valInVPD.at(3) != fcoVal)
+    if (std::memcmp(vpdVal.data(), valInVPD.data(), 4) != 0)
     {
         std::cout << "Writing FCO to VPD: " << fcoVal << std::endl;
         manager.writeKeyword(sdbusplus::message::object_path{SYSTEM_OBJECT},


### PR DESCRIPTION
When syncing FCO attribute with RG keyword in system VPD,
there occurs a corner case where VSYS-RG keyword is not
programmed in VPD and has all ASCII blanks(32 in decimal)
and if FCO BIOS attribute value is 32, then existing logic
fails to initialise the VPD with the BIOS attribute.

The existing code checks if the value in VPD is same as the FCO
value. The check compares only the LSB of the VPD value instead of
the complete value. This commit has a fix for it.

Test:

Case 1: Value in VPD is blank and BIOS FCO value is 32

busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG ay 4 32 32 32 32

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 32 32 32 32

busctl call xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager GetAttribute s "hb_field_core_override"
svv "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Integer" x 0 x 0

busctl call xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager SetAttribute sv "hb_field_core_override" x 32

busctl call xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager GetAttribute s "hb_field_core_override"
svv "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Integer" x 32 x 0

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 0 0 0 32

===================================================================

Case 2: Value in VPD is not blank and BIOS FCO value is 24(numerically different values)

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 0 0 0 32

busctl call xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager SetAttribute sv "hb_field_core_override" x 24

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 0 0 0 24

==================================================================

Case 3: Value in VPD and BIOS FCO value are (equal) 0 (null)

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 0 0 0 0

busctl call xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager SetAttribute sv "hb_field_core_override" x 0

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 0 0 0 0

===================================================================

Case 4: Value in VPD is blank and BIOS FCO value is 16

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 32 32 32 32

busctl call xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager SetAttribute sv "hb_field_core_override" x 16

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG
ay 4 0 0 0 16

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>
Change-Id: I417d6099f1fe76115c4e71fd575e6977cef0affd