### PR TITLE
Add delay after trigerring DIMM VPD Collection

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -24,6 +24,7 @@
 #include <iterator>
 #include <phosphor-logging/log.hpp>
 #include <regex>
+#include <thread>
 
 using namespace std;
 using namespace openpower::vpd;
@@ -1140,6 +1141,9 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
                 if (chipVersion >= 2)
                 {
                     doEnableAllDimms(js);
+                    // Sleep for a few seconds to let the DIMM parses start
+                    using namespace std::chrono_literals;
+                    std::this_thread::sleep_for(5s);
                 }
             }
         }


### PR DESCRIPTION
Since systems can have a number of DIMMs (as opposed to other FRUs) and the DIMM VPD collection is only kicked off after the primary processor VPD is collected, add a small delay at the end of trigerring the udev events for all DIMMs.

This ensures that we can properly wait for all the VPD to be collected before we can reach BMC Ready state.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>