### PR TITLE
Rewordings required in logging PEL

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -97,10 +97,9 @@ constexpr auto mapperDestination = "xyz.openbmc_project.ObjectMapper";
 constexpr auto loggerService = "xyz.openbmc_project.Logging";
 constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
 constexpr auto loggerCreateInterface = "xyz.openbmc_project.Logging.Create";
-constexpr auto errIntfForBlankSystemVPD = "com.ibm.VPD.Error.BlankSystemVPD";
+constexpr auto errIntfForVPDDefault = "com.ibm.VPD.Error.DefaultValue";
 constexpr auto errIntfForInvalidVPD = "com.ibm.VPD.Error.InvalidVPD";
-constexpr auto errIntfForSystemVPDMismatch =
-    "com.ibm.VPD.Error.SystemVPDMismatch";
+constexpr auto errIntfForVPDMismatch = "com.ibm.VPD.Error.Mismatch";
 constexpr auto errIntfForStreamFail = "com.ibm.VPD.Error.InavlidEepromPath";
 constexpr auto errIntfForEccCheckFail = "com.ibm.VPD.Error.EccCheckFailed";
 constexpr auto errIntfForJsonFailure = "com.ibm.VPD.Error.InvalidJson";
@@ -115,7 +114,6 @@ constexpr auto systemVpdFilePath = "/sys/bus/i2c/drivers/at24/8-0050/eeprom";
 constexpr auto i2cPathPrefix = "/sys/bus/i2c/drivers/at24/";
 constexpr auto spiPathPrefix = "/sys/bus/spi/drivers/at25/";
 constexpr auto invItemIntf = "xyz.openbmc_project.Inventory.Item";
-constexpr auto errIntfForSysVPDMismatch = "com.ibm.VPD.Error.SystemVPDMismatch";
 
 namespace lengths
 {

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -884,8 +884,8 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                             // both the data are present, check for mismatch
                             if (busValue != kwdValue)
                             {
-                                string errMsg = "VPD data mismatch on cache "
-                                                "and hardware for record: ";
+                                string errMsg = "Mismatch found between backup "
+                                                "and primary VPD for record: ";
                                 errMsg += (*it).first;
                                 errMsg += " and keyword: ";
                                 errMsg += keyword;
@@ -913,35 +913,36 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
                                                            objectPath);
 
                                 additionalData.emplace("DESCRIPTION", errMsg);
-                                additionalData.emplace("Value on Cache: ",
-                                                       busStream.str());
                                 additionalData.emplace(
-                                    "Value read from EEPROM: ",
+                                    "Value read from Backup: ",
+                                    busStream.str());
+                                additionalData.emplace(
+                                    "Value read from Primary: ",
                                     vpdStream.str());
 
                                 createPEL(additionalData, PelSeverity::WARNING,
-                                          errIntfForSysVPDMismatch, nullptr);
+                                          errIntfForVPDMismatch, nullptr);
                             }
                         }
 
-                        // If cache data is not default, then irrespective of
-                        // hardware data(default or other than cache), copy the
-                        // cache data to vpd map as we don't need to change the
-                        // cache data in either case in the process of
+                        // If backup data is not default, then irrespective of
+                        // primary data(default or other than backup), copy the
+                        // backup data to vpd map as we don't need to change the
+                        // backup data in either case in the process of
                         // restoring system vpd.
                         kwdValue = busValue;
                     }
                     else if (kwdDataInBinary == defaultValue &&
                              get<2>(keywordInfo)) // Check isPELRequired is true
                     {
-                        string errMsg = "VPD is blank on both cache and "
-                                        "hardware for record: ";
+                        string errMsg = "Found default value on both backup "
+                                        "and primary VPD for record: ";
                         errMsg += (*it).first;
                         errMsg += " and keyword: ";
                         errMsg += keyword;
-                        errMsg += ". SSR need to update hardware VPD.";
+                        errMsg += ". SSR need to update primary VPD.";
 
-                        // both the data are blanks, log PEL
+                        // mfg default on both backup and primary, log PEL
                         PelAdditionalData additionalData;
                         additionalData.emplace("CALLOUT_INVENTORY_PATH",
                                                INVENTORY_PATH + objectPath);
@@ -950,7 +951,7 @@ void restoreSystemVPD(Parsed& vpdMap, const string& objectPath)
 
                         // log PEL TODO: Block IPL
                         createPEL(additionalData, PelSeverity::ERROR,
-                                  errIntfForBlankSystemVPD, nullptr);
+                                  errIntfForVPDDefault, nullptr);
                         continue;
                     }
                 }

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -727,28 +727,28 @@ void VpdTool::printFixSystemVPDOption(UserOption option)
         case VpdTool::EXIT:
             cout << "\nEnter 0 => To exit successfully : ";
             break;
-        case VpdTool::BMC_DATA_FOR_ALL:
-            cout << "\n\nEnter 1 => If you choose the data on BMC for all "
+        case VpdTool::BACKUP_DATA_FOR_ALL:
+            cout << "\n\nEnter 1 => If you choose the data on backup for all "
                     "mismatching record-keyword pairs";
             break;
         case VpdTool::SYSTEM_BACKPLANE_DATA_FOR_ALL:
-            cout << "\nEnter 2 => If you choose the data on System "
-                    "Backplane for all mismatching record-keyword pairs";
+            cout << "\nEnter 2 => If you choose the data on primary for all "
+                    "mismatching record-keyword pairs";
             break;
         case VpdTool::MORE_OPTIONS:
             cout << "\nEnter 3 => If you wish to explore more options";
             break;
-        case VpdTool::BMC_DATA_FOR_CURRENT:
-            cout << "\nEnter 4 => If you choose the data on BMC as the "
+        case VpdTool::BACKUP_DATA_FOR_CURRENT:
+            cout << "\nEnter 4 => If you choose the data on backup as the "
                     "right value";
             break;
         case VpdTool::SYSTEM_BACKPLANE_DATA_FOR_CURRENT:
-            cout << "\nEnter 5 => If you choose the data on System "
-                    "Backplane as the right value";
+            cout << "\nEnter 5 => If you choose the data on primary as the "
+                    "right value";
             break;
         case VpdTool::NEW_VALUE_ON_BOTH:
-            cout << "\nEnter 6 => If you wish to enter a new value to "
-                    "update both on BMC and System Backplane";
+            cout << "\nEnter 6 => If you wish to enter a new value to update "
+                    "both on backup and primary";
             break;
         case VpdTool::SKIP_CURRENT:
             cout << "\nEnter 7 => If you wish to skip the above "
@@ -787,13 +787,13 @@ void VpdTool::getSystemDataFromCache(IntfPropMap& svpdBusData)
 int VpdTool::fixSystemVPD()
 {
     std::string outline(191, '=');
-    cout << "\nRestorable record-keyword pairs and their data on BMC & "
-            "System Backplane.\n\n"
+    cout << "\nRestorable record-keyword pairs and their data on backup & "
+            "primary.\n\n"
          << outline << std::endl;
 
     cout << left << setw(6) << "S.No" << left << setw(8) << "Record" << left
-         << setw(9) << "Keyword" << left << setw(75) << "Data On BMC" << left
-         << setw(75) << "Data On System Backplane" << left << setw(14)
+         << setw(9) << "Keyword" << left << setw(75) << "Data On Backup" << left
+         << setw(75) << "Data On Primary" << left << setw(14)
          << "Data Mismatch\n"
          << outline << std::endl;
 
@@ -907,7 +907,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
 {
     do
     {
-        printFixSystemVPDOption(VpdTool::BMC_DATA_FOR_ALL);
+        printFixSystemVPDOption(VpdTool::BACKUP_DATA_FOR_ALL);
         printFixSystemVPDOption(VpdTool::SYSTEM_BACKPLANE_DATA_FOR_ALL);
         printFixSystemVPDOption(VpdTool::MORE_OPTIONS);
         printFixSystemVPDOption(VpdTool::EXIT);
@@ -925,7 +925,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
 
         bool mismatchFound = false;
 
-        if (option == VpdTool::BMC_DATA_FOR_ALL)
+        if (option == VpdTool::BACKUP_DATA_FOR_ALL)
         {
             for (const auto& data : recKwData)
             {
@@ -942,7 +942,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
             {
                 cout << "\nData updated successfully for all mismatching "
                         "record-keyword pairs by choosing their corresponding "
-                        "data on BMC. Exit successfully.\n"
+                        "data from backup. Exit successfully.\n"
                      << endl;
             }
             else
@@ -970,7 +970,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
             {
                 cout << "\nData updated successfully for all mismatching "
                         "record-keyword pairs by choosing their corresponding "
-                        "data on System Backplane.\n"
+                        "data from primary VPD.\n"
                      << endl;
             }
             else
@@ -993,10 +993,9 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
 
                     cout << left << setw(6) << "S.No" << left << setw(8)
                          << "Record" << left << setw(9) << "Keyword" << left
-                         << setw(75) << setfill(' ') << "Data On BMC" << left
-                         << setw(75) << setfill(' ')
-                         << "Data On System Backplane" << left << setw(14)
-                         << "Data Mismatch" << endl;
+                         << setw(75) << setfill(' ') << "Backup Data" << left
+                         << setw(75) << setfill(' ') << "Primary Data" << left
+                         << setw(14) << "Data Mismatch" << endl;
 
                     cout << left << setw(6) << get<0>(data) << left << setw(8)
                          << get<1>(data) << left << setw(9) << get<2>(data)
@@ -1015,7 +1014,8 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
                     }
                     else
                     {
-                        printFixSystemVPDOption(VpdTool::BMC_DATA_FOR_CURRENT);
+                        printFixSystemVPDOption(
+                            VpdTool::BACKUP_DATA_FOR_CURRENT);
                         printFixSystemVPDOption(
                             VpdTool::SYSTEM_BACKPLANE_DATA_FOR_CURRENT);
                         printFixSystemVPDOption(VpdTool::NEW_VALUE_ON_BOTH);
@@ -1029,7 +1029,7 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
                     EditorImpl edit(constants::systemVpdFilePath, json,
                                     get<1>(data), get<2>(data));
 
-                    if (option == VpdTool::BMC_DATA_FOR_CURRENT)
+                    if (option == VpdTool::BACKUP_DATA_FOR_CURRENT)
                     {
                         edit.updateKeyword(toBinary(get<3>(data)), 0, true);
                         cout << "\nData updated successfully.\n";
@@ -1045,9 +1045,9 @@ void VpdTool::parseSVPDOptions(const nlohmann::json& json)
                     else if (option == VpdTool::NEW_VALUE_ON_BOTH)
                     {
                         string value;
-                        cout << "\nEnter the new value to update both on BMC & "
-                                "System Backplane (Value should be in ASCII or "
-                                "in HEX(prefixed with 0x)) : ";
+                        cout << "\nEnter the new value to update on both "
+                                "primary & backup. Value should be in ASCII or "
+                                "in HEX(prefixed with 0x) : ";
                         cin >> value;
                         cout << '\n' << outline << endl;
 

--- a/vpd_tool_impl.hpp
+++ b/vpd_tool_impl.hpp
@@ -151,10 +151,10 @@ class VpdTool
     enum UserOption
     {
         EXIT = 0,
-        BMC_DATA_FOR_ALL = 1,
+        BACKUP_DATA_FOR_ALL = 1,
         SYSTEM_BACKPLANE_DATA_FOR_ALL = 2,
         MORE_OPTIONS = 3,
-        BMC_DATA_FOR_CURRENT = 4,
+        BACKUP_DATA_FOR_CURRENT = 4,
         SYSTEM_BACKPLANE_DATA_FOR_CURRENT = 5,
         NEW_VALUE_ON_BOTH = 6,
         SKIP_CURRENT = 7


### PR DESCRIPTION
This commit rewords some of the comments and variables in restore VPD PEL code and in vpd-tool restore function.

Eg:
>>Cache value -> Backup value
    [As backup need not be in cache only]
>>Blank data -> Default data
    [As default data need not be blank only]
>>Hardware data -> Primary data
The VPD backup values and backup memory are machine specific.

Thus providing generic terms makes the code statements/comments more reliable w.r.t any machine.


Change-Id: I34fcd44e94b928db0fc30cda94eb8f03e6e87987