### PR TITLE
vpd-tool:Skip displaying Asset interface

### DIFF
--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -341,6 +341,15 @@ json VpdTool::interfaceDecider(json& itemEEPROM)
 
         for (const auto& ex : itemEEPROM["extraInterfaces"].items())
         {
+            // Properties under Decorator.Asset interface are derived from VINI
+            // keywords. Displaying VINI keywords and skipping Decorator.Asset
+            // interface's properties will avoid duplicate entries in vpd-tool
+            // output.
+            if (ex.key() == "xyz.openbmc_project.Inventory.Decorator.Asset")
+            {
+                continue;
+            }
+
             if (!(ex.value().is_null()))
             {
                 // TODO: Remove this if condition check once inventory json is


### PR DESCRIPTION
vpd-tool by default displays specific VINI properties for all FRUs which is again displayed as a part of Asset interface properties when the Asset interface is found in vpd JSON extraInterfaces{}.

To avoid displaying duplicates in vpd-tool, vpd-tool skips displaying Asset interface properties.

Test:
Tested that no duplicates are found in vpd-tool output.

vpd-tool -o -O /system/chassis/motherboard/fan1
[
    {
        "/system/chassis/motherboard/fan1": {
            "CC": "7B5G",
            "DR": "Fan",
            "FN": "02YK237",
            "LocationCode": "U78DA.ND0.WZS002T-A1",             "Manufacturer": "Delta",
            "PN": "02YK200",
            "Present": "true",
            "RI": "",
            "RT": "",
            "SN": "YS10JP12V0TY",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.Fan"         }
    }
]


Change-Id: I6ee4d7210ac9cf5178685a3dbf6581f973dd2235