### PR TITLE
Defect fix in restoring system VPD via vpd-manager

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -103,9 +103,13 @@ static void
                     const string& busValue = readBusProperty(
                         objectPath, ipzVpdInf + recordName, keyword);
 
-                    if (busValue.find_first_not_of(' ') != string::npos)
+                    const auto& defaultValue = get<1>(keywordInfo);
+
+                    if (Binary(busValue.begin(), busValue.end()) !=
+                        defaultValue)
                     {
-                        if (kwdValue.find_first_not_of(' ') == string::npos)
+                        if (Binary(kwdValue.begin(), kwdValue.end()) ==
+                            defaultValue)
                         {
                             // implies data is blank on EEPROM but not on cache.
                             // So EEPROM vpd update is required.


### PR DESCRIPTION
In vpd-manager restore api, the keyword defaults should be taken from the system vpd map. Instead it assumes blank value as default for all keywords.
This fails to restore UTIL D0 keyword as its default value is 0x00.

This commit fixes the issue.

Test:

=> vpd-tool -w -H -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R UTIL -K D0 -V 0x00

vpd-tool --fixSystemVPD

S.No  Record  Keyword  Data On BMC                                                                Data On System Backplane                                                   Data Mismatch

1     UTIL    D0       0x01                                                                       0x00                                                                       YES

busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard xyz.openbmc_project.Inventory.Item Present b false

systemctl restart system-vpd.service

vpd-tool --fixSystemVPD

S.No  Record  Keyword  Data On BMC                                                                Data On System Backplane                                                   Data Mismatch

1     UTIL    D0       0x01                                                                       0x01                                                                       NO


Change-Id: If6817829211e9b8a47652deab5d1ec7643855fb6