### PR TITLE
vpd-tool: Flow to read keyword from hardware updated

### DIFF
--- a/vpd_tool.cpp
+++ b/vpd_tool.cpp
@@ -233,9 +233,10 @@ int main(int argc, char** argv)
 
         if (*Hardware)
         {
-            std::cerr << "Did you provide a valid offset? By default VPD "
-                         "offset is taken as 0. To input offset, use --seek. "
-                         "Refer vpd-tool help."
+            std::cerr << std::endl
+                      << "Did you provide a valid offset? By"
+                         " default VPD offset is taken as 0. To input offset,"
+                         " use --seek. Refer vpd-tool help."
                       << std::endl;
         }
         rc = -1;


### PR DESCRIPTION
The commit implements change to check if the offset passed by the user for a given EEPROM path is equal to the offset if defined for that EEPROM in inventory JSON.
In case of any mismatch, error message is flagged to the user.

As all EEPROMs are not modelled in inventory JSON file, In order to handle case where an EEPROM path passed by user is not present in JSON, check has been added to avoid any exception thrown due to extraction of inventory path from JSON based on the passed EEPROM path.

Test cases:

CASE1: Trying to read from i2c FRU

/tmp/vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K PN --seek 0x30000 Invalid offset, please correct the offset
Recommended Offset is: 0

/tmp/vpd-tool -r -H -O "/sys/bus/i2c/drivers/at24/8-0050/eeprom" -R VINI -K PN {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "PN": "00L5521"
    }
}

CASE2: Trying to read from proc and EEPROM not defined in JSON:

/tmp/vpd-tool -r -H -O /sys/bus/spi/drivers/at25/spi22.0/eeprom  -R VINI -K CC Invalid offset, please correct the offset
Recommended Offset is: 196608

/tmp/vpd-tool -r -H -O /sys/bus/spi/drivers/at25/spi22.0/eeprom  -R VINI -K CC --seek 0x30000 {
    "/sys/bus/spi/drivers/at25/spi22.0/eeprom": {
        "CC": "5C5F"
    }
}
/tmp/vpd-tool -r -H -O /sys/bus/spi/drivers/at25/spi23.0/eeprom  -R VINI -K CC --seek 0x30000 {
    "/sys/bus/spi/drivers/at25/spi23.0/eeprom": {
        "CC": "5C5F"
    }
}

/tmp/vpd-tool -r -H -O /sys/bus/spi/drivers/at25/spi23.0/eeprom  -R VINI -K CC --seek 0x3000 VHDR record not found
Did you provide a valid offset? By default VPD offset is taken as 0. To input offset, use --seek. Refer vpd-tool help.

/tmp/vpd-tool -r -H -O /sys/bus/spi/drivers/at25/spi23.0/eeprom  -R VINI -K CC VHDR record not found
Did you provide a valid offset? By default VPD offset is taken as 0. To input offset, use --seek. Refer vpd-tool help.

/tmp/vpd-tool -r -H -O /sys/bus/spi/drivers/at25/spi22.0/eeprom  -R VINI -K CC --seek 0x3000 Invalid offset, please correct the offset
Recommended Offset is: 196608


Change-Id: I246ca983fc75490999f18386bf60e949959d49d2