### PR TITLE
Set timer to detect system VPD collection

### DIFF
--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -32,7 +32,7 @@ class Manager
      */
     Manager(const std::shared_ptr<boost::asio::io_context>& ioCon,
             const std::shared_ptr<sdbusplus::asio::dbus_interface>& iFace,
-            const std::shared_ptr<sdbusplus::asio::connection>& conn);
+            const std::shared_ptr<sdbusplus::asio::connection>& asioConnection);
 
     /**
      * @brief Destructor.
@@ -40,6 +40,21 @@ class Manager
     ~Manager() = default;
 
   private:
+#ifdef IBM_SYSTEM
+    /**
+     * @brief API to set timer to detect system VPD over D-Bus.
+     *
+     * System VPD is required before bus name for VPD-Manager is claimed. Once
+     * system VPD is published, VPD for other FRUs should be collected. This API
+     * detects id system VPD is already published on D-Bus and based on that
+     * triggers VPD collection for rest of the FRUs.
+     *
+     * Note: Throws exception in case of any failure. Needs to be handled by the
+     * caller.
+     */
+    void setTimerForSystemVPDDetection();
+#endif
+
     // Shared pointer to asio context object.
     const std::shared_ptr<boost::asio::io_context>& m_ioContext;
 
@@ -47,7 +62,7 @@ class Manager
     const std::shared_ptr<sdbusplus::asio::dbus_interface>& m_interface;
 
     // Shared pointer to bus connection.
-    const std::shared_ptr<sdbusplus::asio::connection>& m_conn;
+    const std::shared_ptr<sdbusplus::asio::connection>& m_asioConnection;
 
     // Shared pointer to worker class
     std::shared_ptr<Worker> m_worker;

--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -61,6 +61,13 @@ class Worker
      */
     void processAllFRU();
 
+    /**
+     * @brief An API to check if system VPD is already published.
+     *
+     * @return Status, true if system is already collected else false.
+     */
+    bool isSystemVPDOnDBus() const;
+
   private:
     /**
      * @brief An API to set appropriate device tree and JSON.
@@ -264,11 +271,6 @@ class Worker
      */
     void primeInventory(const types::IPZVpdMap& ipzVpdMap,
                         types::ObjectMap primeObjects);
-
-    /**
-     * @brief An API to check if system VPD is already published.
-     */
-    bool isSystemVPDOnDBus() const;
 
     // Parsed JSON file.
     nlohmann::json m_parsedJson{};

--- a/meson.build
+++ b/meson.build
@@ -100,7 +100,7 @@ parser_dependencies = [sdbusplus]
 
 parser_build_arguments = []
 if get_option('ibm_system').enabled()
-    parser_build_arguments += ['-IBM_SYSTEM']
+    parser_build_arguments += ['-DIBM_SYSTEM']
 endif
 
 if get_option('use_json').enabled()

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1,14 +1,19 @@
+#include "config.h"
+
 #include "manager.hpp"
 
 #include "logger.hpp"
 
+#include <boost/asio/steady_timer.hpp>
+
 namespace vpd
 {
-Manager::Manager(const std::shared_ptr<boost::asio::io_context>& ioCon,
-                 const std::shared_ptr<sdbusplus::asio::dbus_interface>& iFace,
-                 const std::shared_ptr<sdbusplus::asio::connection>& conn) :
+Manager::Manager(
+    const std::shared_ptr<boost::asio::io_context>& ioCon,
+    const std::shared_ptr<sdbusplus::asio::dbus_interface>& iFace,
+    const std::shared_ptr<sdbusplus::asio::connection>& asioConnection) :
     m_ioContext(ioCon),
-    m_interface(iFace), m_conn(conn)
+    m_interface(iFace), m_asioConnection(asioConnection)
 {
     try
     {
@@ -17,7 +22,11 @@ Manager::Manager(const std::shared_ptr<boost::asio::io_context>& ioCon,
 
         // Set up minimal things that is needed before bus name is claimed.
         m_worker->performInitialSetup();
+
+        // set async timer to detect if system VPD is published on D-Bus.
+        SetTimerToDetectSVPDOnDbus();
 #endif
+        // TBD: register interface(s) for exposed APIs here.
     }
     catch (const std::exception& e)
     {
@@ -25,4 +34,38 @@ Manager::Manager(const std::shared_ptr<boost::asio::io_context>& ioCon,
         throw;
     }
 }
+
+#ifdef IBM_SYSTEM
+void Manager::SetTimerToDetectSVPDOnDbus()
+{
+    static boost::asio::steady_timer timer(*m_ioContext);
+
+    // timer for 2 seconds
+    auto asyncCancelled = timer.expires_after(std::chrono::seconds(2));
+
+    (asyncCancelled == 0) ? std::cout << "Timer started" << std::endl
+                          : std::cout << "Timer re-started" << std::endl;
+
+    timer.async_wait([this](const boost::system::error_code& ec) {
+        if (ec == boost::asio::error::operation_aborted)
+        {
+            throw std::runtime_error(
+                "Timer to detect system VPD collection status was aborted");
+        }
+
+        if (ec)
+        {
+            throw std::runtime_error(
+                "Timer to detect System VPD collection failed");
+        }
+
+        if (m_worker->isSystemVPDOnDBus())
+        {
+            // cancel the timer
+            timer.cancel();
+            m_worker->processAllFRU();
+        }
+    });
+}
+#endif
 } // namespace vpd


### PR DESCRIPTION
FRU VPD collection needs to be triggered only once system VPD has been collected.
Also, manager service cannot be blocked until all the FRU VPD has been collected. So, an async timer has been implemented to revisit at timer expiration, to check if system VPD is available on D-Bus and FRU VPD collection is triggered accordingly.