### PR TITLE
vpd-tool: Fixing of display of KW values having 0x00s

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -678,15 +678,7 @@ string getPrintableValue(const Binary& vec)
 
     if (it != vec.end()) // if the given vector has any non printable value
     {
-        for (auto itr = it; itr != vec.end(); itr++)
-        {
-            if (*itr != 0x00)
-            {
-                str = byteArrayToHexString(vec);
-                return str;
-            }
-        }
-        str = string(vec.begin(), it);
+        str = byteArrayToHexString(vec);
     }
     else
     {


### PR DESCRIPTION
Keywords with values "0x00..." are being displayed now in Hex. ~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B4 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B4": "0x00"
    }
}
~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B3 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B3": "0x000000000000"
    }
}
~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B7 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B7": "0x000000000000000000000000"
    }
}
HexDump results for comparison:


Change-Id: I242caab54cb3c28d74819e614b99df79f881ba5a