### PR TITLE
Backup VSYS FV system backplane keyword

### DIFF
--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -17,7 +17,7 @@ namespace vpd
 // The list of keywords for VSYS record is as per the S0 system. Should
 // be updated for another type of systems
 static const std::unordered_map<std::string, std::vector<std::string>>
-    svpdKwdMap{{"VSYS", {"BR", "TM", "SE", "SU", "RB", "WN", "RG"}},
+    svpdKwdMap{{"VSYS", {"BR", "TM", "SE", "SU", "RB", "WN", "RG", "FV"}},
                {"VCEN", {"FC", "SE"}},
                {"LXR0", {"LX"}},
                {"UTIL", {"D0"}}};

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -595,21 +595,16 @@ void VpdTool::printFixSystemVPDOption(UserOption option)
 
 int VpdTool::fixSystemVPD()
 {
+    std::string outline(191, '=');
     cout << "\nRestorable record-keyword pairs and their data on BMC & "
-            "System Backplane.\n ";
-
-    cout << "\n|==============================================================="
-            "=======================================|"
-         << endl;
+            "System Backplane.\n\n"
+         << outline << std::endl;
 
     cout << left << setw(6) << "S.No" << left << setw(8) << "Record" << left
-         << setw(9) << "Keyword" << left << setw(30) << "Data On BMC" << left
-         << setw(30) << "Data On System Backplane" << left << setw(14)
-         << "Data Mismatch";
-
-    cout << "\n|==============================================================="
-            "=======================================|"
-         << endl;
+         << setw(9) << "Keyword" << left << setw(75) << "Data On BMC" << left
+         << setw(75) << "Data On System Backplane" << left << setw(14)
+         << "Data Mismatch\n"
+         << outline << std::endl;
 
     int num = 0;
 
@@ -761,14 +756,13 @@ int VpdTool::fixSystemVPD()
             }
             recKwData.push_back(
                 make_tuple(++num, record, keyword, busStr, hwValStr, mismatch));
-            cout << left << setw(6) << num << left << setw(8) << record << left
-                 << setw(9) << keyword << left << setw(30) << setfill(' ')
-                 << busStr << left << setw(30) << setfill(' ') << hwValStr
-                 << left << setw(14) << mismatch;
 
-            cout << "\n|--------------------------------------------------"
-                    "----------------------------------------------------|"
-                 << endl;
+            std::string splitLine(191, '-');
+            cout << left << setw(6) << num << left << setw(8) << record << left
+                 << setw(9) << keyword << left << setw(75) << setfill(' ')
+                 << busStr << left << setw(75) << setfill(' ') << hwValStr
+                 << left << setw(14) << mismatch << '\n'
+                 << splitLine << endl;
         }
     }
     parseSVPDOptions(js);
@@ -786,9 +780,9 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
 
         int option = 0;
         cin >> option;
-        cout << "\n|==========================================================="
-                "===========================================|"
-             << endl;
+
+        std::string outline(191, '=');
+        cout << '\n' << outline << endl;
 
         if (json.find("frus") == json.end())
         {
@@ -861,28 +855,22 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
             {
                 do
                 {
-                    cout << "\n|==============================================="
-                            "=================================================="
-                            "=====|"
-                         << endl;
+                    cout << '\n' << outline << endl;
 
                     cout << left << setw(6) << "S.No" << left << setw(8)
                          << "Record" << left << setw(9) << "Keyword" << left
-                         << setw(30) << setfill(' ') << "Data On BMC" << left
-                         << setw(30) << setfill(' ')
+                         << setw(75) << setfill(' ') << "Data On BMC" << left
+                         << setw(75) << setfill(' ')
                          << "Data On System Backplane" << left << setw(14)
                          << "Data Mismatch" << endl;
 
                     cout << left << setw(6) << get<0>(data) << left << setw(8)
                          << get<1>(data) << left << setw(9) << get<2>(data)
-                         << left << setw(30) << setfill(' ') << get<3>(data)
-                         << left << setw(30) << setfill(' ') << get<4>(data)
+                         << left << setw(75) << setfill(' ') << get<3>(data)
+                         << left << setw(75) << setfill(' ') << get<4>(data)
                          << left << setw(14) << get<5>(data);
 
-                    cout << "\n|==============================================="
-                            "=================================================="
-                            "=====|"
-                         << endl;
+                    cout << '\n' << outline << endl;
 
                     if (get<5>(data) == "NO")
                     {
@@ -902,11 +890,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
                     }
 
                     cin >> option;
-
-                    cout << "\n|==============================================="
-                            "=================================================="
-                            "=====|"
-                         << endl;
+                    cout << '\n' << outline << endl;
 
                     EditorImpl edit(constants::systemVpdFilePath, json,
                                     get<1>(data), get<2>(data));
@@ -931,10 +915,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
                                 "System Backplane (Value should be in ASCII or "
                                 "in HEX(prefixed with 0x)) : ";
                         cin >> value;
-                        cout << "\n|==========================================="
-                                "=============================================="
-                                "=============|"
-                             << endl;
+                        cout << '\n' << outline << endl;
 
                         edit.updateKeyword(toBinary(value), 0, true);
                         cout << "\nData updated successfully.\n";


### PR DESCRIPTION
VSYS FV keyword tells about the minimum BMC version required.
It's a PE requirement to backup and restore VSYS FV keyword so that BMC downgrades can be blocked on newly shipped systems.