### PR TITLE
P11_dev: Keyword VPD class

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -5,13 +5,21 @@ namespace vpd
 {
 namespace constants
 {
-static constexpr auto FORMAT_11S_LEN = 3;
-static constexpr auto MEMORY_VPD_DATA_START = 416;
-static constexpr int IPZ_DATA_START = 11;
-static constexpr uint8_t KW_VAL_PAIR_START_TAG = 0x84;
-static constexpr int KW_VPD_DATA_START = 0;
+static constexpr uint8_t IPZ_DATA_START = 11;
+static constexpr uint8_t IPZ_DATA_START_TAG = 0x84;
+static constexpr uint8_t IPZ_RECORD_END_TAG = 0x78;
+
+static constexpr uint8_t KW_VPD_DATA_START = 0;
 static constexpr uint8_t KW_VPD_START_TAG = 0x82;
+static constexpr uint8_t KW_VPD_PAIR_START_TAG = 0x84;
+static constexpr uint8_t ALT_KW_VPD_PAIR_START_TAG = 0x90;
+static constexpr uint8_t KW_VPD_END_TAG = 0x78;
+static constexpr uint8_t KW_VAL_PAIR_END_TAG = 0x79;
+
+static constexpr auto MEMORY_VPD_DATA_START = 416;
 static constexpr auto MEMORY_VPD_START_TAG = "11S";
+static constexpr auto FORMAT_11S_LEN = 3;
+
 static constexpr auto SPD_BYTE_2 = 2;
 static constexpr auto SPD_BYTE_3 = 3;
 static constexpr auto SPD_BYTE_4 = 4;
@@ -38,6 +46,8 @@ static constexpr auto UUID_TIME_MID_END = 13;
 static constexpr auto UUID_TIME_HIGH_END = 18;
 static constexpr auto UUID_CLK_SEQ_END = 23;
 static constexpr auto MAC_ADDRESS_LEN_BYTES = 6;
+static constexpr auto ONE_BYTE = 1;
+static constexpr auto TWO_BYTES = 2;
 
 constexpr auto pimPath = "/xyz/openbmc_project/inventory";
 constexpr auto pimIntf = "xyz.openbmc_project.Inventory.Manager";

--- a/include/keyword_vpd_parser.hpp
+++ b/include/keyword_vpd_parser.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "parser_interface.hpp"
+#include "types.hpp"
+
+namespace vpd
+{
+
+/**
+ * @brief Concrete class to implement Keyword VPD parsing
+ *
+ * The class inherits ParserInterface class and overrides the parser
+ * functionality to implement parsing logic for Keyword VPD format.
+ */
+class KeywordVpdParser : public ParserInterface
+{
+  public:
+    KeywordVpdParser() = delete;
+    KeywordVpdParser(const KeywordVpdParser&) = delete;
+    KeywordVpdParser(KeywordVpdParser&&) = delete;
+    ~KeywordVpdParser() = default;
+
+    /**
+     * @brief Constructor
+     *
+     * @param kwVpdVector - move it to object's m_keywordVpdVector
+     */
+    KeywordVpdParser(const types::BinaryVector& kwVpdVector) :
+        m_keywordVpdVector(kwVpdVector),
+        m_vpdIterator(m_keywordVpdVector.begin())
+    {
+    }
+
+    /**
+     * @brief A wrapper function to parse the keyword VPD binary data.
+     *
+     * It validates certain tags and checksum data, calls helper function
+     * to parse and emplace the data as keyword-value pairs in KeywordVpdMap.
+     *
+     * @throw DataException - VPD is not valid
+     * @return map of keyword:value
+     */
+    types::VPDMapVariant parse();
+
+  private:
+    /**
+     * @brief Parse the vpd data and emplace them as pair into the Map.
+     *
+     * @throw DataException - VPD data size is 0, check vpd
+     * @return map of keyword:value
+     */
+    types::KeywordVpdMap populateVpdMap();
+
+    /**
+     * @brief Validate checksum.
+     *
+     * Finding the 2's complement of sum of all the
+     * keywords,values and large resource identifier string.
+     *
+     * @param checkSumStart - vpd iterator pointing at checksum start value
+     * @param checkSumEnd - vpd iterator pointing at checksum end value
+     * @throw DataException - checksum invalid, check vpd
+     */
+    void validateChecksum(types::BinaryVector::const_iterator checkSumStart,
+                          types::BinaryVector::const_iterator checkSumEnd);
+
+    /**
+     * @brief It reads 2 bytes from current vpd pointer
+     *
+     * @return 2 bytes of vpd data
+     */
+    inline size_t getKwDataSize()
+    {
+        return (*(m_vpdIterator + 1) << 8 | *m_vpdIterator);
+    }
+
+    /**
+     * @brief Check for given number of bytes validity
+     *
+     * Check if number of elements from (begining of the vector) to (iterator +
+     * numberOfBytes) is lesser than or equal to the total no.of elements in
+     * the vector. This check is performed before advancement of the iterator.
+     *
+     * @param[in] numberOfBytes - no.of positions the iterator is going to be
+     * iterated
+     *
+     * @throw DataException - Truncated vpd data, check VPD.
+     */
+    void checkNextBytesValidity(uint8_t numberOfBytes);
+
+    /*Vector of keyword VPD data*/
+    const types::BinaryVector& m_keywordVpdVector;
+
+    /*Iterator to vpd data*/
+    types::BinaryVector::const_iterator m_vpdIterator;
+};
+} // namespace vpd

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -52,7 +52,7 @@ using KWdVPDValueType = std::variant<BinaryVector,std::string, size_t>;
 using KeywordVpdMap = std::unordered_map<std::string, KWdVPDValueType>;
 
 /**
- * Type tp hold keyword::value map of a VPP.
+ * Type to hold keyword::value map of a VPD.
  * Variant can be extended to support additional type.
 */
 using VPDKWdValueMap = std::variant<IPZKwdValueMap, KeywordVpdMap>;

--- a/meson.build
+++ b/meson.build
@@ -90,7 +90,8 @@ vpd_manager_SOURCES = ['src/main.cpp',
                        'src/utils.cpp',
                        'src/parser_factory.cpp',
                        'src/ipz_parser.cpp',
-                       'src/worker.cpp']
+                       'src/worker.cpp',
+		       'src/keyword_vpd_parser.cpp']
 
 vpd_manager_dependencies = [sdbusplus]
 

--- a/src/keyword_vpd_parser.cpp
+++ b/src/keyword_vpd_parser.cpp
@@ -1,0 +1,141 @@
+#include "keyword_vpd_parser.hpp"
+
+#include "constants.hpp"
+#include "exceptions.hpp"
+#include "logger.hpp"
+
+#include <iostream>
+#include <numeric>
+#include <string>
+
+namespace vpd
+{
+
+types::VPDMapVariant KeywordVpdParser::parse()
+{
+    try
+    {
+        m_vpdIterator = m_keywordVpdVector.begin();
+
+        if (*m_vpdIterator != constants::KW_VPD_START_TAG)
+        {
+            throw(
+                DataException("Invalid Large resource type Identifier String"));
+        }
+
+        checkNextBytesValidity(sizeof(constants::KW_VPD_START_TAG));
+        std::advance(m_vpdIterator, sizeof(constants::KW_VPD_START_TAG));
+
+        uint16_t dataSize = getKwDataSize();
+
+        checkNextBytesValidity(constants::TWO_BYTES + dataSize);
+        std::advance(m_vpdIterator, constants::TWO_BYTES + dataSize);
+
+        // Check for invalid vendor defined large resource type
+        if (*m_vpdIterator != constants::KW_VPD_PAIR_START_TAG)
+        {
+            if (*m_vpdIterator != constants::ALT_KW_VPD_PAIR_START_TAG)
+            {
+                throw(DataException("Invalid Keyword Vpd Start Tag"));
+            }
+        }
+        auto kwValMap = populateVpdMap();
+
+        // Do these validations before returning parsed data.
+        // Check for small resource type end tag
+        if (*m_vpdIterator != constants::KW_VAL_PAIR_END_TAG)
+        {
+            throw(DataException("Invalid Small resource type End"));
+        }
+
+        // Check vpd end Tag.
+        if (*m_vpdIterator != constants::KW_VPD_END_TAG)
+        {
+            throw(DataException("Invalid Small resource type."));
+        }
+        return kwValMap;
+    }
+    catch (const DataException& ex)
+    {
+        logging::logMessage(ex.what());
+
+        throw(DataException("VPD is corrupted, need to fix it."));
+    }
+}
+
+types::KeywordVpdMap KeywordVpdParser::populateVpdMap()
+{
+    types::BinaryVector::const_iterator checkSumStart = m_vpdIterator;
+    checkNextBytesValidity(constants::ONE_BYTE);
+    std::advance(m_vpdIterator, constants::ONE_BYTE);
+
+    auto totalSize = getKwDataSize();
+    if (totalSize == 0)
+    {
+        throw(DataException("Data size is 0, badly formed keyword VPD"));
+    }
+
+    checkNextBytesValidity(constants::TWO_BYTES);
+    std::advance(m_vpdIterator, constants::TWO_BYTES);
+
+    types::KeywordVpdMap kwValMap;
+
+    // Parse the keyword-value and store the pairs in map
+    while (totalSize > 0)
+    {
+        checkNextBytesValidity(constants::TWO_BYTES);
+        std::string keywordName(m_vpdIterator,
+                                m_vpdIterator + constants::TWO_BYTES);
+        std::advance(m_vpdIterator, constants::TWO_BYTES);
+
+        size_t kwSize = *m_vpdIterator;
+        checkNextBytesValidity(kwSize);
+        m_vpdIterator++;
+        std::vector<uint8_t> valueBytes(m_vpdIterator, m_vpdIterator + kwSize);
+        std::advance(m_vpdIterator, kwSize);
+
+        kwValMap.emplace(
+            std::make_pair(std::move(keywordName), std::move(valueBytes)));
+
+        totalSize -= constants::TWO_BYTES + constants::ONE_BYTE + kwSize;
+    }
+
+    types::BinaryVector::const_iterator checkSumEnd = m_vpdIterator;
+
+    validateChecksum(checkSumStart, checkSumEnd);
+
+    return kwValMap;
+}
+
+void KeywordVpdParser::validateChecksum(
+    types::BinaryVector::const_iterator checkSumStart,
+    types::BinaryVector::const_iterator checkSumEnd)
+{
+    uint8_t checkSumCalculated = 0;
+
+    // Checksum calculation
+    checkSumCalculated =
+        std::accumulate(checkSumStart, checkSumEnd, checkSumCalculated);
+    checkSumCalculated = ~checkSumCalculated + 1;
+    uint8_t checksumVpdValue = *(m_vpdIterator + constants::ONE_BYTE);
+
+    if (checkSumCalculated != checksumVpdValue)
+    {
+        throw(DataException("Invalid Checksum"));
+    }
+
+    checkNextBytesValidity(constants::TWO_BYTES);
+    std::advance(m_vpdIterator, constants::TWO_BYTES);
+}
+
+void KeywordVpdParser::checkNextBytesValidity(uint8_t numberOfBytes)
+{
+    if ((std::distance(m_keywordVpdVector.begin(),
+                       m_vpdIterator + numberOfBytes)) >
+        std::distance(m_keywordVpdVector.begin(), m_keywordVpdVector.end()))
+    {
+        throw(DataException("Truncated VPD data"));
+    }
+}
+
+} // namespace vpd

--- a/src/parser_factory.cpp
+++ b/src/parser_factory.cpp
@@ -3,6 +3,7 @@
 #include "constants.hpp"
 #include "exceptions.hpp"
 #include "ipz_parser.hpp"
+#include "keyword_vpd_parser.hpp"
 
 namespace vpd
 {
@@ -30,8 +31,7 @@ enum vpdType
  */
 static vpdType vpdTypeCheck(const types::BinaryVector& vpdVector)
 {
-    if (vpdVector[constants::IPZ_DATA_START] ==
-        constants::KW_VAL_PAIR_START_TAG)
+    if (vpdVector[constants::IPZ_DATA_START] == constants::IPZ_DATA_START_TAG)
     {
         return vpdType::IPZ_VPD;
     }
@@ -105,8 +105,7 @@ std::shared_ptr<ParserInterface> ParserFactory::getParser(
 
         case vpdType::KEYWORD_VPD:
         {
-            // TODO:
-            // return shared pointer to class object.
+            return std::make_shared<KeywordVpdParser>(vpdVector);
         }
 
         case vpdType::DDR4_DDIMM_MEMORY_VPD:


### PR DESCRIPTION
This commit implements concrete class to parse keyword VPD.


Test:
Tested parser code for set of vpds in keyword vpd format.
It works fine. Sharing console output-

Start Tag is - 82 - it's keyword vpd.
Got the description size : 3, skip and go ahead.
Start Tag found is - 90 -  now parse the data.
Parser Entered
totalSize of data : 16
SN : 11111

PN : 55555
Done, got all the datas.
Checksum calculated and Checksum from vpd matched.


Change-Id: Id37fd0363cd2113e6915b04464d74263e8f6d808