### PR TITLE
Skip displaying asset only if VINI is not present

### DIFF
--- a/vpd_tool_impl.cpp
+++ b/vpd_tool_impl.cpp
@@ -345,7 +345,9 @@ json VpdTool::interfaceDecider(json& itemEEPROM)
             // keywords. Displaying VINI keywords and skipping Decorator.Asset
             // interface's properties will avoid duplicate entries in vpd-tool
             // output.
-            if (ex.key() == "xyz.openbmc_project.Inventory.Decorator.Asset")
+            if (ex.key() == "xyz.openbmc_project.Inventory.Decorator.Asset" &&
+                itemEEPROM["extraInterfaces"].find(constants::kwdVpdInf) !=
+                    itemEEPROM["extraInterfaces"].end())
             {
                 continue;
             }


### PR DESCRIPTION
This commit has logic in vpd-tool to display properties under Asset interface only if VINI properties are not required to display. This is done to avoid duplicate entries in vpd-tool output as the properties from Asset interface are derived from keyowrds under VINI interface.

Test:
vpd-tool -o -O /system
[
    {
        "/system": {
            "LocationCode": "U9105.42A.13BEA10",
            "Model": "9105-42A",
            "Present": "true",
            "PrettyName": "System",
            "SerialNumber": "13BEA10",
            "SubModel": "S0",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.System"
        }
    }
]

vpd-tool -o -O /system/chassis/motherboard/fan1
[
    {
        "/system/chassis/motherboard/fan1": {
            "CC": "7B5F",
            "DR": "Blower",
            "FN": "02YK323",
            "LocationCode": "U78DB.ND0.WZS0018-A1",
            "PN": "02YK323",
            "Present": "true",
            "RI": "",
            "RT": "",
            "SN": "YL12JP1C1234",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.Fan"
        }
    }
]


Change-Id: Ia9c76bd03220b7218cb5f7792100e01fc57a6131