### PR TITLE
Clear inventory data on removal

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -115,6 +115,7 @@ static constexpr auto SPD_DRAM_TYPE_DDR4 = 0x0C;
 
 constexpr auto pimPath = "/xyz/openbmc_project/inventory";
 constexpr auto pimIntf = "xyz.openbmc_project.Inventory.Manager";
+constexpr auto pimService = "xyz.openbmc_project.Inventory.Manager";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto memVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto ipzVpdInf = "com.ibm.ipzvpd.";
@@ -145,6 +146,9 @@ constexpr auto at24driver = "at24";
 constexpr auto at25driver = "at25";
 constexpr auto ee1004driver = "ee1004";
 constexpr auto invItemIntf = "xyz.openbmc_project.Inventory.Item";
+constexpr auto invAssetIntf = "xyz.openbmc_project.Inventory.Decorator.Asset";
+constexpr auto invOperationalStatusIntf =
+    "xyz.openbmc_project.State.Decorator.OperationalStatus";
 static constexpr std::uintmax_t MAX_VPD_SIZE = 65504;
 
 namespace lengths

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -81,6 +81,32 @@ MapperResponse
     return result;
 }
 
+MapperGetObjectResponse getObject(const std::string& objectPath,
+                                  const std::vector<std::string>& interfaces)
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto mapperCall = bus.new_method_call(mapperDestination, mapperObjectPath,
+                                          mapperInterface, "GetObject");
+    mapperCall.append(objectPath);
+    mapperCall.append(interfaces);
+
+    MapperGetObjectResponse result = {};
+
+    try
+    {
+        auto response = bus.call(mapperCall);
+
+        response.read(result);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        log<level::ERR>("Error in mapper GetObject",
+                        entry("ERROR=%s", e.what()));
+    }
+
+    return result;
+}
+
 } // namespace inventory
 
 LE2ByteData readUInt16LE(Binary::const_iterator iterator)
@@ -1130,6 +1156,68 @@ void getBackupRecordKeyword(std::string& record, std::string& keyword)
                 }
             }
             break;
+        }
+    }
+}
+
+void clearVpdOnRemoval(const std::string& objPath,
+                       inventory::InterfaceMap& interfacesPropMap)
+{
+    std::vector<std::string> vpdRelatedInterfaces{
+        constants::invOperationalStatusIntf, constants::invItemIntf,
+        constants::invAssetIntf};
+
+    std::vector<std::string> interfaces{};
+    auto mapperResponse = inventory::getObject(objPath, interfaces);
+
+    for (const auto& [service, interfaceList] : mapperResponse)
+    {
+        // Handle FRUs under PIM
+        if (service.compare(pimService) != 0)
+        {
+            continue;
+        }
+
+        for (const auto& interface : interfaceList)
+        {
+            // Only process for VPD related interfaces.
+            if ((interface.find("com.ibm.ipzvpd") != std::string::npos) ||
+                ((std::find(vpdRelatedInterfaces.begin(),
+                            vpdRelatedInterfaces.end(), interface)) !=
+                 vpdRelatedInterfaces.end()))
+            {
+                const auto propertyList = getAllDBusProperty<GetAllResultType>(
+                    service, objPath, interface);
+
+                inventory::PropertyMap propertyValueMap;
+                for (auto aProperty : propertyList)
+                {
+                    const auto& propertyName = std::get<0>(aProperty);
+                    const auto& propertyValue = std::get<1>(aProperty);
+
+                    if (std::holds_alternative<Binary>(propertyValue))
+                    {
+                        propertyValueMap.emplace(propertyName, Binary{});
+                    }
+                    else if (std::holds_alternative<std::string>(propertyValue))
+                    {
+                        propertyValueMap.emplace(propertyName, std::string{});
+                    }
+                    else if (std::holds_alternative<bool>(propertyValue))
+                    {
+                        if (propertyName.compare("Present") == 0)
+                        {
+                            propertyValueMap.emplace(propertyName, false);
+                        }
+                        else if (propertyName.compare("Functional") == 0)
+                        {
+                            propertyValueMap.emplace(propertyName, true);
+                        }
+                    }
+                }
+                interfacesPropMap.emplace(interface,
+                                          std::move(propertyValueMap));
+            }
         }
     }
 }

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -87,6 +87,17 @@ MapperResponse
     getObjectSubtreeForInterfaces(const std::string& root, const int32_t depth,
                                   const std::vector<std::string>& interfaces);
 
+/**
+ * @brief API to call GetObject API of mapper.
+ *
+ * @param[in] objectPath - inventory path.
+ * @param[in] interfaces - List of interfaces.
+ *
+ * @return - response of the API call.
+ */
+MapperGetObjectResponse getObject(const std::string& objectPath,
+                                  const std::vector<std::string>& interfaces);
+
 } // namespace inventory
 
 /**@brief This API reads 2 Bytes of data and swap the read data
@@ -538,5 +549,13 @@ void findBackupVPDPaths(std::string& backupEepromPath,
  */
 void getBackupRecordKeyword(std::string& record, std::string& keyword);
 
+/**
+ * @brief API to remove VPD data from Dbus on removal of FRU.
+ *
+ * @param[in] objPath - Inventory path of the FRU.
+ * @param[out] interfacesPropMap - Map of interface, property and value.
+ */
+void clearVpdOnRemoval(const std::string& objPath,
+                       inventory::InterfaceMap& interfacesPropMap);
 } // namespace vpd
 } // namespace openpower

--- a/types.hpp
+++ b/types.hpp
@@ -59,6 +59,7 @@ using PelAdditionalData = std::map<std::string, std::string>;
 using Service = std::string;
 using MapperResponse =
     std::map<Path, std::map<Service, std::vector<Interface>>>;
+using MapperGetObjectResponse = std::map<Service, std::vector<Interface>>;
 using RestoredEeproms = std::tuple<Path, std::string, Keyword, Binary>;
 using ReplaceableFrus = std::vector<VPDfilepath>;
 using EssentialFrus = std::vector<Path>;

--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -32,6 +32,7 @@ namespace vpd
 {
 namespace manager
 {
+
 Manager::Manager(std::shared_ptr<boost::asio::io_context>& ioCon,
                  std::shared_ptr<sdbusplus::asio::dbus_interface>& iFace,
                  std::shared_ptr<sdbusplus::asio::connection>& conn) :
@@ -770,16 +771,11 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path& path)
     }
     else
     {
-        // Set present property of FRU as false as it has been removed.
-        // CC data for FRU is also removed as
-        // a) FRU is not there so CC does not make sense.
-        // b) Sensors dependent on Panel uses CC data.
-        inventory::InterfaceMap interfaces{
-            {"xyz.openbmc_project.Inventory.Item", {{"Present", false}}},
-            {"com.ibm.ipzvpd.VINI", {{"CC", Binary{}}}}};
+        inventory::InterfaceMap interfacesPropMap;
+        clearVpdOnRemoval(INVENTORY_PATH + objPath, interfacesPropMap);
 
         inventory::ObjectMap objectMap;
-        objectMap.emplace(objPath, move(interfaces));
+        objectMap.emplace(objPath, move(interfacesPropMap));
 
         common::utility::callPIM(move(objectMap));
     }


### PR DESCRIPTION
In case any FRU is removed from the system, the data w.r.t the FRU, as it is persisted continues to stay on DBus. This sometimes can be mis-leading as data is displayed for FRU which is actially not present in the system.

The commit, in case the FRU is removed via delte FRU procedure, clears all the VPD related data for the FRU and updtaes its present and functional status.

Test:
Delete any FRU using "deleteFRUVPD" exposed via VPD-Manager, check the DBus, data related to VPD should be cleared.