### PR TITLE
Update instantiation of concrete Parser classes

### DIFF
--- a/include/ipz_parser.hpp
+++ b/include/ipz_parser.hpp
@@ -29,16 +29,14 @@ class IpzVpdParser : public ParserInterface
      * @brief Constructor.
      *
      * @param[in] vpdVector - VPD data.
-     * @param[in] inventoryPath - D-Bus path of the FRU.
-     * @param[in] vpdFilePath - VPD file path.
-     * @param[in] offset - Offset to the start of VPD in the file.
+     * @param[in] vpdFilePath - Path to VPD EEPROM.
+     * @param[in] vpdStartOffset - Offset from where VPD starts in the file.
+     * Defaulted to 0.
      */
     IpzVpdParser(const types::BinaryVector& vpdVector,
-                 const std::string& inventoryPath,
-                 const std::string& vpdFilePath, uint32_t offset) :
+                 const std::string& vpdFilePath, size_t vpdStartOffset = 0) :
         m_vpdVector(vpdVector),
-        m_inventoryPath(inventoryPath), m_vpdFilePath(vpdFilePath),
-        m_vpdStartOffset(offset)
+        m_vpdFilePath(vpdFilePath), m_vpdStartOffset(vpdStartOffset)
     {
         try
         {
@@ -149,19 +147,16 @@ class IpzVpdParser : public ParserInterface
     // Holds VPD data.
     const types::BinaryVector& m_vpdVector;
 
-    // Holds inventory path of the FRU.
-    const std::string& m_inventoryPath;
-
-    // Holds VPD EEPROM path
-    const std::string& m_vpdFilePath;
-
     // stores parsed VPD data.
     types::IPZVpdMap m_parsedVPDMap{};
 
-    // File stream to VPD file
+    // Holds the VPD file path
+    const std::string& m_vpdFilePath;
+
+    // Stream to the VPD file. Required to correct ECC
     std::fstream m_vpdFileStream;
 
-    // Offset to VPD.
-    uint32_t m_vpdStartOffset = 0;
+    // VPD start offset. Required for ECC correction.
+    size_t m_vpdStartOffset = 0;
 };
 } // namespace vpd

--- a/include/parser_factory.hpp
+++ b/include/parser_factory.hpp
@@ -34,8 +34,6 @@ class ParserFactory
      * unknown type. Caller responsibility to handle the exception.
      *
      * @param[in] vpdVector - vpd file content to check for the type.
-     * @param[in] inventoryPath - InventoryPath to call out FRU in case PEL is
-     * logged by concrere parser class.
      * @param[in] vpdFilePath - FRU EEPROM path.
      * @param[in] vpdStartOffset - Offset from where VPD starts in the VPD file.
      *
@@ -43,7 +41,6 @@ class ParserFactory
      */
     static std::shared_ptr<ParserInterface>
         getParser(const types::BinaryVector& vpdVector,
-                  const std::string& inventoryPath,
-                  const std::string& vpdFilePath, uint32_t vpdStartOffset);
+                  const std::string& vpdFilePath, size_t vpdStartOffset);
 };
 } // namespace vpd

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <source_location>
 #include <span>
 #include <string_view>
@@ -234,6 +235,31 @@ constexpr auto toHex(size_t aByte)
     constexpr auto map = "0123456789abcdef";
     return map[aByte];
 }
+
+/**
+ * @brief An API to get VPD in a vector.
+ *
+ * The vector is required by the respective parser to fill the VPD map.
+ * Note: API throws exception in case of failure. Caller needs to handle.
+ *
+ * @param[in] vpdFileStream - File stream to read VPDfrom path.
+ * @param[in] vpdFilePath - EEPROM path of the FRU.
+ * @param[out] vpdVector - VPD in vector form.
+ * @param[in] vpdStartOffset - Offset of VPD data in EEPROM.
+ */
+void getVpdDataInVector(std::fstream& vpdFileStream,
+                        const std::string& vpdFilePath,
+                        types::BinaryVector& vpdVector, size_t& vpdStartOffset);
+
+/**
+ * @brief API to read VPD offset from json file.
+ *
+ * @param[in] parsedJson - Parsed JSON file for the system.
+ * @param[in] vpdFilePath - path to the VPD file.
+ * @return Offset of VPD in VPD file.
+ */
+size_t getVPDOffset(const nlohmann::json& parsedJson,
+                    const std::string& vpdFilePath);
 
 } // namespace utils
 } // namespace vpd

--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -114,20 +114,6 @@ class Worker
                     types::VPDMapVariant& parsedVpd);
 
     /**
-     * @brief An API to get VPD in a vector.
-     *
-     * The vector is required by the respective parser to fill the VPD map.
-     * Note: API throws exception in case of failure. Caller needs to handle.
-     *
-     * @param[in] vpdFilePath - EEPROM path of the FRU.
-     * @param[out] vpdVector - VPD in vector form.
-     * @param[in] vpdStartOffset - Offset of VPD data in EEPROM.
-     */
-    void getVpdDataInVector(const std::string& vpdFilePath,
-                            types::BinaryVector& vpdVector,
-                            size_t& vpdStartOffset);
-
-    /**
      * @brief AN API to populate DBus interfaces for a FRU.
      *
      * @param[in] parsedVpdMap - Parsed VPD as a map.

--- a/src/ipz_parser.cpp
+++ b/src/ipz_parser.cpp
@@ -1,9 +1,12 @@
+#include "config.h"
+
 #include "ipz_parser.hpp"
 
 #include "constants.hpp"
 #include "exceptions.hpp"
 #include "utils.hpp"
 
+#include <nlohmann/json.hpp>
 #include <typeindex>
 
 #include "vpdecc/vpdecc.h"
@@ -606,52 +609,8 @@ types::VPDMapVariant IpzVpdParser::parse()
     }
     catch (const std::exception& e)
     {
-        if (typeid(e) == std::type_index(typeid(DataException)))
-        {
-            // TODO: Do what needs to be done in case of Data exception.
-            // Uncomment when PEL implementation goes in.
-            /* string errorMsg =
-                 "VPD file is either empty or invalid. Parser failed for [";
-             errorMsg += m_vpdFilePath;
-             errorMsg += "], with error = " + std::string(ex.what());
-
-             additionalData.emplace("DESCRIPTION", errorMsg);
-             additionalData.emplace("CALLOUT_INVENTORY_PATH",
-                                    INVENTORY_PATH + baseFruInventoryPath);
-             createPEL(additionalData, pelSeverity, errIntfForInvalidVPD,
-             nullptr);*/
-
-            // throw generic error from here to inform main caller about
-            // failure.
-            logging::logMessage(e.what());
-            throw std::runtime_error("Data Exception in IPZ parser for file " +
-                                     m_vpdFilePath);
-        }
-
-        if (typeid(e) == std::type_index(typeid(EccException)))
-        {
-            // TODO: Do what needs to be done in case of ECC exception.
-            // Uncomment when PEL implementation goes in.
-            /* additionalData.emplace("DESCRIPTION", "ECC check failed");
-             additionalData.emplace("CALLOUT_INVENTORY_PATH",
-                                    INVENTORY_PATH + baseFruInventoryPath);
-             createPEL(additionalData, pelSeverity, errIntfForEccCheckFail,
-                       nullptr);
-             */
-
-            logging::logMessage(e.what());
-            utils::dumpBadVpd(m_vpdFilePath, m_vpdVector);
-
-            // throw generic error from here to inform main caller about
-            // failure.
-            throw std::runtime_error("Ecc Exception in IPZ parser for file " +
-                                     m_vpdFilePath);
-        }
-
         logging::logMessage(e.what());
-        throw std::runtime_error(
-            "Generic exception occured in IPZ parser for file " +
-            m_vpdFilePath);
+        throw e;
     }
 }
 

--- a/src/parser_factory.cpp
+++ b/src/parser_factory.cpp
@@ -84,9 +84,10 @@ static vpdType vpdTypeCheck(const types::BinaryVector& vpdVector)
     return vpdType::INVALID_VPD_FORMAT;
 }
 
-std::shared_ptr<ParserInterface> ParserFactory::getParser(
-    const types::BinaryVector& vpdVector, const std::string& inventoryPath,
-    const std::string& vpdFilePath, uint32_t vpdStartOffset)
+std::shared_ptr<ParserInterface>
+    ParserFactory::getParser(const types::BinaryVector& vpdVector,
+                             const std::string& vpdFilePath,
+                             size_t vpdStartOffset)
 {
     if (vpdVector.empty())
     {
@@ -99,8 +100,8 @@ std::shared_ptr<ParserInterface> ParserFactory::getParser(
     {
         case vpdType::IPZ_VPD:
         {
-            return std::make_shared<IpzVpdParser>(vpdVector, inventoryPath,
-                                                  vpdFilePath, vpdStartOffset);
+            return std::make_shared<IpzVpdParser>(vpdVector, vpdFilePath,
+                                                  vpdStartOffset);
         }
 
         case vpdType::KEYWORD_VPD:


### PR DESCRIPTION
Parser factory is not required to be dependent on any other data other than vpd type to decide which parser needs to be instantiated.
Also input to concrete parser need not be any thing else than VPD vector as the responsibility of parser class should be limited to parsing VPD.
VPD file path is required in case of IPZ parser to support ECC correction during the process of parsing VPD.