### PR TITLE
vpd-tool:Fix system VPD and its backup VPD

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -1093,5 +1093,45 @@ std::string getDbusNameForThisKw(const std::string& keyword)
     return keyword;
 }
 
+void findBackupVPDPaths(std::string& backupEepromPath,
+                        std::string& backupInvPath, const nlohmann::json& js)
+{
+    for (const auto& item : js["frus"][constants::systemVpdFilePath])
+    {
+        if (item.find("systemVpdBackupPath") != item.end())
+        {
+            backupEepromPath = item["systemVpdBackupPath"];
+            for (const auto& item : js["frus"][backupEepromPath])
+            {
+                if (item.find("inventoryPath") != item.end())
+                {
+                    backupInvPath = item["inventoryPath"];
+                    break;
+                }
+            }
+            break;
+        }
+    }
+}
+
+void getBackupRecordKeyword(std::string& record, std::string& keyword)
+{
+    for (const auto& recordKw : svpdKwdMap)
+    {
+        if (record == recordKw.first)
+        {
+            for (const auto& keywordInfo : recordKw.second)
+            {
+                if (keyword == get<0>(keywordInfo))
+                {
+                    record = get<4>(keywordInfo);
+                    keyword = get<5>(keywordInfo);
+                    break;
+                }
+            }
+            break;
+        }
+    }
+}
 } // namespace vpd
 } // namespace openpower

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -520,5 +520,23 @@ Binary getVpdDataInVector(const nlohmann::json& js, const std::string& file);
  */
 std::string getDbusNameForThisKw(const std::string& keyword);
 
+/**
+ * @brief Find backup VPD path if any for the system VPD
+ *
+ * @param[out] backupEepromPath - Backup VPD path
+ * @param[out] backupInvPath - Backup inventory path
+ * @param[in] js - Inventory JSON object
+ */
+void findBackupVPDPaths(std::string& backupEepromPath,
+                        std::string& backupInvPath, const nlohmann::json& js);
+
+/**
+ * @brief Get backup VPD's record and keyword for the given system VPD keyword
+ *
+ * @param[in,out] record - Record name
+ * @param[in,out] keyword - Keyword name
+ */
+void getBackupRecordKeyword(std::string& record, std::string& keyword);
+
 } // namespace vpd
 } // namespace openpower

--- a/vpd_tool.cpp
+++ b/vpd_tool.cpp
@@ -199,8 +199,20 @@ int main(int argc, char** argv)
         }
         else if (*fixSystemVPDFlag)
         {
+            std::string backupEepromPath;
+            std::string backupInvPath;
+            findBackupVPDPaths(backupEepromPath, backupInvPath, jsObject);
             VpdTool vpdToolObj;
-            rc = vpdToolObj.fixSystemVPD();
+
+            if (backupEepromPath.empty())
+            {
+                rc = vpdToolObj.fixSystemVPD();
+            }
+            else
+            {
+                rc = vpdToolObj.fixSystemBackupVPD(backupEepromPath,
+                                                   backupInvPath);
+            }
         }
         else if (*mfgClean)
         {

--- a/vpd_tool_impl.hpp
+++ b/vpd_tool_impl.hpp
@@ -12,7 +12,7 @@ using json = nlohmann::json;
 
 // <S.no, Record, Keyword, D-Bus value, HW value, Data mismatch>
 using SystemCriticalData =
-    std::vector<std::tuple<int, std::string, std::string, std::string,
+    std::vector<std::tuple<uint8_t, std::string, std::string, std::string,
                            std::string, std::string>>;
 
 class VpdTool
@@ -141,8 +141,10 @@ class VpdTool
      * @brief Parse through the options to fix system VPD
      *
      * @param[in] json - Inventory JSON
+     * @param[in] backupEEPROMPath - Backup VPD path
      */
-    void parseSVPDOptions(const nlohmann::json& json);
+    void parseSVPDOptions(const nlohmann::json& json,
+                          const std::string& backupEEPROMPath);
 
     /**
      * @brief List of user options that can be used to fix system VPD keywords.
@@ -277,6 +279,19 @@ class VpdTool
      * @return return code (success/failure)
      */
     int cleanSystemVPD();
+
+    /**
+     * @brief Fix system VPD and its backup VPD
+     * API is triggerred if the backup of system VPD has to be taken in a
+     * hardware VPD. User can use the --fixSystemVPD option to restore the
+     * keywords in backup VPD and/or system VPD.
+     *
+     * @param[in] backupEepromPath - Backup VPD path
+     * @param[in] backupInvPath - Backup inventory path
+     * @return returncode
+     */
+    int fixSystemBackupVPD(const std::string& backupEepromPath,
+                           const std::string& backupInvPath);
 
     /**
      * @brief Constructor


### PR DESCRIPTION
vpd-tool fixSystemVPD implementation to backup and restore system VPD to and from the backup VPD if the backup VPD path is found in vpd inventory JSON.

Test:
(Truncating the output in commit message)

===>>CASE 1: Option 6 to update new value on both backup and primary hardware and its cache.

vpd-tool --fixSystemVPD
**=============================================================
S.No  Record  Keyword  Backup Data  Primary Data    Data Mismatch
1     UTIL    D0       0x01         0x01            NO
**============================================================

 Enter the new value to update on both primary & backup. Value should be in ASCII or in HEX(prefixed with 0x) : 0x00

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth com.ibm.ipzvpd.VSBK D0 ay 1 0

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.UTIL D0 ay 1 0

===>>CASE 2: Option 4 to update primary with backup data

vpd-tool -w -O /system/chassis/motherboard -R LXR0 -K LX -V 0x333435363738 Data updated successfully

vpd-tool --fixSystemVPD
**=================================================================================
S.No  Record  Keyword  Backup Data            Primary Data           Data Mismatch
6     LXR0    LX       0x310004010030007b     0x333435363738007b     YES
**=================================================================================

Enter 4 => If you choose the data on backup as the right value : 4

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.LXR0 LX ay 8 49 0 4 1 0 48 0 123

===>>CASE 3: Option 5 to update backup with primary value vpd-tool -w -O /system/chassis/motherboard/base_op_panel_blyth -R VSBK -K FC -V "abcd" Data updated successfully

vpd-tool --fixSystemVPD
**=================================================================================
S.No  Record  Keyword  Backup Data            Primary Data           Data Mismatch
7     VCEN    FC       0x616263642d303031     0x324534412d303031     YES
**=================================================================================

Enter 5 => If you choose the data on primary as the right value : 5

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth com.ibm.ipzvpd.VSBK FC ay 8 50 69 52 65 45 48 48 49

===>>CASE 4: Option 2 to update all mismatching keywords with its primary data

vpd-tool -w -O /system/chassis/motherboard/base_op_panel_blyth -R VSBK -K FC -V "abcd" Data updated successfully

vpd-tool -w -O /system/chassis/motherboard/base_op_panel_blyth -R VSBK -K D0 -V "abcd" Data updated successfully

vpd-tool --fixSystemVPD
**=================================================================================
S.No  Record  Keyword  Backup Data            Primary Data           Data Mismatch
**=================================================================================
1     UTIL    D0       0x61                   0x01                   YES
**-------------------------------------------------------------------------------
7     VCEN    FC       0x616263642d303031     0x324534412d303031     YES
**=================================================================================

Enter 2 => If you choose the data on primary for all mismatching record-keyword pairs : 2

Data updated successfully for all mismatching record-keyword pairs by choosing their corresponding data from primary VPD.

vpd-tool -r -O /system/chassis/motherboard/base_op_panel_blyth -R VSBK -K FC {
    "/system/chassis/motherboard/base_op_panel_blyth": {
        "FC": "2E4A-001"
    }
}
vpd-tool -r -O /system/chassis/motherboard/base_op_panel_blyth -R VSBK -K D0 {
    "/system/chassis/motherboard/base_op_panel_blyth": {
        "D0": "0x01"
    }
}

===>>CASE 5: Option 1

vpd-tool -w -O /system/chassis/motherboard -R UTIL -K D0 -V "abcd" Data updated successfully
vpd-tool -w -O /system/chassis/motherboard -R UTIL -K D1 -V "abcd" Data updated successfully

vpd-tool --fixSystemVPD
**=================================================================================
S.No  Record  Keyword  Backup Data            Primary Data           Data Mismatch
**=================================================================================
1     UTIL    D0       0x01                   0x61                   YES
**-------------------------------------------------------------------------------
2     UTIL    D1       0x00                   0x61                   YES
**=================================================================================

Enter 1 => If you choose the data on backup for all mismatching record-keyword pairs: 1

Data updated successfully for all mismatching record-keyword pairs by choosing their corresponding data from backup. Exit successfully.

vpd-tool -r -O /system/chassis/motherboard  -R UTIL -K D0 {
    "/system/chassis/motherboard": {
        "D0": "0x01"
    }
}
vpd-tool -r -O /system/chassis/motherboard  -R UTIL -K D1 {
    "/system/chassis/motherboard": {
        "D1": "0x00"
    }
}


Change-Id: I0cfa5c869d4c44d2dd74916b5284fa2ad9b4f398