### PR TITLE
Correction of VPD using ECC

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -48,7 +48,9 @@ int main(int argc, char** argv)
                    std::istreambuf_iterator<char>());
 
         // Parse VPD
-        IpzVpdParser ipzParser(std::move(vpd), std::string{});
+        uint32_t vpdStartOffset = 0;
+        IpzVpdParser ipzParser(std::move(vpd), std::string{}, file,
+                               vpdStartOffset);
         auto vpdStore = std::move(std::get<Store>(ipzParser.parse()));
 
         if (doDump)

--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1474,9 +1474,18 @@ int main(int argc, char** argv)
 
         try
         {
+            uint32_t vpdStartOffset = 0;
+            for (const auto& item : js["frus"][file])
+            {
+                if (item.find("offset") != item.end())
+                {
+                    vpdStartOffset = item["offset"];
+                }
+            }
             vpdVector = getVpdDataInVector(js, file);
             ParserInterface* parser = ParserFactory::getParser(
-                vpdVector, (pimPath + baseFruInventoryPath));
+                vpdVector, (pimPath + baseFruInventoryPath), file,
+                vpdStartOffset);
             variant<KeywordVpdMap, Store> parseResult;
             parseResult = parser->parse();
 

--- a/impl.cpp
+++ b/impl.cpp
@@ -74,7 +74,7 @@ RecordOffset Impl::getVtocOffset() const
 }
 
 #ifdef IPZ_PARSER
-int Impl::vhdrEccCheck() const
+int Impl::vhdrEccCheck()
 {
     int rc = eccStatus::SUCCESS;
     auto vpdPtr = vpd.cbegin();
@@ -84,8 +84,32 @@ int Impl::vhdrEccCheck() const
                           lengths::VHDR_RECORD_LENGTH,
                           const_cast<uint8_t*>(&vpdPtr[offsets::VHDR_ECC]),
                           lengths::VHDR_ECC_LENGTH);
-
-    if (l_status != VPD_ECC_OK)
+    if (l_status == VPD_ECC_CORRECTABLE_DATA)
+    {
+        try
+        {
+            if (vpdFileStream.is_open())
+            {
+                vpdFileStream.seekp(vpdStartOffset + offsets::VHDR_RECORD,
+                                    std::ios::beg);
+                vpdFileStream.write(
+                    reinterpret_cast<const char*>(&vpd[offsets::VHDR_RECORD]),
+                    lengths::VHDR_RECORD_LENGTH);
+            }
+            else
+            {
+                std::cerr << "File not open";
+                rc = eccStatus::FAILED;
+            }
+        }
+        catch (const std::fstream::failure& e)
+        {
+            std::cout << "Error while operating on file with exception:"
+                      << e.what();
+            rc = eccStatus::FAILED;
+        }
+    }
+    else if (l_status != VPD_ECC_OK)
     {
         rc = eccStatus::FAILED;
     }
@@ -93,7 +117,7 @@ int Impl::vhdrEccCheck() const
     return rc;
 }
 
-int Impl::vtocEccCheck() const
+int Impl::vtocEccCheck()
 {
     int rc = eccStatus::SUCCESS;
     // Use another pointer to get ECC information from VHDR,
@@ -122,8 +146,31 @@ int Impl::vtocEccCheck() const
     auto l_status = vpdecc_check_data(
         const_cast<uint8_t*>(&vpdPtr[vtocOffset]), vtocLength,
         const_cast<uint8_t*>(&vpdPtr[vtocECCOffset]), vtocECCLength);
-
-    if (l_status != VPD_ECC_OK)
+    if (l_status == VPD_ECC_CORRECTABLE_DATA)
+    {
+        try
+        {
+            if (vpdFileStream.is_open())
+            {
+                vpdFileStream.seekp(vpdStartOffset + vtocOffset, std::ios::beg);
+                vpdFileStream.write(
+                    reinterpret_cast<const char*>(&vpdPtr[vtocOffset]),
+                    vtocLength);
+            }
+            else
+            {
+                std::cerr << "File not open";
+                rc = eccStatus::FAILED;
+            }
+        }
+        catch (const std::fstream::failure& e)
+        {
+            std::cout << "Error while operating on file with exception "
+                      << e.what();
+            rc = eccStatus::FAILED;
+        }
+    }
+    else if (l_status != VPD_ECC_OK)
     {
         rc = eccStatus::FAILED;
     }
@@ -131,7 +178,7 @@ int Impl::vtocEccCheck() const
     return rc;
 }
 
-int Impl::recordEccCheck(Binary::const_iterator iterator) const
+int Impl::recordEccCheck(Binary::const_iterator iterator)
 {
     int rc = eccStatus::SUCCESS;
 
@@ -163,7 +210,32 @@ int Impl::recordEccCheck(Binary::const_iterator iterator) const
     auto l_status = vpdecc_check_data(
         const_cast<uint8_t*>(&vpdPtr[recordOffset]), recordLength,
         const_cast<uint8_t*>(&vpdPtr[eccOffset]), eccLength);
-    if (l_status != VPD_ECC_OK)
+    if (l_status == VPD_ECC_CORRECTABLE_DATA)
+    {
+        try
+        {
+            if (vpdFileStream.is_open())
+            {
+                vpdFileStream.seekp(vpdStartOffset + recordOffset,
+                                    std::ios::beg);
+                vpdFileStream.write(
+                    reinterpret_cast<const char*>(&vpdPtr[recordOffset]),
+                    recordLength);
+            }
+            else
+            {
+                std::cerr << "File not open";
+                rc = eccStatus::FAILED;
+            }
+        }
+        catch (const std::fstream::failure& e)
+        {
+            std::cout << "Error while operating on file with exception "
+                      << e.what();
+            rc = eccStatus::FAILED;
+        }
+    }
+    else if (l_status != VPD_ECC_OK)
     {
         rc = eccStatus::FAILED;
     }
@@ -172,7 +244,7 @@ int Impl::recordEccCheck(Binary::const_iterator iterator) const
 }
 #endif
 
-void Impl::checkHeader() const
+void Impl::checkHeader()
 {
     if (vpd.empty() || (lengths::RECORD_MIN > vpd.size()))
     {
@@ -201,7 +273,7 @@ void Impl::checkHeader() const
     }
 }
 
-std::size_t Impl::readTOC(Binary::const_iterator& iterator) const
+std::size_t Impl::readTOC(Binary::const_iterator& iterator)
 {
     // The offset to VTOC could be 1 or 2 bytes long
     RecordOffset vtocOffset = getVtocOffset();
@@ -244,7 +316,7 @@ std::size_t Impl::readTOC(Binary::const_iterator& iterator) const
 }
 
 internal::OffsetList Impl::readPT(Binary::const_iterator iterator,
-                                  std::size_t ptLength) const
+                                  std::size_t ptLength)
 {
     internal::OffsetList offsets{};
 

--- a/impl.hpp
+++ b/impl.hpp
@@ -4,6 +4,7 @@
 #include "store.hpp"
 
 #include <cstddef>
+#include <fstream>
 
 namespace openpower
 {
@@ -68,10 +69,24 @@ class Impl
      *
      *  @param[in] vpdBuffer - Binary VPD
      *  @param[in] path - To call out FRU in case of any PEL.
+     *  @param[in] vpdFilePath - VPD File Path
+     *  @param[in] vpdStartOffset - Start offset of VPD.
      */
-    Impl(const Binary& vpdBuffer, const std::string& path) :
-        vpd(vpdBuffer), inventoryPath(path), out{}
+    Impl(const Binary& vpdBuffer, const std::string& path,
+         const std::string& vpdFilePath, uint32_t vpdStartOffset) :
+        vpd(vpdBuffer),
+        inventoryPath(path), vpdFilePath(vpdFilePath),
+        vpdStartOffset(vpdStartOffset), out{}
     {
+        try
+        {
+            vpdFileStream.open(vpdFilePath,
+                               std::ios::in | std::ios::out | std::ios::binary);
+        }
+        catch (const std::fstream::failure& e)
+        {
+            std::cout << e.what();
+        }
     }
 
     /** @brief Run the parser on binary VPD
@@ -99,7 +114,7 @@ class Impl
      *  @param[in] iterator - iterator to buffer containing VPD
      *  @returns Size of the PT keyword in VTOC
      */
-    std::size_t readTOC(Binary::const_iterator& iterator) const;
+    std::size_t readTOC(Binary::const_iterator& iterator);
 
     /** @brief Read the PT keyword contained in the VHDR record,
      *         to obtain offsets to other records in the VPD.
@@ -110,7 +125,7 @@ class Impl
      *  @returns List of offsets to records in VPD
      */
     internal::OffsetList readPT(Binary::const_iterator iterator,
-                                std::size_t ptLen) const;
+                                std::size_t ptLen);
 
     /** @brief Read VPD information contained within a record
      *
@@ -143,24 +158,24 @@ class Impl
     internal::KeywordMap readKeywords(Binary::const_iterator iterator);
 
     /** @brief Checks if the VHDR record is present in the VPD */
-    void checkHeader() const;
+    void checkHeader();
 
     /** @brief Checks the ECC for VHDR Record.
      *  @returns Success(0) OR corrupted data(-1)
      */
-    int vhdrEccCheck() const;
+    int vhdrEccCheck();
 
     /** @brief Checks the ECC for VTOC Record.
      *  @returns Success(0) OR corrupted data(-1)
      */
-    int vtocEccCheck() const;
+    int vtocEccCheck();
 
     /** @brief Checks the ECC for the given record.
      *
      * @param[in] iterator - iterator pointing to a record in the VPD
      * @returns Success(0) OR corrupted data(-1)
      */
-    int recordEccCheck(Binary::const_iterator iterator) const;
+    int recordEccCheck(Binary::const_iterator iterator);
 
     /** @brief This interface collects Offset of VTOC
      *  @returns VTOC Offset
@@ -172,6 +187,15 @@ class Impl
 
     /** Inventory path to call out FRU if required */
     const std::string inventoryPath;
+
+    /** Eeprom hardware path */
+    inventory::Path vpdFilePath;
+
+    /** VPD Offset **/
+    uint32_t vpdStartOffset;
+
+    /** File stream for VPD */
+    std::fstream vpdFileStream;
 
     /** @brief parser output */
     Parsed out;

--- a/test/ipz_parser/parser.cpp
+++ b/test/ipz_parser/parser.cpp
@@ -1,6 +1,7 @@
 #include "ipz_parser.hpp"
 
 #include <cassert>
+#include <const.hpp>
 #include <defines.hpp>
 #include <fstream>
 #include <impl.hpp>
@@ -10,6 +11,9 @@
 #include <gtest/gtest.h>
 
 using namespace openpower::vpd;
+using namespace openpower::vpd::constants;
+
+constexpr uint32_t vpdOffset = 0;
 
 TEST(IpzVpdParserApp, vpdGoodPath)
 {
@@ -37,7 +41,7 @@ TEST(IpzVpdParserApp, vpdGoodPath)
         0x00, 0x52, 0x54, 0x04};
 
     // call app for this vpd
-    parser::Impl p(std::move(vpd), std::string{});
+    parser::Impl p(std::move(vpd), std::string{}, systemVpdFilePath, vpdOffset);
     Store vpdStore = p.run();
 
     static const std::string record = "VINI";
@@ -65,7 +69,7 @@ TEST(IpzVpdParserApp, vpdBadPathEmptyVPD)
     Binary vpd = {};
 
     // VPD is empty
-    parser::Impl p(std::move(vpd), std::string{});
+    parser::Impl p(std::move(vpd), std::string{}, systemVpdFilePath, vpdOffset);
 
     // Expecting a throw here
     EXPECT_THROW(p.run(), std::runtime_error);
@@ -98,7 +102,7 @@ TEST(IpzVpdParserApp, vpdBadPathMissingHeader)
     // corrupt the VHDR
     vpd[17] = 0x00;
 
-    parser::Impl p(std::move(vpd), std::string{});
+    parser::Impl p(std::move(vpd), std::string{}, systemVpdFilePath, vpdOffset);
 
     // Expecting a throw here
     EXPECT_THROW(p.run(), std::runtime_error);
@@ -131,7 +135,7 @@ TEST(IpzVpdParserApp, vpdBadPathMissingVTOC)
     // corrupt the VTOC
     vpd[61] = 0x00;
 
-    parser::Impl p(std::move(vpd), std::string{});
+    parser::Impl p(std::move(vpd), std::string{}, systemVpdFilePath, vpdOffset);
 
     // Expecting a throw here
     EXPECT_THROW(p.run(), std::runtime_error);

--- a/vpd-manager/editor_impl.hpp
+++ b/vpd-manager/editor_impl.hpp
@@ -171,6 +171,9 @@ class EditorImpl
     void makeDbusCall(const std::string& object, const std::string& interface,
                       const std::string& property, const std::variant<T>& data);
 
+    /** @brief Method to check the record's Data using ECC */
+    void checkRecordData();
+
     // path to the VPD file to edit
     inventory::Path vpdFilePath;
 
@@ -179,6 +182,9 @@ class EditorImpl
 
     // stream to perform operation on file
     std::fstream vpdFileStream;
+
+    // stream to operate on VPD data
+    std::fstream vpdDataFileStream;
 
     // offset to get vpd data from EEPROM
     uint32_t startOffset;

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -168,11 +168,13 @@ void Manager::restoreSystemVpd()
     try
     {
         auto vpdVector = getVpdDataInVector(jsonFile, systemVpdFilePath);
+        uint32_t vpdStartOffset = 0;
         const auto& inventoryPath =
             jsonFile["frus"][systemVpdFilePath][0]["inventoryPath"]
                 .get_ref<const nlohmann::json::string_t&>();
 
-        parser = ParserFactory::getParser(vpdVector, (pimPath + inventoryPath));
+        parser = ParserFactory::getParser(vpdVector, (pimPath + inventoryPath),
+                                          systemVpdFilePath, vpdStartOffset);
         auto parseResult = parser->parse();
 
         if (auto pVal = std::get_if<Store>(&parseResult))

--- a/vpd-parser/ipz_parser.cpp
+++ b/vpd-parser/ipz_parser.cpp
@@ -15,14 +15,14 @@ using namespace openpower::vpd::constants;
 
 std::variant<kwdVpdMap, Store> IpzVpdParser::parse()
 {
-    Impl p(vpd, inventoryPath);
+    Impl p(vpd, inventoryPath, vpdFilePath, vpdStartOffset);
     Store s = p.run();
     return s;
 }
 
 void IpzVpdParser::processHeader()
 {
-    Impl p(vpd, inventoryPath);
+    Impl p(vpd, inventoryPath, vpdFilePath, vpdStartOffset);
     p.checkVPDHeader();
 }
 

--- a/vpd-parser/ipz_parser.hpp
+++ b/vpd-parser/ipz_parser.hpp
@@ -31,9 +31,16 @@ class IpzVpdParser : public ParserInterface
 
     /**
      * @brief Constructor
+     * @param[in] - VpdVector - vpd buffer
+     * @param[in] - path - Inventory Path
+     * @param[in] - vpdFilePath - VPD H/w path
+     * @param[in] - vpdStartOffset - VPD starting offset
      */
-    IpzVpdParser(const Binary& VpdVector, const std::string& path) :
-        vpd(VpdVector), inventoryPath(path)
+    IpzVpdParser(const Binary& VpdVector, const std::string& path,
+                 const std::string& vpdFilePath, uint32_t vpdStartOffset) :
+        vpd(VpdVector),
+        inventoryPath(path), vpdFilePath(vpdFilePath),
+        vpdStartOffset(vpdStartOffset)
     {
     }
 
@@ -63,6 +70,13 @@ class IpzVpdParser : public ParserInterface
 
     /*Inventory path of the FRU */
     const std::string inventoryPath;
+
+    /* VPD Path */
+    const std::string vpdFilePath;
+
+    /* Offset */
+    uint32_t vpdStartOffset;
+
 }; // class IpzVpdParser
 
 } // namespace parser

--- a/vpd-parser/parser_factory.cpp
+++ b/vpd-parser/parser_factory.cpp
@@ -24,9 +24,9 @@ namespace parser
 {
 namespace factory
 {
-interface::ParserInterface*
-    ParserFactory::getParser(const Binary& vpdVector,
-                             const std::string& inventoryPath)
+interface::ParserInterface* ParserFactory::getParser(
+    const Binary& vpdVector, const std::string& inventoryPath,
+    const std::string& vpdFilePath, uint32_t vpdStartOffset)
 {
     vpdType type = vpdTypeCheck(vpdVector);
 
@@ -34,7 +34,8 @@ interface::ParserInterface*
     {
         case IPZ_VPD:
         {
-            return new IpzVpdParser(vpdVector, inventoryPath);
+            return new IpzVpdParser(vpdVector, inventoryPath, vpdFilePath,
+                                    vpdStartOffset);
         }
 
         case KEYWORD_VPD:

--- a/vpd-parser/parser_factory.hpp
+++ b/vpd-parser/parser_factory.hpp
@@ -31,10 +31,13 @@ class ParserFactory
      * @brief A method to get object of concrete parser class.
      * @param[in] - vpd file to check for the type.
      * @param[in] - InventoryPath to call out FRU in case PEL is logged.
+     * @param[in] - vpdFilePath for VPD HW path.
+     * @param[in] - vpdStartOffset for starting offset of VPD.
      * @return - Pointer to concrete parser class object.
      */
     static interface::ParserInterface*
-        getParser(const Binary& vpdVector, const std::string& inventoryPath);
+        getParser(const Binary& vpdVector, const std::string& inventoryPath,
+                  const std::string& vpdFilePath, uint32_t vpdStartOffset);
 
     /**
      * @brief A method to delete the parser object.

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -121,8 +121,10 @@ static void
 
     Binary vpdVector{};
 
+    uint32_t vpdStartOffset = 0;
     vpdVector = getVpdDataInVector(js, constants::systemVpdFilePath);
-    ParserInterface* parser = ParserFactory::getParser(vpdVector, invPath);
+    ParserInterface* parser = ParserFactory::getParser(
+        vpdVector, invPath, constants::systemVpdFilePath, vpdStartOffset);
     auto parseResult = parser->parse();
     ParserFactory::freeParser(parser);
 
@@ -687,7 +689,17 @@ void VpdTool::readKwFromHw(const uint32_t& startOffset)
     const std::string& inventoryPath =
         jsonFile["frus"][fruPath][0]["inventoryPath"];
 
-    Impl obj(completeVPDFile, (constants::pimPath + inventoryPath));
+    uint32_t vpdStartOffset = 0;
+    for (const auto& item : jsonFile["frus"][fruPath])
+    {
+        if (item.find("offset") != item.end())
+        {
+            vpdStartOffset = item["offset"];
+        }
+    }
+
+    Impl obj(completeVPDFile, (constants::pimPath + inventoryPath), fruPath,
+             vpdStartOffset);
     std::string keywordVal = obj.readKwFromHw(recordName, keyword);
 
     if ((keyword[0] == '#') && (!keywordVal.empty()))


### PR DESCRIPTION
ECC algorithm corrects VPD data in 32:1 bit ratio in the event of corruption.
Main Test Cases:
1) Check correction of KW in records.
2) Check correction while writing and reading VPD. 3) Check for Module VPD correction.


Change-Id: I48a3db18df9d3a2aecde814610ab1b357e6f310d