### PR TITLE
UTIL F0 keyword addition.

### DIFF
--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -38,6 +38,7 @@ static const inventory::SystemKeywordsMap svpdKwdMap{
     {"LXR0", {inventory::SystemKeywordInfo("LX", Binary(), true, false)}},
     {"UTIL",
      {inventory::SystemKeywordInfo("D0", Binary(1, 0x00), true, true),
+      inventory::SystemKeywordInfo("F0", Binary(8, 0x00), false, true),
       inventory::SystemKeywordInfo("F5", Binary(16, 0x00), false, true),
       inventory::SystemKeywordInfo("F6", Binary(16, 0x00), false, true)}}};
 


### PR DESCRIPTION
F0 Keyword from UTIL Record is being used for restoring Replay ID even during factory reset.
Data:
Keyword details in Michael Lim's box folder.


Change-Id: Icf8e3f544159ae3d174976681c440260cee3a065