### PR TITLE
DIMM capacity changed from MB to KB

### DIFF
--- a/vpd-parser/memory_vpd_parser.cpp
+++ b/vpd-parser/memory_vpd_parser.cpp
@@ -101,7 +101,7 @@ auto memoryVpdParser::getDimmSize(Binary::const_iterator iterator)
     dimmSize = (sdramCap / JEDEC_PRI_BUS_WIDTH_MULTIPLIER) *
                (priBusWid / sdramWid) * logicalRanksPerDimm;
 
-    return dimmSize;
+    return constants::CONVERT_MB_TO_KB * dimmSize;
 }
 
 kwdVpdMap memoryVpdParser::readKeywords(Binary::const_iterator iterator)


### PR DESCRIPTION
Calculation of DIMM capacity is changed to KB for it to have as required in GUI.

Test Result:
busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0

MemoryDataWidth                                      property  q         0                                        emits-change writable
.MemoryDeviceLocator                                  property  s         ""                                       emits-change writable
.MemoryMedia                                          property  s         "xyz.openbmc_project.Inventory.Item.D... emits-change writable
.MemorySizeInKB                                       property  u         67108864                                 emits-change writable
Signed-off-by: Giridhari Krishna <giridharikrishnan@gmail.com>
Change-Id: Ied51938c4ca9d42f6e761db403c06a69b0d8e0ba