### PR TITLE
DDIMM parser class implementation

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -19,6 +19,10 @@ static constexpr uint8_t KW_VAL_PAIR_END_TAG = 0x79;
 static constexpr auto MEMORY_VPD_DATA_START = 416;
 static constexpr auto MEMORY_VPD_START_TAG = "11S";
 static constexpr auto FORMAT_11S_LEN = 3;
+static constexpr auto PART_NUM_LEN = 7;
+static constexpr auto SERIAL_NUM_LEN = 12;
+static constexpr auto CCIN_LEN = 4;
+static constexpr auto CONVERT_MB_TO_KB = 1024;
 
 static constexpr auto SPD_BYTE_2 = 2;
 static constexpr auto SPD_BYTE_3 = 3;
@@ -26,11 +30,14 @@ static constexpr auto SPD_BYTE_4 = 4;
 static constexpr auto SPD_BYTE_6 = 6;
 static constexpr auto SPD_BYTE_12 = 12;
 static constexpr auto SPD_BYTE_13 = 13;
+static constexpr auto SPD_BYTE_234 = 234;
+static constexpr auto SPD_BYTE_235 = 235;
 static constexpr auto SPD_BYTE_BIT_0_3_MASK = 0x0F;
 static constexpr auto SPD_BYTE_MASK = 0xFF;
 static constexpr auto SPD_MODULE_TYPE_DDIMM = 0x0A;
 static constexpr auto SPD_DRAM_TYPE_DDR5 = 0x12;
 static constexpr auto SPD_DRAM_TYPE_DDR4 = 0x0C;
+
 static constexpr auto LAST_KW = "PF";
 static constexpr auto POUND_KW = '#';
 static constexpr auto MB_YEAR_END = 4;
@@ -48,6 +55,26 @@ static constexpr auto UUID_CLK_SEQ_END = 23;
 static constexpr auto MAC_ADDRESS_LEN_BYTES = 6;
 static constexpr auto ONE_BYTE = 1;
 static constexpr auto TWO_BYTES = 2;
+
+static constexpr auto VALUE_0 = 0;
+static constexpr auto VALUE_1 = 1;
+static constexpr auto VALUE_2 = 2;
+static constexpr auto VALUE_3 = 3;
+static constexpr auto VALUE_4 = 4;
+static constexpr auto VALUE_5 = 5;
+static constexpr auto VALUE_6 = 6;
+static constexpr auto VALUE_7 = 7;
+static constexpr auto VALUE_8 = 8;
+
+static constexpr auto MASK_BYTE_BITS_01 = 0x03;
+static constexpr auto MASK_BYTE_BITS_345 = 0x38;
+static constexpr auto MASK_BYTE_BITS_012 = 0x07;
+static constexpr auto MASK_BYTE_BITS_567 = 0xE0;
+static constexpr auto MASK_BYTE_BITS_01234 = 0x1F;
+
+static constexpr auto SHIFT_BITS_0 = 0;
+static constexpr auto SHIFT_BITS_3 = 3;
+static constexpr auto SHIFT_BITS_5 = 5;
 
 constexpr auto pimPath = "/xyz/openbmc_project/inventory";
 constexpr auto pimIntf = "xyz.openbmc_project.Inventory.Manager";

--- a/include/ddimm_parser.hpp
+++ b/include/ddimm_parser.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "logger.hpp"
+#include "parser_interface.hpp"
+#include "types.hpp"
+
+namespace vpd
+{
+/**
+ * @brief Concrete class to implement DDIMM VPD parsing.
+ *
+ * The class inherits ParserInterface interface class and overrides the parser
+ * functionality to implement parsing logic for DDIMM VPD format.
+ */
+class DdimmVpdParser : public ParserInterface
+{
+  public:
+    // Deleted API's
+    DdimmVpdParser() = delete;
+    DdimmVpdParser(const DdimmVpdParser&) = delete;
+    DdimmVpdParser& operator=(const DdimmVpdParser&) = delete;
+    DdimmVpdParser(DdimmVpdParser&&) = delete;
+    DdimmVpdParser& operator=(DdimmVpdParser&&) = delete;
+
+    /**
+     * @brief Defaul destructor.
+     */
+    ~DdimmVpdParser() = default;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] vpdVector - VPD data.
+     */
+    DdimmVpdParser(const types::BinaryVector& vpdVector) : m_vpdVector(vpdVector) {}
+
+    /**
+     * @brief Api to parse DDIMM VPD file.
+     *
+     * @return parsed VPD data
+     */
+    virtual types::VPDMapVariant parse() override;
+
+  private:
+    /**
+     * @brief Api to read keyword data based on the type DDR4/DDR5.
+     *
+     * @return keyword data, empty otherwise.
+     */
+    types::DdimmVpdMap readKeywords(types::BinaryVector::const_iterator iterator);
+
+    /**
+     * @brief Api to calculate dimm size from DDIMM VPD
+     *
+     * @param[in] iterator - iterator to buffer containing VPD
+     * @return calculated data or 0 in case of any error.
+     */
+    size_t getDDimmSize(types::BinaryVector::const_iterator iterator);
+
+    /**
+     * @brief This function calculates DDR5 based DDIMM's capacity
+     *
+     * @param[in] iterator - iterator to buffer containing VPD
+     * @return calculated data or 0 in case of any error.
+     */
+    auto getDdr5BasedDDimmSize(types::BinaryVector::const_iterator iterator);
+
+    /**
+     * @brief This function calculates DDR5 based die per package
+     *
+     * @param[in] l_ByteValue - the bit value for calculation
+     * @return die per package value.
+     */
+    uint8_t getDDR5DiePerPackage(uint8_t l_ByteValue);
+
+    /**
+     * @brief This function calculates DDR5 based density per die
+     *
+     * @param[in] l_ByteValue - the bit value for calculation
+     * @return density per die.
+     */
+    uint8_t getDDR5DensityPerDie(uint8_t l_ByteValue);
+
+    /**
+     * @brief This function checks the validity of the bits
+     *
+     * @param[in] l_ByteValue - the byte value with relevant bits
+     * @param[in] shift - shifter value to selects needed bits
+     * @param[in] minValue - minimum value it can contain
+     * @param[in] maxValue - maximum value it can contain
+     * @return true if valid else false.
+     */
+    bool checkValidValue(uint8_t l_ByteValue, uint8_t shift, uint8_t minValue,
+                         uint8_t maxValue);
+
+    // vdp file to be parsed
+    const types::BinaryVector& m_vpdVector;
+};
+} // namespace vpd

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -57,6 +57,13 @@ using KeywordVpdMap = std::unordered_map<std::string, KWdVPDValueType>;
 */
 using VPDKWdValueMap = std::variant<IPZKwdValueMap, KeywordVpdMap>;
 
+
+/* Value types supported by DDIMM VPD*/
+using DdimmVPDValueType = std::variant<BinaryVector,std::string, size_t>;
+/* This hold map of parsed data of DDIMM VPD type*/
+using DdimmVpdMap = std::unordered_map<std::string, DdimmVPDValueType>;
+
+
 /* Map<Property, Value>*/
 using PropertyMap = std::map<std::string, DbusVariantType>;
 /* Map<Interface<Property, Value>>*/
@@ -75,7 +82,7 @@ using PoundKwSize = uint16_t;
 
 using RecordOffsetList = std::vector<uint32_t>;
 
-using VPDMapVariant = std::variant<IPZVpdMap, KeywordVpdMap>;
+using VPDMapVariant = std::variant<IPZVpdMap, KeywordVpdMap, DdimmVpdMap>;
 
 using HWVerList = std::vector<std::pair<std::string, std::string>>;
 /**

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ common_SOURCES = ['src/logger.cpp',
                   'src/parser_factory.cpp',
                   'src/ipz_parser.cpp',
                   'src/keyword_vpd_parser.cpp',
+                  'src/ddimm_parser.cpp',
                   'src/parser.cpp',
                   'src/worker.cpp']
 

--- a/src/ddimm_parser.cpp
+++ b/src/ddimm_parser.cpp
@@ -1,0 +1,248 @@
+#include "ddimm_parser.hpp"
+#include "exceptions.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <numeric>
+#include <string>
+
+namespace vpd
+{
+
+static constexpr auto SDRAM_DENSITY_PER_DIE_24GB = 24;
+static constexpr auto SDRAM_DENSITY_PER_DIE_32GB = 32;
+static constexpr auto SDRAM_DENSITY_PER_DIE_48GB = 48;
+static constexpr auto SDRAM_DENSITY_PER_DIE_64GB = 64;
+static constexpr auto SDRAM_DENSITY_PER_DIE_UNDEFINED = 0;
+
+static constexpr auto PRIMARY_BUS_WIDTH_32_BITS = 32;
+static constexpr auto PRIMARY_BUS_WIDTH_UNUSED = 0;
+
+bool DdimmVpdParser::checkValidValue(uint8_t l_ByteValue, uint8_t shift,
+                                      uint8_t minValue, uint8_t maxValue)
+{
+    l_ByteValue = l_ByteValue >> shift;
+    if ((l_ByteValue > maxValue) || (l_ByteValue < minValue))
+    {
+        logging::logMessage("Non valid Value encountered value[" + l_ByteValue
+                            + "] range [" + minValue + ".." + maxValue + "] found ");
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+uint8_t DdimmVpdParser::getDDR5DensityPerDie(uint8_t l_ByteValue)
+{
+    uint8_t l_densityPerDie = SDRAM_DENSITY_PER_DIE_UNDEFINED;
+    if (l_ByteValue < constants::VALUE_5)
+    {
+        l_densityPerDie = l_ByteValue * constants::VALUE_4;
+    }
+    else
+    {
+        switch (l_ByteValue)
+        {
+            case VALUE_5:
+                l_densityPerDie = SDRAM_DENSITY_PER_DIE_24GB;
+                break;
+
+            case VALUE_6:
+                l_densityPerDie = SDRAM_DENSITY_PER_DIE_32GB;
+                break;
+
+            case VALUE_7:
+                l_densityPerDie = SDRAM_DENSITY_PER_DIE_48GB;
+                break;
+
+            case VALUE_8:
+                l_densityPerDie = SDRAM_DENSITY_PER_DIE_64GB;
+                break;
+
+            default:
+                logging::logMessage("default value encountered for density per die");
+                l_densityPerDie = SDRAM_DENSITY_PER_DIE_UNDEFINED;
+                break;
+        }
+    }
+    return l_densityPerDie;
+}
+
+uint8_t DdimmVpdParser::getDDR5DiePerPackage(uint8_t l_ByteValue)
+{
+    uint8_t l_DiePerPackage = constants::VALUE_0;
+    if (l_ByteValue < constants::VALUE_2)
+    {
+        l_DiePerPackage = l_ByteValue + constants::VALUE_1;
+    }
+    else
+    {
+        l_DiePerPackage = pow(constants::VALUE_2,
+                              (l_ByteValue - constants::VALUE_1));
+    }
+    return l_DiePerPackage;
+}
+
+auto DdimmVpdParser::getDdr5BasedDDimmSize(BinaryVector::const_iterator iterator)
+{
+    size_t dimmSize = 0;
+
+    do
+    {
+        if (!checkValidValue(iterator[constants::SPD_BYTE_235] &
+                                 constants::MASK_BYTE_BITS_01,
+                             constants::SHIFT_BITS_0, constants::VALUE_1,
+                             constants::VALUE_3) ||
+            !checkValidValue(iterator[constants::SPD_BYTE_235] &
+                                 constants::MASK_BYTE_BITS_345,
+                             constants::SHIFT_BITS_3, constants::VALUE_1,
+                             constants::VALUE_3))
+        {
+            logging::logMessage("Capacity calculation failed for channels per DIMM. DDIMM Byte 235 value [" +
+                                 iterator[constants::SPD_BYTE_235] + "]");
+            break;
+        }
+        uint8_t l_channelsPerDDimm =
+            (((iterator[constants::SPD_BYTE_235] & constants::MASK_BYTE_BITS_01)
+                  ? constants::VALUE_1
+                  : constants::VALUE_0) +
+             ((iterator[constants::SPD_BYTE_235] &
+               constants::MASK_BYTE_BITS_345)
+                  ? constants::VALUE_1
+                  : constants::VALUE_0));
+
+        if (!checkValidValue(iterator[constants::SPD_BYTE_235] &
+                                 constants::MASK_BYTE_BITS_012,
+                             constants::SHIFT_BITS_0, constants::VALUE_1,
+                             constants::VALUE_3))
+        {
+           logging::logMessage("Capacity calculation failed for bus width per channel. DDIMM Byte 235 value [" +
+                                iterator[constants::SPD_BYTE_235] + "]");
+            break;
+        }
+        uint8_t l_busWidthPerChannel =
+            (iterator[constants::SPD_BYTE_235] & constants::MASK_BYTE_BITS_012)
+                ? PRIMARY_BUS_WIDTH_32_BITS
+                : PRIMARY_BUS_WIDTH_UNUSED;
+
+        if (!checkValidValue(iterator[constants::SPD_BYTE_4] &
+                                 constants::MASK_BYTE_BITS_567,
+                             constants::SHIFT_BITS_5, constants::VALUE_0,
+                             constants::VALUE_5))
+        {
+            logging::logMessage("Capacity calculation failed for die per package. DDIMM Byte 4 value [" +
+                                iterator[constants::SPD_BYTE_4] + "]");
+            break;
+        }
+        uint8_t l_diePerPackage = getDDR5DiePerPackage(
+            (iterator[constants::SPD_BYTE_4] & constants::MASK_BYTE_BITS_567) >>
+            constants::VALUE_5);
+
+        if (!checkValidValue(iterator[constants::SPD_BYTE_4] &
+                                 constants::MASK_BYTE_BITS_01234,
+                             constants::SHIFT_BITS_0, constants::VALUE_1,
+                             constants::VALUE_8))
+        {
+            logging::logMessage("Capacity calculation failed for SDRAM Density per Die. DDIMM Byte 4 value [" +
+                                 iterator[constants::SPD_BYTE_4] + "]");
+            break;
+        }
+        uint8_t l_densityPerDie = getDDR5DensityPerDie(
+            iterator[constants::SPD_BYTE_4] & constants::MASK_BYTE_BITS_01234);
+
+        uint8_t l_ranksPerChannel = ((iterator[constants::SPD_BYTE_234] &
+                                      constants::MASK_BYTE_BITS_345) >>
+                                     constants::VALUE_3) +
+                                    (iterator[constants::SPD_BYTE_234] &
+                                     constants::MASK_BYTE_BITS_012) +
+                                    constants::VALUE_2;
+
+        if (!checkValidValue(iterator[constants::SPD_BYTE_6] &
+                                 constants::MASK_BYTE_BITS_567,
+                             constants::SHIFT_BITS_5, constants::VALUE_0,
+                             constants::VALUE_3))
+        {
+            logging::logMessage("Capacity calculation failed for dram width DDIMM Byte 6 value [" +
+                                 iterator[constants::SPD_BYTE_6] + "]");
+            break;
+        }
+        uint8_t l_dramWidth = VALUE_4 *
+                              (VALUE_1 << ((iterator[constants::SPD_BYTE_6] &
+                                            constants::MASK_BYTE_BITS_567) >>
+                                           constants::VALUE_5));
+
+        dimmSize = (l_channelsPerDDimm * l_busWidthPerChannel *
+                    l_diePerPackage * l_densityPerDie * l_ranksPerChannel) /
+                   (8 * l_dramWidth);
+
+    } while (false);
+
+    return constants::CONVERT_MB_TO_KB * dimmSize;
+}
+
+size_t DdimmVpdParser::getDDimmSize(BinaryVector::const_iterator iterator)
+{
+    size_t dimmSize = 0;
+    if ((iterator[constants::SPD_BYTE_2] & constants::SPD_BYTE_MASK) ==
+             constants::SPD_DRAM_TYPE_DDR5)
+    {
+        dimmSize = getDdr5BasedDDimmSize(iterator);
+    }
+    else
+    {
+        logging::logMessage("Error: DDIMM is neither DDR4 nor DDR5. DDIMM Byte 2 value [" +
+                            iterator[constants::SPD_BYTE_2] + "]");
+    }
+    return dimmSize;
+}
+
+types::DdimmVpdMap DdimmVpdParser::readKeywords(BinaryVector::const_iterator iterator)
+{
+    types::DdimmVpdMap kwdValueMap{};
+
+    // collect Dimm size value
+    auto dimmSize = getDDimmSize(iterator);
+    if (!dimmSize)
+    {
+        throw(DataException("Error: Calculated dimm size is 0."));
+    }
+
+    kwdValueMap.emplace("MemorySizeInKB", dimmSize);
+    // point the iterator to DIMM data and skip "11S"
+    advance(iterator, MEMORY_VPD_DATA_START + 3);
+    BinaryVector partNumber(iterator, iterator + PART_NUM_LEN);
+
+    advance(iterator, PART_NUM_LEN);
+    BinaryVector serialNumber(iterator, iterator + SERIAL_NUM_LEN);
+
+    advance(iterator, SERIAL_NUM_LEN);
+    BinaryVector ccin(iterator, iterator + CCIN_LEN);
+
+    kwdValueMap.emplace("FN", partNumber);
+    kwdValueMap.emplace("PN", move(partNumber));
+    kwdValueMap.emplace("SN", move(serialNumber));
+    kwdValueMap.emplace("CC", move(ccin));
+
+    return kwdValueMap;
+}
+
+types::VPDMapVariant DdimmVpdParser::parse()
+{
+    try{
+        // Read the data and return the map
+        auto iterator = m_vpdVector.cbegin();
+        auto vpdDataMap = readKeywords(iterator);
+
+        return vpdDataMap;
+    }
+    catch (const std::exception& e)
+    {
+        logging::logMessage(e.what());
+        throw e;
+    }
+}
+
+} // namespace vpd

--- a/src/parser_factory.cpp
+++ b/src/parser_factory.cpp
@@ -4,6 +4,7 @@
 #include "exceptions.hpp"
 #include "ipz_parser.hpp"
 #include "keyword_vpd_parser.hpp"
+#include "ddimm_parser.hpp"
 
 namespace vpd
 {
@@ -113,11 +114,11 @@ std::shared_ptr<ParserInterface>
             return std::make_shared<KeywordVpdParser>(vpdVector);
         }
 
-        case vpdType::DDR4_DDIMM_MEMORY_VPD:
         case vpdType::DDR5_DDIMM_MEMORY_VPD:
         {
-            // TODO:
-            // return shared pointer to class object.
+            std::cout << "DDIMM parser selected for VPD file path " << vpdFilePath
+                      << std::endl;
+            return std::make_shared<DdimmVpdParser>(vpdVector);
         }
 
         case vpdType::DDR4_ISDIMM_MEMORY_VPD:


### PR DESCRIPTION
This commit implements concrete class to parse DDIMM VPD. Implemented only for DDR5 dims.