### PR TITLE
vpd-tool: Fix for UTF-8 with necessary changes for HW read

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -657,15 +657,15 @@ std::string hexString(const std::variant<Binary, std::string>& kw)
     std::string hexString;
     std::visit(
         [&hexString](auto&& kw) {
+            std::stringstream ss;
+            std::string hexRep = "0x";
+            ss << hexRep;
             for (auto& kwVal : kw)
             {
-                std::stringstream ss;
-                std::string hexRep = "0x";
-                ss << hexRep;
                 ss << std::setfill('0') << std::setw(2) << std::hex
                    << static_cast<int>(kwVal);
-                hexString = ss.str();
             }
+            hexString = ss.str();
         },
         kw);
     return hexString;

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -652,39 +652,44 @@ const string getKwVal(const Parsed& vpdMap, const string& rec,
     return kwVal;
 }
 
-string byteArrayToHexString(const Binary& vec)
+std::string hexString(const std::variant<Binary, std::string>& kw)
 {
-    stringstream ss;
-    string hexRep = "0x";
-    ss << hexRep;
-    string str = ss.str();
-
-    // convert Decimal to Hex string
-    for (auto& v : vec)
-    {
-        ss << setfill('0') << setw(2) << hex << (int)v;
-        str = ss.str();
-    }
-    return str;
+    std::string hexString;
+    std::visit(
+        [&hexString](auto&& kw) {
+            for (auto& kwVal : kw)
+            {
+                std::stringstream ss;
+                std::string hexRep = "0x";
+                ss << hexRep;
+                ss << std::setfill('0') << std::setw(2) << std::hex
+                   << static_cast<int>(kwVal);
+                hexString = ss.str();
+            }
+        },
+        kw);
+    return hexString;
 }
 
-string getPrintableValue(const Binary& vec)
+std::string getPrintableValue(const std::variant<Binary, std::string>& kwVal)
 {
-    string str{};
-
-    // find for a non printable value in the vector
-    const auto it = std::find_if(vec.begin(), vec.end(),
-                                 [](const auto& ele) { return !isprint(ele); });
-
-    if (it != vec.end()) // if the given vector has any non printable value
-    {
-        str = byteArrayToHexString(vec);
-    }
-    else
-    {
-        str = string(vec.begin(), vec.end());
-    }
-    return str;
+    std::string kwString{};
+    std::visit(
+        [&kwString](auto&& kwVal) {
+            const auto it =
+                std::find_if(kwVal.begin(), kwVal.end(),
+                             [](const auto& kw) { return !isprint(kw); });
+            if (it != kwVal.end())
+            {
+                kwString = hexString(kwVal);
+            }
+            else
+            {
+                kwString = std::string(kwVal.begin(), kwVal.end());
+            }
+        },
+        kwVal);
+    return kwString;
 }
 
 void executePostFailAction(const nlohmann::json& json, const string& file)

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <variant>
 
 using namespace std;
 
@@ -275,21 +276,21 @@ inline string createBindUnbindDriverCmnd(const string& devNameAddr,
 /**
  * @brief Get Printable Value
  *
- * Checks if the vector value has non printable characters.
+ * Checks if the value has non printable characters.
  * Returns hex value if non printable char is found else
  * returns ascii value.
  *
- * @param[in] vector - Reference of the Binary vector
+ * @param[in] kwVal - Reference of the input data, Keyword value
  * @return printable value - either in hex or in ascii.
  */
-string getPrintableValue(const Binary& vec);
+std::string getPrintableValue(const std::variant<Binary, std::string>& kwVal);
 
 /**
- * @brief Convert byte array to hex string.
- * @param[in] vec - byte array
+ * @brief Convert array to hex string.
+ * @param[in] kwVal - input data, Keyword value
  * @return hexadecimal string of bytes.
  */
-string byteArrayToHexString(const Binary& vec);
+std::string hexString(const std::variant<Binary, std::string>& kwVal);
 
 /**
  * @brief Return presence of the FRU.

--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -417,8 +417,8 @@ void VpdTool::readKeyword()
     }
     catch (const json::exception& e)
     {
-        json output = json::object({});
-        json kwVal = json::object({});
+        std::cout << "Keyword Value: " << keyword << std::endl;
+        std::cout << e.what() << std::endl;
     }
 }
 
@@ -560,7 +560,7 @@ void VpdTool::readKwFromHw()
     {
         json output = json::object({});
         json kwVal = json::object({});
-        kwVal.emplace(keyword, keywordVal);
+        kwVal.emplace(keyword, getPrintableValue(keywordVal));
 
         output.emplace(fruPath, kwVal);
 


### PR DESCRIPTION
vpd-tool has issue reading Hexadecimal having no corresponding ASCII values from HW.
It is fixed along with printing of 0x00s.
Following are test result:

 vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B7
{
"/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
"B7": "0x000000000000000000000000"
}
}
  vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K HW
{
"/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
"HW": "0x0001"
}
vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B4
{
"/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
"B4": "0x00"
}
}
vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K B3
{
"/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
"B3": "0x000000000000"
}
}