### PR TITLE
Add Initial Bonnell Support

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -56,6 +56,7 @@ static constexpr auto RAINIER_4U_V2 = "50001000_v2.json";
 static constexpr auto RAINIER_1S4U = "50001002.json";
 static constexpr auto EVEREST = "50003000.json";
 static constexpr auto EVEREST_V2 = "50003000_v2.json";
+static constexpr auto BONNELL = "50004000.json";
 
 constexpr uint8_t KW_VPD_START_TAG = 0x82;
 constexpr uint8_t KW_VPD_END_TAG = 0x78;

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -766,7 +766,8 @@ void setDevTreeEnv(const string& systemType)
         {RAINIER_4U_V2, "conf-aspeed-bmc-ibm-rainier-4u.dtb"},
         {RAINIER_1S4U, "conf-aspeed-bmc-ibm-rainier-1s4u.dtb"},
         {EVEREST, "conf-aspeed-bmc-ibm-everest.dtb"},
-        {EVEREST_V2, "conf-aspeed-bmc-ibm-everest.dtb"}};
+        {EVEREST_V2, "conf-aspeed-bmc-ibm-everest.dtb"},
+        {BONNELL, "conf-aspeed-bmc-ibm-bonnell.dtb"}};
 
     if (deviceTreeSystemTypeMap.find(systemType) !=
         deviceTreeSystemTypeMap.end())


### PR DESCRIPTION
This adds initial support for Bonnell system.
Adds entries to enable loading the Bonnell device tree and setup the right symlink for the VPD JSON.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>