### PR TITLE
vpd-tool: Fixing of display of KW values having 0x00s

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -706,20 +706,7 @@ std::string getPrintableValue(const std::variant<Binary, std::string>& kwVal)
                          [](const auto& kw) { return !isprint(kw); });
         if (it != kwVal.end())
         {
-            bool printable = true;
-            for (auto itr = it; itr != kwVal.end(); itr++)
-            {
-                if (*itr != 0x00)
-                {
-                    kwString = hexString(kwVal);
-                    printable = false;
-                    break;
-                }
-            }
-            if (printable)
-            {
-                kwString = std::string(kwVal.begin(), it);
-            }
+            kwString = hexString(kwVal);
         }
         else
         {


### PR DESCRIPTION
Keywords with values "0x00..." are being displayed now in Hex. ~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B4 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B4": "0x00"
    }
}
~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B3 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B3": "0x000000000000"
    }
}
~# /tmp/vpd_tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B7 {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B7": "0x000000000000000000000000"
    }
}
HexDump results for comparison:
00000170 80 01 42 33 06 00 00 00 00 00 00 42 34 01 00 42 |..B3.......B4..B| 00000180 37 0c 00 00 00 00 00 00 00 00 00 00 00 00 50 46 |7.............PF|


Change-Id: I242caab54cb3c28d74819e614b99df79f881ba5a