### PR TITLE
vpd-tool mfgClean option

### DIFF
--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -13,14 +13,29 @@ namespace openpower
 namespace vpd
 {
 
-// Map to hold record, kwd pair which can be re-stored at standby.
-// The list of keywords for VSYS record is as per the S0 system. Should
-// be updated for another type of systems
-static const std::unordered_map<std::string, std::vector<std::string>>
-    svpdKwdMap{{"VSYS", {"BR", "TM", "SE", "SU", "RB", "WN", "RG", "FV"}},
-               {"VCEN", {"FC", "SE"}},
-               {"LXR0", {"LX"}},
-               {"UTIL", {"D0"}}};
+// Map which holds system vpd keywords which can be restored at standby and via
+// vpd-tool and also can be used to reset keywords to its defaults at
+// manufacturing. The list of keywords for VSYS record is as per the S0 system.
+// Should be updated for another type of systems For those keywords whose
+// default value is system specific, the default value field is left empty.
+// Record : {Keyword, Default value, Is PEL required on restore failure, Is MFG
+// reset required}
+static const inventory::SystemKeywordsMap svpdKwdMap{
+    {"VSYS",
+     {inventory::SystemKeywordInfo("BR", Binary(2, 0x20), true, true),
+      inventory::SystemKeywordInfo("TM", Binary(8, 0x20), true, true),
+      inventory::SystemKeywordInfo("SE", Binary(7, 0x20), true, true),
+      inventory::SystemKeywordInfo("SU", Binary(6, 0x20), true, true),
+      inventory::SystemKeywordInfo("RB", Binary(4, 0x20), true, true),
+      inventory::SystemKeywordInfo("WN", Binary(12, 0x20), true, true),
+      inventory::SystemKeywordInfo("RG", Binary(4, 0x20), true, true),
+      inventory::SystemKeywordInfo("FV", Binary(32, 0x20), false, true)}},
+    {"VCEN",
+     {inventory::SystemKeywordInfo("FC", Binary(), true, false),
+      inventory::SystemKeywordInfo("SE", Binary(7, 0x20), true, true)}},
+    {"LXR0", {inventory::SystemKeywordInfo("LX", Binary(), true, false)}},
+    {"UTIL",
+     {inventory::SystemKeywordInfo("D0", Binary(1, 0x00), true, true)}}};
 
 /** @brief Return the hex representation of the incoming byte
  *

--- a/types.hpp
+++ b/types.hpp
@@ -77,6 +77,8 @@ using SystemKeywordsMap =
 
 using GetAllResultType = std::vector<std::pair<Keyword, Value>>;
 using IntfPropMap = std::map<RecordName, GetAllResultType>;
+using RecKwValMap =
+    std::unordered_map<RecordName, std::unordered_map<Keyword, Binary>>;
 } // namespace inventory
 
 } // namespace vpd

--- a/types.hpp
+++ b/types.hpp
@@ -61,6 +61,19 @@ using MapperResponse =
 using RestoredEeproms = std::tuple<Path, std::string, Keyword, Binary>;
 using ReplaceableFrus = std::vector<VPDfilepath>;
 using EssentialFrus = std::vector<Path>;
+using RecordName = std::string;
+using KeywordDefault = Binary;
+using isPELReqOnRestoreFailure = bool;
+using isMFGResetRequired = bool;
+using SystemKeywordInfo =
+    std::tuple<Keyword, KeywordDefault, isPELReqOnRestoreFailure,
+               isMFGResetRequired>;
+
+/** Map of system backplane records to list of keywords and its related data. {
+ * Record : { Keyword, Default value, Is PEL required on restore failure, Is MFG
+ * reset required }} **/
+using SystemKeywordsMap =
+    std::unordered_map<RecordName, std::vector<SystemKeywordInfo>>;
 } // namespace inventory
 
 } // namespace vpd

--- a/types.hpp
+++ b/types.hpp
@@ -74,6 +74,9 @@ using SystemKeywordInfo =
  * reset required }} **/
 using SystemKeywordsMap =
     std::unordered_map<RecordName, std::vector<SystemKeywordInfo>>;
+
+using GetAllResultType = std::vector<std::pair<Keyword, Value>>;
+using IntfPropMap = std::map<RecordName, GetAllResultType>;
 } // namespace inventory
 
 } // namespace vpd

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -87,8 +87,10 @@ static void
         if (it != vpdMap.end())
         {
             const auto& kwdListForRecord = systemRecKwdPair.second;
-            for (const auto& keyword : kwdListForRecord)
+            for (const auto& keywordInfo : kwdListForRecord)
             {
+                const auto& keyword = get<0>(keywordInfo);
+
                 DbusPropertyMap& kwdValMap = it->second;
                 auto iterator = kwdValMap.find(keyword);
 

--- a/vpd_tool.cpp
+++ b/vpd_tool.cpp
@@ -84,6 +84,14 @@ int main(int argc, char** argv)
         "--fixSystemVPD", "Use this option to interactively fix critical "
                           "system VPD keywords {vpd-tool-exe --fixSystemVPD}");
 
+    auto mfgClean =
+        app.add_flag("--mfgClean", "Flag to clean and reset specific keywords "
+                                   "on system VPD to its default value.");
+
+    auto confirm =
+        app.add_flag("--yes", "Using this flag with --mfgClean option, assumes "
+                              "yes to proceed without confirmation.");
+
     CLI11_PARSE(app, argc, argv);
 
     ifstream inventoryJson(INVENTORY_JSON_SYM_LINK);
@@ -163,6 +171,24 @@ int main(int argc, char** argv)
         {
             VpdTool vpdToolObj;
             rc = vpdToolObj.fixSystemVPD();
+        }
+        else if (*mfgClean)
+        {
+            if (!*confirm)
+            {
+                std::string confirmation{};
+                std::cout << "\nThis option resets some of the system VPD "
+                             "keywords to their default values. Do you really "
+                             "wish to proceed further?[yes/no]: ";
+                std::cin >> confirmation;
+
+                if (confirmation != "yes")
+                {
+                    return 0;
+                }
+            }
+            VpdTool vpdToolObj;
+            rc = vpdToolObj.cleanSystemVPD();
         }
         else
         {

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -969,3 +969,69 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
 
     } while (true);
 }
+
+int VpdTool::cleanSystemVPD()
+{
+    try
+    {
+        // Get system VPD hardware data in map
+        unordered_map<string, DbusPropertyMap> vpdMap;
+        json js;
+        getVPDInMap(constants::systemVpdFilePath, vpdMap, js,
+                    constants::pimPath +
+                        static_cast<std::string>(constants::SYSTEM_OBJECT));
+
+        RecKwValMap kwdsToBeUpdated;
+
+        for (auto recordMap : svpdKwdMap)
+        {
+            const auto& record = recordMap.first;
+            std::unordered_map<std::string, Binary> kwDefault;
+            for (auto keywordMap : recordMap.second)
+            {
+                // Skip those keywords which cannot be reset at manufacturing
+                if (!std::get<3>(keywordMap))
+                {
+                    continue;
+                }
+                const auto& keyword = std::get<0>(keywordMap);
+
+                // Get hardware value for this keyword from vpdMap
+                Binary hardwareValue;
+
+                auto recItr = vpdMap.find(record);
+
+                if (recItr != vpdMap.end())
+                {
+                    DbusPropertyMap& kwValMap = recItr->second;
+                    auto kwItr = kwValMap.find(keyword);
+                    if (kwItr != kwValMap.end())
+                    {
+                        hardwareValue = toBinary(kwItr->second);
+                    }
+                }
+
+                // compare hardware value with the keyword's default value
+                auto defaultValue = std::get<1>(keywordMap);
+                if (hardwareValue != defaultValue)
+                {
+                    EditorImpl edit(constants::systemVpdFilePath, js, record,
+                                    keyword);
+                    edit.updateKeyword(defaultValue, 0, true);
+                }
+            }
+        }
+
+        std::cout
+            << "\n The critical keywords from system backplane VPD has been "
+               "reset successfully."
+            << std::endl;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what();
+        std::cerr
+            << "\nManufacturing reset on system vpd keywords is unsuccessful";
+    }
+    return 0;
+}

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -696,8 +696,10 @@ int VpdTool::fixSystemVPD()
         string busStr{}, hwValStr{};
         string mismatch = "NO"; // no mismatch
 
-        for (const auto& keyword : recordKw.second)
+        for (const auto& keywordInfo : recordKw.second)
         {
+            const auto& keyword = get<0>(keywordInfo);
+
             string hardwareValue{};
             auto recItr = vpdMap.find(record);
 

--- a/vpd_tool_impl.hpp
+++ b/vpd_tool_impl.hpp
@@ -166,6 +166,14 @@ class VpdTool
      */
     void printFixSystemVPDOption(UserOption option);
 
+    /**
+     * @brief Get System VPD data stored in cache
+     *
+     * @param[in] svpdBusData - Map of system VPD record data.
+     */
+    void getSystemDataFromCache(
+        openpower::vpd::inventory::IntfPropMap& svpdBusData);
+
   public:
     /**
      * @brief Dump the complete inventory in JSON format

--- a/vpd_tool_impl.hpp
+++ b/vpd_tool_impl.hpp
@@ -251,6 +251,13 @@ class VpdTool
     int fixSystemVPD();
 
     /**
+     * @brief Clean specific keywords in system backplane VPD
+     *
+     * @return return code (success/failure)
+     */
+    int cleanSystemVPD();
+
+    /**
      * @brief Constructor
      * Constructor is called during the
      * object instantiation for dumpInventory option and


### PR DESCRIPTION
This PR has 3 commits where all 3 commits are required for vpd-tool --mfgClean option to work.

**Commit e02154:** Enhancing system VPD map -> Intent is to modify the system VPD map to incorporate information about **mfg resettable keywords.**

**Commit f5c6ec:** Re-use some of vpd-tool apis in mfgClean option -> As vpd-tool --fixSystemVPD and vpd-tool --mfgClean options has **system VPD processing** in common, I created separate apis in vpd-tool to reuse in both options.

**Commit fc7ea3:** vpd-tool --**mfgClean implementation**
