### PR TITLE
Shift to boost asio library

### DIFF
--- a/vpd-manager/bios_handler.cpp
+++ b/vpd-manager/bios_handler.cpp
@@ -27,9 +27,9 @@ void BiosHandler::checkAndListenPLDMService()
 {
     // Setup a match on NameOwnerChanged to determine when PLDM is up. In
     // the signal handler, call restoreBIOSAttribs
-    static std::shared_ptr<sdbusplus::bus::match::match> nameOwnerMatch =
-        std::make_shared<sdbusplus::bus::match::match>(
-            bus,
+    static std::shared_ptr<sdbusplus::bus::match_t> nameOwnerMatch =
+        std::make_shared<sdbusplus::bus::match_t>(
+            *conn,
             sdbusplus::bus::match::rules::nameOwnerChanged(
                 "xyz.openbmc_project.PLDM"),
             [this](sdbusplus::message::message& msg) {
@@ -82,9 +82,9 @@ void BiosHandler::checkAndListenPLDMService()
 
 void BiosHandler::listenBiosAttribs()
 {
-    static std::shared_ptr<sdbusplus::bus::match::match> biosMatcher =
-        std::make_shared<sdbusplus::bus::match::match>(
-            bus,
+    static std::shared_ptr<sdbusplus::bus::match_t> biosMatcher =
+        std::make_shared<sdbusplus::bus::match_t>(
+            *conn,
             sdbusplus::bus::match::rules::propertiesChanged(
                 "/xyz/openbmc_project/bios_config/manager",
                 "xyz.openbmc_project.BIOSConfig.Manager"),

--- a/vpd-manager/bios_handler.hpp
+++ b/vpd-manager/bios_handler.hpp
@@ -4,23 +4,8 @@
 
 #include <stdint.h>
 
+#include <sdbusplus/asio/connection.hpp>
 #include <string>
-
-namespace sdbusplus
-{
-namespace bus
-{
-class bus;
-} // namespace bus
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace message
-{
-class message;
-} // namespace message
-} // namespace sdbusplus
 
 namespace openpower
 {
@@ -55,8 +40,10 @@ class BiosHandler
     BiosHandler& operator=(BiosHandler&&) = delete;
     ~BiosHandler() = default;
 
-    BiosHandler(sdbusplus::bus::bus& bus, Manager& manager) :
-        bus(bus), manager(manager)
+    BiosHandler(std::shared_ptr<sdbusplus::asio::connection>& conn,
+                Manager& manager) :
+        conn(conn),
+        manager(manager)
     {
         checkAndListenPLDMService();
     }
@@ -254,9 +241,9 @@ class BiosHandler
     void restoreBIOSAttribs();
 
     /**
-     * @brief Reference to the bus.
+     * @brief Reference to the connection.
      */
-    sdbusplus::bus::bus& bus;
+    std::shared_ptr<sdbusplus::asio::connection>& conn;
 
     /**
      * @brief Reference to the manager.

--- a/vpd-manager/gpioMonitor.cpp
+++ b/vpd-manager/gpioMonitor.cpp
@@ -3,19 +3,12 @@
 #include "common_utility.hpp"
 #include "ibm_vpd_utils.hpp"
 
-#include <systemd/sd-event.h>
-
-#include <chrono>
+#include <boost/asio.hpp>
+#include <boost/bind/bind.hpp>
 #include <gpiod.hpp>
-#include <sdeventplus/clock.hpp>
-#include <sdeventplus/utility/timer.hpp>
 
 using namespace std;
 using namespace openpower::vpd::constants;
-using sdeventplus::ClockId;
-using sdeventplus::Event;
-using Timer = sdeventplus::utility::Timer<ClockId::Monotonic>;
-using namespace std::chrono_literals;
 
 namespace openpower
 {
@@ -44,7 +37,8 @@ bool GpioEventHandler::getPresencePinValue()
     return gpioData;
 }
 
-void GpioMonitor::initGpioInfos(Event& event)
+void GpioMonitor::initGpioInfos(
+    std::shared_ptr<boost::asio::io_context>& ioContext)
 {
     Byte outputValue = 0;
     Byte presenceValue = 0;
@@ -105,7 +99,7 @@ void GpioMonitor::initGpioInfos(Event& event)
                         make_shared<GpioEventHandler>(
                             presencePinName, presenceValue, outputPinName,
                             outputValue, devNameAddr, driverType, busType,
-                            objectPath, event);
+                            objectPath, ioContext);
 
                     gpioObjects.push_back(gpioObj);
                 }
@@ -161,20 +155,43 @@ void GpioEventHandler::toggleGpio()
     executeCmd(cmnd);
 }
 
-void GpioEventHandler::doEventAndTimerSetup(sdeventplus::Event& event)
+void GpioEventHandler::handleTimerExpiry(
+    const boost::system::error_code& ec,
+    std::shared_ptr<boost::asio::steady_timer>& timer)
+{
+    if (ec == boost::asio::error::operation_aborted)
+    {
+        return;
+    }
+
+    if (ec)
+    {
+        std::cerr << "Timer wait failed for gpio pin" << ec.message();
+        return;
+    }
+
+    if (hasEventOccurred())
+    {
+        toggleGpio();
+    }
+    timer->expires_at(std::chrono::steady_clock::now() +
+                      std::chrono::seconds(5));
+    timer->async_wait(boost::bind(&GpioEventHandler::handleTimerExpiry, this,
+                                  boost::asio::placeholders::error, timer));
+}
+
+void GpioEventHandler::doEventAndTimerSetup(
+    std::shared_ptr<boost::asio::io_context>& ioContext)
 {
     prevPresPinValue = getPresencePinValue();
 
-    static vector<shared_ptr<Timer>> timers;
-    shared_ptr<Timer> timer = make_shared<Timer>(
-        event,
-        [this](Timer&) {
-            if (hasEventOccurred())
-            {
-                toggleGpio();
-            }
-        },
-        std::chrono::seconds{5s});
+    static vector<std::shared_ptr<boost::asio::steady_timer>> timers;
+
+    auto timer = make_shared<boost::asio::steady_timer>(
+        *ioContext, std::chrono::seconds(5));
+
+    timer->async_wait(boost::bind(&GpioEventHandler::handleTimerExpiry, this,
+                                  boost::asio::placeholders::error, timer));
 
     timers.push_back(timer);
 }

--- a/vpd-manager/manager.hpp
+++ b/vpd-manager/manager.hpp
@@ -1,19 +1,11 @@
 #pragma once
 
+#include "bios_handler.hpp"
 #include "editor_impl.hpp"
-#include "types.hpp"
+#include "gpioMonitor.hpp"
 
-#include <com/ibm/VPD/Manager/server.hpp>
 #include <map>
-#include <nlohmann/json.hpp>
-
-namespace sdbusplus
-{
-namespace bus
-{
-class bus;
-}
-} // namespace sdbusplus
+#include <sdbusplus/asio/object_server.hpp>
 
 namespace openpower
 {
@@ -22,18 +14,12 @@ namespace vpd
 namespace manager
 {
 
-template <typename T>
-using ServerObject = T;
-
-using ManagerIface = sdbusplus::com::ibm::VPD::server::Manager;
-
 /** @class Manager
  *  @brief OpenBMC VPD Manager implementation.
  *
- *  A concrete implementation for the
- *  com.ibm.vpd.Manager
+ *  Implements methods under interface com.ibm.vpd.Manager.
  */
-class Manager : public ServerObject<ManagerIface>
+class Manager
 {
   public:
     /* Define all of the basic class operations:
@@ -54,14 +40,14 @@ class Manager : public ServerObject<ManagerIface>
         sd_bus_unref(sdBus);
     }
 
-    /** @brief Constructor to put object onto bus at a dbus path.
-     *  @param[in] bus - Bus connection.
-     *  @param[in] busName - Name to be requested on Bus
-     *  @param[in] objPath - Path to attach at.
-     *  @param[in] iFace - interface to implement
+    /** @brief Constructor.
+     *  @param[in] ioCon - IO context.
+     *  @param[in] iFace - interface to implement.
+     *  @param[in] connection - Dbus Connection.
      */
-    Manager(sdbusplus::bus::bus&& bus, const char* busName, const char* objPath,
-            const char* iFace);
+    Manager(std::shared_ptr<boost::asio::io_context>& ioCon,
+            std::shared_ptr<sdbusplus::asio::dbus_interface>& iFace,
+            std::shared_ptr<sdbusplus::asio::connection>& conn);
 
     /** @brief Implementation for WriteKeyword
      *  Api to update the keyword value for a given inventory.
@@ -72,9 +58,9 @@ class Manager : public ServerObject<ManagerIface>
      *  @param[in] keyword - keyword whose value needs to be updated
      *  @param[in] value - value that needs to be updated
      */
-    void writeKeyword(const sdbusplus::message::object_path path,
-                      const std::string recordName, const std::string keyword,
-                      const Binary value);
+    void writeKeyword(const sdbusplus::message::object_path& path,
+                      const std::string& recordName, const std::string& keyword,
+                      const Binary& value);
 
     /** @brief Implementation for GetFRUsByUnexpandedLocationCode
      *  A method to get list of FRU D-BUS object paths for a given unexpanded
@@ -89,7 +75,7 @@ class Manager : public ServerObject<ManagerIface>
      *  List of all the FRUs D-Bus object paths for the given location code.
      */
     inventory::ListOfPaths
-        getFRUsByUnexpandedLocationCode(const std::string locationCode,
+        getFRUsByUnexpandedLocationCode(const std::string& locationCode,
                                         const uint16_t nodeNumber);
 
     /** @brief Implementation for GetFRUsByExpandedLocationCode
@@ -103,7 +89,7 @@ class Manager : public ServerObject<ManagerIface>
      *  List of all the FRUs D-Bus object path for the given location code.
      */
     inventory::ListOfPaths
-        getFRUsByExpandedLocationCode(const std::string locationCode);
+        getFRUsByExpandedLocationCode(const std::string& locationCode);
 
     /** @brief Implementation for GetExpandedLocationCode
      *  An API to get expanded location code corresponding to a given
@@ -115,11 +101,8 @@ class Manager : public ServerObject<ManagerIface>
      *
      *  @return locationCode[std::string] - Location code in expanded format.
      */
-    std::string getExpandedLocationCode(const std::string locationCode,
+    std::string getExpandedLocationCode(const std::string& locationCode,
                                         const uint16_t nodeNumber);
-
-    /** @brief Start processing DBus messages. */
-    void run();
 
     /** @brief Api to perform VPD recollection.
      * This api will trigger parser to perform VPD recollection for FRUs that
@@ -140,6 +123,11 @@ class Manager : public ServerObject<ManagerIface>
     void collectFRUVPD(const sdbusplus::message::object_path path);
 
   private:
+    /**
+     * @brief An api to process some initial requiremets.
+     */
+    void initManager();
+
     /** @brief process the given JSON file
      */
     void processJSON();
@@ -190,11 +178,14 @@ class Manager : public ServerObject<ManagerIface>
      */
     void checkEssentialFrus();
 
-    /** @brief Persistent sdbusplus DBus bus connection. */
-    sdbusplus::bus::bus _bus;
+    // Shared pointer to asio context object.
+    std::shared_ptr<boost::asio::io_context>& ioContext;
 
-    /** @brief sdbusplus org.freedesktop.DBus.ObjectManager reference. */
-    sdbusplus::server::manager::manager _manager;
+    // Shared prt to Dbus interface class.
+    std::shared_ptr<sdbusplus::asio::dbus_interface>& interface;
+
+    // Bus connection.
+    std::shared_ptr<sdbusplus::asio::connection>& conn;
 
     // file to store parsed json
     nlohmann::json jsonFile;
@@ -212,8 +203,11 @@ class Manager : public ServerObject<ManagerIface>
     // List of FRUs marked as essential in the system.
     inventory::EssentialFrus essentialFrus;
 
-    // sd-bus
-    sd_bus* sdBus = nullptr;
+    // Shared pointer to gpio monitor object.
+    std::shared_ptr<GpioMonitor> gpioMon;
+
+    // Shared pointer to instance of the BIOS handler.
+    std::shared_ptr<BiosHandler> biosHandler;
 };
 
 } // namespace manager

--- a/vpd-manager/manager_main.cpp
+++ b/vpd-manager/manager_main.cpp
@@ -2,18 +2,29 @@
 
 #include "manager.hpp"
 
-#include <cstdlib>
-#include <exception>
-#include <iostream>
-#include <sdbusplus/bus.hpp>
+#include <sdbusplus/asio/connection.hpp>
 
 int main(int /*argc*/, char** /*argv*/)
 {
     try
     {
-        openpower::vpd::manager::Manager vpdManager(
-            sdbusplus::bus::new_system(), BUSNAME, OBJPATH, IFACE);
-        vpdManager.run();
+        auto io_con = std::make_shared<boost::asio::io_context>();
+        auto connection =
+            std::make_shared<sdbusplus::asio::connection>(*io_con);
+        connection->request_name(BUSNAME);
+
+        auto server = sdbusplus::asio::object_server(connection);
+
+        std::shared_ptr<sdbusplus::asio::dbus_interface> interface =
+            server.add_interface(OBJPATH, IFACE);
+
+        auto vpdManager = std::make_shared<openpower::vpd::manager::Manager>(
+            io_con, interface, connection);
+        interface->initialize();
+
+        // Start event loop.
+        io_con->run();
+
         exit(EXIT_SUCCESS);
     }
     catch (const std::exception& e)

--- a/vpd-manager/meson.build
+++ b/vpd-manager/meson.build
@@ -1,12 +1,10 @@
 systemd = dependency('libsystemd', version: '>= 221')
-phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
 sdeventplus = dependency('sdeventplus')
 
 configuration_inc = include_directories('.', '../', '../vpd-parser/')
 
 vpd_manager_SOURCES =['manager_main.cpp',
                       'manager.cpp',
-                      'server.cpp',
                       'error.cpp',
                       'editor_impl.cpp',
                       'reader_impl.cpp',
@@ -21,10 +19,8 @@ vpd_manager_SOURCES =['manager_main.cpp',
                       '../vpd-parser/parser_factory.cpp'
                      ]
 
-vpd_manager_dependencies =[sdbusplus,
-                           phosphor_logging,
+vpd_manager_dependencies =[phosphor_logging,
                            systemd,
-                           phosphor_dbus_interfaces,
                            libgpiodcxx,
                            sdeventplus,
                           ]


### PR DESCRIPTION
This commit shifts vpd manager from sdbusplus event loop to boost io_context event loop.
The shift was done to have a more flexible way to perform async Dbus calls.
For example read/write of vpd data can be performed asynchronously.

It also removes dependency of Manager class on the interface class created as a part of PDI repo.

Test:
- Introspect com.ibm.VPD.Manager /com/ibm/VPD/Manager to ensure that all the methods exposed under com.ibm.VPD.Manager interface matches to the ones documented under PDI repo.

- Make DBus call to each of the exposed api to ensure that the funcation calls are working fine.

-To ensure bios handler call back is working.
Stop vpd-manager service.
Stop pldm service.
Start vpd-manager service
Start pldm service.
Should recieve callback.

-To ensure gpio call back
std::cout were added to callback function being trigerred on timer expiration and the same were verified in journal.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: I00640f64de487d5244e8be2e7a3f3d63a013644e