### PR TITLE
DDR5 DDIMM Capacity fix

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -75,6 +75,7 @@ static constexpr auto PART_NUM_LEN = 7;
 static constexpr auto SERIAL_NUM_LEN = 12;
 static constexpr auto CCIN_LEN = 4;
 static constexpr auto CONVERT_MB_TO_KB = 1024;
+static constexpr auto CONVERT_GB_TO_KB = 1024 * CONVERT_MB_TO_KB;
 
 static constexpr auto SPD_BYTE_2 = 2;
 static constexpr auto SPD_BYTE_3 = 3;

--- a/vpd-parser/memory_vpd_parser.cpp
+++ b/vpd-parser/memory_vpd_parser.cpp
@@ -210,7 +210,7 @@ auto memoryVpdParser::getDdr5BasedDDimmSize(Binary::const_iterator iterator)
 
     } while (false);
 
-    return constants::CONVERT_MB_TO_KB * dimmSize;
+    return constants::CONVERT_GB_TO_KB * dimmSize;
 }
 
 auto memoryVpdParser::getDdr4BasedDDimmSize(Binary::const_iterator iterator)


### PR DESCRIPTION
Conversion of DDR5 DDIMM size from GB
to KB.

Change-Id: Ie68302c876e40b6379e42b5af911c0e127f34d1b