### PR TITLE
vpd-tool: Fix for UTF-8 with necessary changes for HW read

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -657,39 +657,57 @@ const std::string getKwVal(const Parsed& vpdMap, const std::string& rec,
     return kwVal;
 }
 
-std::string byteArrayToHexString(const Binary& vec)
+std::string hexString(const std::variant<Binary, std::string>& kw)
 {
-    std::stringstream ss;
-    std::string hexRep = "0x";
-    ss << hexRep;
-    std::string str = ss.str();
-
-    // convert Decimal to Hex string
-    for (auto& v : vec)
-    {
-        ss << std::setfill('0') << std::setw(2) << std::hex << (int)v;
-        str = ss.str();
-    }
-    return str;
+    std::string hexString;
+    std::visit(
+        [&hexString](auto&& kw) {
+            for (auto& kwVal : kw)
+            {
+                std::stringstream ss;
+                std::string hexRep = "0x";
+                ss << hexRep;
+                ss << std::setfill('0') << std::setw(2) << std::hex
+                   << static_cast<int>(kwVal);
+                hexString = ss.str();
+            }
+        },
+        kw);
+    return hexString;
 }
 
-std::string getPrintableValue(const Binary& vec)
+std::string getPrintableValue(const std::variant<Binary, std::string>& kwVal)
 {
-    std::string str{};
-
-    // find for a non printable value in the vector
-    const auto it = std::find_if(vec.begin(), vec.end(),
-                                 [](const auto& ele) { return !isprint(ele); });
-
-    if (it != vec.end()) // if the given vector has any non printable value
-    {
-        str = byteArrayToHexString(vec);
-    }
-    else
-    {
-        str = std::string(vec.begin(), vec.end());
-    }
-    return str;
+    std::string kwString{};
+    std::visit(
+        [&kwString](auto&& kwVal) {
+            const auto it =
+                std::find_if(kwVal.begin(), kwVal.end(),
+                             [](const auto& kw) { return !isprint(kw); });
+            if (it != kwVal.end())
+            {
+                bool printable = true;
+                for (auto itr = it; itr != kwVal.end(); itr++)
+                {
+                    if (*itr != 0x00)
+                    {
+                        kwString = hexString(kwVal);
+                        printable = false;
+                        break;
+                    }
+                }
+                if (printable)
+                {
+                    kwString = std::string(kwVal.begin(), it);
+                }
+            }
+            else
+            {
+                kwString = std::string(kwVal.begin(), kwVal.end());
+            }
+        },
+        kwVal);
+    return kwString;
 }
 
 void executePostFailAction(const nlohmann::json& json, const std::string& file)

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -662,15 +662,15 @@ std::string hexString(const std::variant<Binary, std::string>& kw)
     std::string hexString;
     std::visit(
         [&hexString](auto&& kw) {
+            std::stringstream ss;
+            std::string hexRep = "0x";
+            ss << hexRep;
             for (auto& kwVal : kw)
             {
-                std::stringstream ss;
-                std::string hexRep = "0x";
-                ss << hexRep;
                 ss << std::setfill('0') << std::setw(2) << std::hex
                    << static_cast<int>(kwVal);
-                hexString = ss.str();
             }
+            hexString = ss.str();
         },
         kw);
     return hexString;
@@ -686,20 +686,7 @@ std::string getPrintableValue(const std::variant<Binary, std::string>& kwVal)
                              [](const auto& kw) { return !isprint(kw); });
             if (it != kwVal.end())
             {
-                bool printable = true;
-                for (auto itr = it; itr != kwVal.end(); itr++)
-                {
-                    if (*itr != 0x00)
-                    {
-                        kwString = hexString(kwVal);
-                        printable = false;
-                        break;
-                    }
-                }
-                if (printable)
-                {
-                    kwString = std::string(kwVal.begin(), it);
-                }
+                kwString = hexString(kwVal);
             }
             else
             {

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <variant>
 
 namespace openpower
 {
@@ -353,21 +354,21 @@ inline std::string createBindUnbindDriverCmnd(const std::string& devNameAddr,
 /**
  * @brief Get Printable Value
  *
- * Checks if the vector value has non printable characters.
+ * Checks if the value has non printable characters.
  * Returns hex value if non printable char is found else
  * returns ascii value.
  *
- * @param[in] vector - Reference of the Binary vector
+ * @param[in] kwVal - Reference of the input data, Keyword value
  * @return printable value - either in hex or in ascii.
  */
-std::string getPrintableValue(const Binary& vec);
+std::string getPrintableValue(const std::variant<Binary, std::string>& kwVal);
 
 /**
- * @brief Convert byte array to hex string.
- * @param[in] vec - byte array
+ * @brief Convert array to hex string.
+ * @param[in] kwVal - input data, Keyword value
  * @return hexadecimal string of bytes.
  */
-std::string byteArrayToHexString(const Binary& vec);
+std::string hexString(const std::variant<Binary, std::string>& kwVal);
 
 /**
  * @brief Return presence of the FRU.

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -550,7 +550,7 @@ void VpdTool::readKwFromHw(const uint32_t& startOffset)
     {
         json output = json::object({});
         json kwVal = json::object({});
-        kwVal.emplace(keyword, keywordVal);
+        kwVal.emplace(keyword, getPrintableValue(keywordVal));
 
         output.emplace(fruPath, kwVal);
 
@@ -563,14 +563,6 @@ void VpdTool::readKwFromHw(const uint32_t& startOffset)
                   << " or both are not present in the given FRU path "
                   << fruPath << std::endl;
     }
-
-    json output = json::object({});
-    json kwVal = json::object({});
-    kwVal.emplace(keyword, getPrintableValue(keywordVal));
-
-    output.emplace(fruPath, kwVal);
-
-    debugger(output);
 }
 
 void VpdTool::printFixSystemVPDOption(UserOption option)

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -429,8 +429,8 @@ void VpdTool::readKeyword()
     }
     catch (const json::exception& e)
     {
-        json output = json::object({});
-        json kwVal = json::object({});
+        std::cout << "Keyword Value: " << keyword << std::endl;
+        std::cout << e.what() << std::endl;
     }
 }
 
@@ -563,6 +563,14 @@ void VpdTool::readKwFromHw(const uint32_t& startOffset)
                   << " or both are not present in the given FRU path "
                   << fruPath << std::endl;
     }
+
+    json output = json::object({});
+    json kwVal = json::object({});
+    kwVal.emplace(keyword, getPrintableValue(keywordVal));
+
+    output.emplace(fruPath, kwVal);
+
+    debugger(output);
 }
 
 void VpdTool::printFixSystemVPDOption(UserOption option)
@@ -700,7 +708,7 @@ int VpdTool::fixSystemVPD()
                 }
             }
 
-            if (keyword != "SE")
+            if (keyword != "SE") // SE to display in Hex string only
             {
                 ostringstream hwValStream;
                 hwValStream << "0x";
@@ -714,7 +722,7 @@ int VpdTool::fixSystemVPD()
 
                 if (const auto value = get_if<Binary>(&kwValue))
                 {
-                    busStr = byteArrayToHexString(*value);
+                    busStr = hexString(*value);
                 }
                 if (busStr != hwValStr)
                 {


### PR DESCRIPTION
vpd-tool has issue reading Hexadecimal having no corresponding ASCII values from HW.
It is fixed along with printing of 0x00s.
Following are test result:

:~# vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B7
{
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "B7": "0x000000000000000000000000"
    }
}
~# vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K HW
{
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "HW": "0x0001"
    }
vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B4
    {
        "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
            "B4": "0x00"
        }
    }
  vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B3
    {
        "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
            "B3": "0x000000000000"
        }
    }