### PR TITLE
parser: Publish FRU Number For DIMMs

### DIFF
--- a/vpd-parser/memory_vpd_parser.cpp
+++ b/vpd-parser/memory_vpd_parser.cpp
@@ -126,6 +126,7 @@ kwdVpdMap memoryVpdParser::readKeywords(Binary::const_iterator iterator)
     advance(iterator, SERIAL_NUM_LEN);
     Binary ccin(iterator, iterator + CCIN_LEN);
 
+    map.emplace("FN", partNumber);
     map.emplace("PN", move(partNumber));
     map.emplace("SN", move(serialNumber));
     map.emplace("CC", move(ccin));


### PR DESCRIPTION
Make the memory VPD parser publish com.ibm.ipzvd.VINI FN.
This is the FRU number and for DDIMMs it is the same as the part number.
This ensures that the same is published over Redfish as the
SparePartNumber.

Tested:

Made sure that when the DIMM VPD is collected, we see both
com.ibm.ipzvpd.VINI FN as well as
xyz.openbmc_project.Inventory.Decorator.Asset SparePartNumber
show up on D-Bus.

Also verified that the SparePartNumber shows up in the GUI.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>