### PR TITLE
vpd-tool: Fixing of display of KW values having 0x00s

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -683,15 +683,7 @@ std::string getPrintableValue(const Binary& vec)
 
     if (it != vec.end()) // if the given vector has any non printable value
     {
-        for (auto itr = it; itr != vec.end(); itr++)
-        {
-            if (*itr != 0x00)
-            {
-                str = byteArrayToHexString(vec);
-                return str;
-            }
-        }
-        str = std::string(vec.begin(), it);
+        str = byteArrayToHexString(vec);
     }
     else
     {


### PR DESCRIPTION
Keywords with values "0x00..." are being displayed now in Hex. ~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B4 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B4": "0x00"
    }
}
~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B3 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B3": "0x000000000000"
    }
}
~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B7 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B7": "0x000000000000000000000000"
    }
}
HexDump results for comparison:
00000170  80 01 42 33 06 00 00 00  00 00 00 42 34 01 00 42  |..B3.......B4..B|
00000180  37 0c 00 00 00 00 00 00  00 00 00 00 00 00 50 46  |7.............PF|

Change-Id: I242caab54cb3c28d74819e614b99df79f881ba5a