### PR TITLE
Correct PEL create on default value in D1 keyword

### DIFF
--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -51,7 +51,7 @@ static const inventory::SystemKeywordsMap svpdKwdMap{
     {"UTIL",
      {inventory::SystemKeywordInfo("D0", Binary(1, 0x00), true, true, "VSBK",
                                    "D0"),
-      inventory::SystemKeywordInfo("D1", Binary(1, 0x00), true, true, "VSBK",
+      inventory::SystemKeywordInfo("D1", Binary(1, 0x00), false, true, "VSBK",
                                    "D1"),
       inventory::SystemKeywordInfo("F0", Binary(8, 0x00), false, true, "VSBK",
                                    "F0"),


### PR DESCRIPTION
  We will not create a PEL if the D1 keyword is the
default value both on the Primary and the secondary we will go ahead as the value gets updated at a later stage