### PR TITLE
Skip logging PEL if unable to restore VSYS FV

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -927,6 +927,15 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                     else if (kwdValue.find_first_not_of(defaultValue) ==
                              string::npos)
                     {
+                        if (recordName == "VSYS" && keyword == "FV")
+                        {
+                            // Continue to the next keyword without logging +PEL
+                            // for VSYS FV(stores min version of BMC firmware).
+                            // Reason:There is a requirement to support blank FV
+                            // so that customer can use the system without
+                            // upgrading BMC to the minimum required version.
+                            continue;
+                        }
                         string errMsg = "VPD is blank on both cache and "
                                         "hardware for record: ";
                         errMsg += (*it).first;


### PR DESCRIPTION
During system backplane VPD restore, the critical
keywords will be checked for its default value in
both cache and hardware and a PEL will be logged if both cache and hardware has default value.

This needs to be skipped for the record-keyword pair VSYS:FV as there is a requirement to support customers to use older level without errors and also requires an error-free upgrade if required.

Test: Tested on rainier that no PELs are logged for VSYS FV when its blank on both cache and hardware.

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>
Change-Id: I1711fd1545dfff988a9908a13ca3119f8da5eae5