### PR TITLE
Enable backup&reset on system brand name keywords

### DIFF
--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -35,7 +35,9 @@ static const inventory::SystemKeywordsMap svpdKwdMap{
       inventory::SystemKeywordInfo("SE", Binary(7, 0x20), true, true)}},
     {"LXR0", {inventory::SystemKeywordInfo("LX", Binary(), true, false)}},
     {"UTIL",
-     {inventory::SystemKeywordInfo("D0", Binary(1, 0x00), true, true)}}};
+     {inventory::SystemKeywordInfo("D0", Binary(1, 0x00), true, true),
+      inventory::SystemKeywordInfo("F5", Binary(16, 0x00), false, true),
+      inventory::SystemKeywordInfo("F6", Binary(16, 0x00), false, true)}}};
 
 /** @brief Return the hex representation of the incoming byte
  *


### PR DESCRIPTION
The system backplane UTIL F5 and F6 are declared to hold system brand name. The keyword value takes 16 bytes each and by default it holds 0x00.

Added these keywords to the system vpd list to perform backup and restore and also to perform manufacturing reset at FAB test.


Change-Id: I8f8cda1732a9ac8521bdb339ee80492bed172056