### PR TITLE
UTIL:D1 keyword added to backup restore.

### DIFF
--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -49,6 +49,8 @@ static const inventory::SystemKeywordsMap svpdKwdMap{
     {"UTIL",
      {inventory::SystemKeywordInfo("D0", Binary(1, 0x00), true, true, "VSBK",
                                    "D0"),
+      inventory::SystemKeywordInfo("D1", Binary(1, 0x00), true, true, "VSBK",
+                                   "D1"),
       inventory::SystemKeywordInfo("F0", Binary(8, 0x00), false, true, "VSBK",
                                    "F0"),
       inventory::SystemKeywordInfo("F5", Binary(16, 0x00), false, true, "VSBK",


### PR DESCRIPTION
FUTIL:D1 keywords needs to be backed up and restored as the 
case may be to either the cache or hardware.  On Hardware 
based back up storage it will be backed to VSBK:D1

Change-Id: I7f79532b216468751525aa81282e342b6ba6fb20