### PR TITLE
vpd-tool:Remove adding parent's presence for child FRUs

### DIFF
--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -301,28 +301,25 @@ json VpdTool::interfaceDecider(json& itemEEPROM)
     return subOutput;
 }
 
-json VpdTool::getPresentPropJson(const std::string& invPath,
-                                 std::string& parentPresence)
+json VpdTool::getPresentPropJson(const std::string& invPath)
 {
     std::variant<bool> response;
-    makeDBusCall(invPath, "xyz.openbmc_project.Inventory.Item", "Present")
-        .read(response);
+    std::string presence = "Unknown";
 
-    std::string presence{};
-
-    if (auto pVal = get_if<bool>(&response))
+    try
     {
-        presence = *pVal ? "true" : "false";
-        if (parentPresence.empty())
+        makeDBusCall(invPath, "xyz.openbmc_project.Inventory.Item", "Present")
+            .read(response);
+
+        if (auto pVal = get_if<bool>(&response))
         {
-            parentPresence = presence;
+            presence = *pVal ? "true" : "false";
         }
     }
-    else
+    catch (const sdbusplus::exception::SdBusError& e)
     {
-        presence = parentPresence;
+        // not required to handle the exception. Present will be set to Unknown
     }
-
     json js;
     js.emplace("Present", presence);
     return js;
@@ -341,7 +338,6 @@ json VpdTool::parseInvJson(const json& jsObject, char flag, string fruPath)
     {
         for (const auto& itemFRUS : jsObject["frus"].items())
         {
-            string parentPresence{};
             for (auto itemEEPROM : itemFRUS.value())
             {
                 json subOutput = json::object({});
@@ -359,20 +355,11 @@ json VpdTool::parseInvJson(const json& jsObject, char flag, string fruPath)
                             validObject = true;
                             subOutput = interfaceDecider(itemEEPROM);
                             json presentJs = getPresentPropJson(
-                                "/xyz/openbmc_project/inventory" + fruPath,
-                                parentPresence);
+                                "/xyz/openbmc_project/inventory" + fruPath);
                             subOutput.insert(presentJs.begin(),
                                              presentJs.end());
                             output.emplace(fruPath, subOutput);
                             return output;
-                        }
-                        else // this else is to keep track of parent present
-                             // property.
-                        {
-                            json presentJs = getPresentPropJson(
-                                "/xyz/openbmc_project/inventory" +
-                                    string(itemEEPROM.at("inventoryPath")),
-                                parentPresence);
                         }
                     }
                     else
@@ -380,33 +367,10 @@ json VpdTool::parseInvJson(const json& jsObject, char flag, string fruPath)
                         subOutput = interfaceDecider(itemEEPROM);
                         json presentJs = getPresentPropJson(
                             "/xyz/openbmc_project/inventory" +
-                                string(itemEEPROM.at("inventoryPath")),
-                            parentPresence);
+                            string(itemEEPROM.at("inventoryPath")));
                         subOutput.insert(presentJs.begin(), presentJs.end());
                         output.emplace(string(itemEEPROM.at("inventoryPath")),
                                        subOutput);
-                    }
-                }
-                catch (const sdbusplus::exception::SdBusError& e)
-                {
-                    // if any of frupath doesn't have Present property of its
-                    // own, emplace its parent's present property value.
-                    if (e.name() == std::string("org.freedesktop.DBus.Error."
-                                                "UnknownProperty") &&
-                        (((flag == 'O') && validObject) || flag == 'I'))
-                    {
-                        json presentJs;
-                        presentJs.emplace("Present", parentPresence);
-                        subOutput.insert(presentJs.begin(), presentJs.end());
-                        output.emplace(string(itemEEPROM.at("inventoryPath")),
-                                       subOutput);
-                    }
-
-                    // for the user given child frupath which doesn't have
-                    // Present prop (vpd-tool -o).
-                    if ((flag == 'O') && validObject)
-                    {
-                        return output;
                     }
                 }
                 catch (const exception& e)

--- a/vpd_tool_impl.hpp
+++ b/vpd_tool_impl.hpp
@@ -132,11 +132,9 @@ class VpdTool
     /**
      * @brief Get the json which has Present property value of the given fru.
      * @param[in] invPath - inventory path of the fru.
-     * @param[out] parentPresence - Update the parent fru's present property.
      * @return output json which has the Present property value.
      */
-    json getPresentPropJson(const std::string& invPath,
-                            std::string& parentPresence);
+    json getPresentPropJson(const std::string& invPath);
 
     /**
      * @brief Parse through the options to fix system VPD


### PR DESCRIPTION
In the existing code, vpd-tool emplaces the parent FRU's presence for child FRU whose "Present" property is not available on d-bus. This gives a misleading information on presence state of non embedded FRU's, which can either be present or absent on a machine.

Fix:
This commit modifies the vpd-tool code to print "Unknown" if the FRU's Present property is not available on d-bus.

Test:
1. When Present property is not published on d-bus vpd-tool -o -O /system/chassis/motherboard/powersupply0 [
    {
        "/system/chassis/motherboard/powersupply0": {
            "LocationCode": "U78DA.ND0.WZS0065-E0",
            "Present": "Unknown",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.PowerSupply"
        }
    }
]

2. When Present property is set to true on dbus :~# vpd-tool -o -O /system/chassis/motherboard/powersupply0 [
    {
        "/system/chassis/motherboard/powersupply0": {
            "CC": "51DA",
            "DR": "IBM PS",
            "FN": "03FP221",
            "LocationCode": "U780C.ND0.RCH0014-E0",
            "PN": "03FP207",
            "Present": "true",
            "SN": "YL31KY12K0CX",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.PowerSupply"
        }
    }
]

3. When Present property is set to false on dbus :~# vpd-tool -o -O /system/chassis/motherboard/powersupply0 [
    {
        "/system/chassis/motherboard/powersupply0": {
            "CC": "51DA",
            "DR": "IBM PS",
            "FN": "03FP221",
            "LocationCode": "U780C.ND0.RCH0014-E0",
            "PN": "03FP207",
            "Present": "false",
            "SN": "YL31KY12K0CX",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.PowerSupply"
        }
    }
]


Change-Id: I4c8ce2141b9ae7c46f1421c59de5d627b8aad429