### PR TITLE
vpd-tool: Bug fix for displaying non printable value

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -681,15 +681,15 @@ std::string hexString(const std::variant<Binary, std::string>& kw)
     std::string hexString;
     std::visit(
         [&hexString](auto&& kw) {
+            std::stringstream ss;
+            std::string hexRep = "0x";
+            ss << hexRep;
             for (auto& kwVal : kw)
             {
-                std::stringstream ss;
-                std::string hexRep = "0x";
-                ss << hexRep;
                 ss << std::setfill('0') << std::setw(2) << std::hex
                    << static_cast<int>(kwVal);
-                hexString = ss.str();
             }
+            hexString = ss.str();
         },
         kw);
     return hexString;


### PR DESCRIPTION
Hexa decimal string getting truncated to a byte,
This fix addresses the issue.
Test:
/tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VCFG -K Z1 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "Z1": "0x0894ef83188c"
    }
}
/tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VCFG -K Z0 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "Z0": "0x0894ef83188b"
    }
}
/tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VCFG -K HW The given keyword HW or record VCFG or both are not present in the given FRU path /sys/bus/i2c/drivers/at24/8-0050/eeprom
 /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K HW
{
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "HW": "0x8001"
    }
}
~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B3 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B3": ""
    }
}
:~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B4 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B4": ""
    }
}
~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B7 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B7": ""
    }
}
~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R PSPD -K "#D" {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
    "#D": "0x00100c0c000 .... 000000000000000000" }
}
10240 Bytes printed.

~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K SN {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "SN": "YF30UF31C007"
    }
}
~# /tmp/vpd-tool_combin -r -O /system/chassis/motherboard -R VINI -K SN {
    "/system/chassis/motherboard": {
        "SN": "YF30UF31C007"
    }
}
~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K FN {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "FN": "F230306"
    }
}
~# /tmp/vpd-tool_combin -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K PN {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "PN": "03KP340"
    }
}
~# /tmp/vpd-tool_combin -r -O /system/chassis/motherboard -R VINI -K FN {
    "/system/chassis/motherboard": {
        "FN": "F230306"
    }
}
~# /tmp/vpd-tool_combin -r -O /system/chassis/motherboard -R VINI -K PN {
    "/system/chassis/motherboard": {
        "PN": "03KP340"
    }
}
~# /tmp/vpd-tool_combin -r -O /system/chassis/motherboard -R VINI -K B3 {
    "/system/chassis/motherboard": {
        "B3": ""
    }
}
~# /tmp/vpd-tool_combin -r -O /system/chassis/motherboard -R VINI -K B4 {
    "/system/chassis/motherboard": {
        "B4": ""
    }
}
~# /tmp/vpd-tool_combin -r -O /system/chassis/motherboard -R VINI -K B7 {
    "/system/chassis/motherboard": {
        "B7": ""
    }
}

HexDump results for comparison:

00000820  47 56 5a 02 30 31 5a 30  06 08 94 ef 83 18 8b 5a  |GVZ.01Z0.......Z| 00000830  31 06 08 94 ef 83 18 8c  50 46 0b 00 00 00 00 00  |1.......PF...... 00000160  45 04 30 30 30 31 43 54  04 40 18 00 0e 48 57 02  |E.0001CT.@...HW.| 00000170  80 01 42 33 06 00 00 00  00 00 00 42 34 01 00 42  |..B3.......B4..B| 00000180  37 0c 00 00 00 00 00 00  00 00 00 00 00 00 50 46  |7.............PF| 000008a0  30 32 56 4d 04 00 00 00  00 23 44 00 28 00 10 0c  |02VM.....#D.(...| 000008b0  0c 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| 000008c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| *
00000920  00 00 00 00 00 00 00 00  00 00 00 b9 cc 00 00 00  |................| 00000930  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| *
00000970  00 00 00 80 29 b0 00 15  60 04 50 00 00 df 03 ff  |....)...`.P.....| 00000980  f3 0f 00 00 01 00 00 00  00 03 00 00 00 00 00 00  |................| 00000990  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| *
000009b0  00 00 00 00 00 00 00 00  00 00 00 00 00 81 00 00  |................|


Change-Id: If380ca3483fb4fc88ca1dd159b2fa75703c8fe1c