### PR TITLE
Enable CM for NVMe Drives

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -538,7 +538,16 @@ void Manager::collectFRUVPD(const sdbusplus::message::object_path path)
     const std::vector<nlohmann::json>& groupEEPROM =
         jsonFile["frus"][vpdFilePath].get_ref<const nlohmann::json::array_t&>();
 
-    const nlohmann::json& singleFru = groupEEPROM[0];
+    nlohmann::json singleFru{};
+    for (const auto& item : groupEEPROM)
+    {
+        if (item["inventoryPath"] == objPath)
+        {
+            // this is the inventory we are looking for
+            singleFru = item;
+            break;
+        }
+    }
 
     // check if the device qualifies for CM.
     if (singleFru.value("concurrentlyMaintainable", false))


### PR DESCRIPTION
Since NVMe backplane is not CMable whereas NVMe drives are CMable, code has been modified to loop through the list of FRUs under an EEPROM path instead of just checking the base FRU for CMable flag.

Test:
TRigger collectFRUVPD using busctl command for NVMe drive and check if the parser has been re-trigerred to collect its VPD.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>