### PR TITLE
Set same value for PN and FN keywords in Bonnell ISDIMM vpd

### DIFF
--- a/vpd-parser/isdimm_vpd_parser.cpp
+++ b/vpd-parser/isdimm_vpd_parser.cpp
@@ -326,7 +326,9 @@ kwdVpdMap isdimmVpdParser::readKeywords(Binary::const_iterator& iterator)
         auto fruNumber = getDDR4FruNumber(partNumber, iterator);
         auto serialNumber = getDDR4SerialNumber(iterator);
         auto ccin = getDDR4CCIN(fruNumber);
-        keywordValueMap.emplace("PN", move(partNumber));
+	// Per defect PE00MHKW PN value is made same as FN value
+	auto displayPartNumber = fruNumber;
+        keywordValueMap.emplace("PN", move(displayPartNumber));
         keywordValueMap.emplace("FN", move(fruNumber));
         keywordValueMap.emplace("SN", move(serialNumber));
         keywordValueMap.emplace("CC", move(ccin));


### PR DESCRIPTION
  Make thePN keyword value to be same as that of the FN valuue