### PR TITLE
P11: Editor Class Support

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 namespace vpd
 {
@@ -86,6 +87,35 @@ static constexpr auto BD_YEAR_END = 4;
 static constexpr auto BD_MONTH_END = 7;
 static constexpr auto BD_DAY_END = 10;
 static constexpr auto BD_HOUR_END = 13;
+static constexpr auto POUND_KW_PREFIX = "PD_";
+static constexpr auto NUMERIC_KW_PREFIX = "N_";
+
+// Offset of different entries in VPD data.
+enum Offset
+{
+    VHDR = 17,
+    VHDR_TOC_ENTRY = 29,
+    VTOC_PTR = 35,
+    VTOC_REC_LEN = 37,
+    VTOC_ECC_OFF = 39,
+    VTOC_ECC_LEN = 41,
+    VTOC_DATA = 13,
+    VHDR_ECC = 0,
+    VHDR_RECORD = 11
+};
+
+// Length of some specific entries w.r.t VPD data.
+enum Length
+{
+    RECORD_NAME = 4,
+    KW_NAME = 2,
+    RECORD_OFFSET = 2,
+    RECORD_MIN = 44,
+    RECORD_LENGTH = 2,
+    RECORD_ECC_OFFSET = 2,
+    VHDR_ECC_LENGTH = 11,
+    VHDR_RECORD_LENGTH = 44
+}; // enum Length
 
 } // namespace constants
 } // namespace vpd

--- a/include/editor.hpp
+++ b/include/editor.hpp
@@ -1,0 +1,200 @@
+#pragma once
+
+#include "constants.hpp"
+#include "types.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cstddef>
+#include <fstream>
+
+namespace vpd
+{
+/* @brief Class to modify the VPD.
+ *
+ * It writes the new data to asked Record-Keyword, on hardware file path
+ * and on cache if required.
+ *
+ */
+class editor
+{
+  public:
+    editor() = delete;
+    editor(const editor&) = delete;
+    editor& operator=(const editor&) = delete;
+    editor(editor&&) = delete;
+    editor& operator=(editor&&) = delete;
+    ~editor() {}
+
+    /* @brief Construct editor class.
+     *
+     * param[in] path - vpd file path
+     * param[in] inventoryPath - objectPath
+     * param[in] data - new data to write
+     * param[in] keyword - keyword's name whose data going to update
+     * param[in] record - record's name containing this keyword
+     */
+
+    editor(const std::string& path,
+           const sdbusplus::message::object_path& inventoryPath,
+           const nlohmann::json& json, const types::BinaryVector& data,
+           const std::string& keyword, const std::string& record) :
+        m_vpdFilePath(path),
+        m_objPath(inventoryPath), m_jsonFile(json),
+        m_thisRecord(data, keyword, record){};
+
+    /* @brief API to modify VPD data.
+     *
+     * This API modifies the VPD's requested record-keyword with new data
+     * with help of helper functions.
+     *
+     * @param[in] isCacheUpdateRequired
+     */
+    void modifyVpd(const bool& isCacheUpdateRequired);
+
+  private:
+    /* @brief Get the 2 bytes data.
+     *
+     * @returns 2 Bytes value read.
+     */
+    types::LE2ByteData
+        get2BytesValue(types::BinaryVector::const_iterator iterator);
+
+    /* @brief ECC check for VHDR.
+     *
+     * It calls helper function to validate the ECC data at ECC offset for VHDR.
+     *
+     * @returns true if ECC check passes.
+     *          false if ECC check fails.
+     */
+    bool eccCheckForVHDR();
+
+    /* @brief Validates VHDR.
+     *
+     * It checks for 'VHDR' record name at defined byte to confirm it is
+     * VPD's header.
+     *
+     * @throw DataException - if VHDR record name not found OR ECC check fails.
+     */
+    void validateHeader();
+
+    /* @brief ECC check for VTOC.
+     *
+     * It calls helper function to validate the ECC data at ECC offset for VTOC.
+     *
+     * @returns true if ECC check passes.
+     *          false if ECC check fails.
+     */
+    bool eccCheckForVtoc();
+
+    /* @brief validates VTOC.
+     *
+     * It checks for 'VTOC' record name at defined byte to confirm it is
+     * VPD's TOC.
+     *
+     * @throw DataException - if VTOC record name not found OR ECC check fails.
+     */
+    void validateVtoc();
+
+    /* @brief process through VTOC.
+     *
+     * This API process through the VTOC and checks every Record's ECC
+     * Also, it looks for requested RECORD to modify, once found it collects
+     * all the required fields.
+     * RecordOffset
+     * RecordLength
+     * RecordEccOffset
+     * RecordECCLength
+     *
+     * @throw DataException- if data offset,length is not valid.
+     * @throw EccException - if ECC check fails.
+     */
+    void processVtoc();
+
+    /* @brief Get the Keyword information.
+     *
+     * This API goes through the Record and finds out requested Keyword offset
+     * and length.
+     *
+     * @throw DataException - if keyword not found
+     */
+    void getTheKwdOffsetAndLength();
+
+    /* @brief It writes the new data to the VPD.
+     *
+     * This API writes the new data to the VPD on HW.
+     */
+    void writeNewDataToVpd();
+
+    /* @brief Updates the New ECC as per New Data.
+     *
+     * @throw EccException - if ECC update fails.
+     */
+    void updateRecordEcc();
+
+    /* @brief Updates the Cache for the reqeusted record-keyword.
+     *
+     * Cache will be updated only when requested explicitly.
+     */
+    void updateCache();
+
+    /* @brief Updates EI for the reqeusted record-keyword.
+     *
+     * If requested keyword is part of ExtraInterfaces, need to update
+     * it there also.
+     */
+    void updateEI(const nlohmann::json& singleEEPROM,
+                  const std::string& objPath);
+
+    /* @brief Updates CI for the reqeusted record-keyword.
+     *
+     * If requested keyword is part of commonInterfaces, need to update
+     * it there also.
+     */
+    void updateCI(const std::string& objectPath);
+
+    // VPD file path on HW
+    const std::string m_vpdFilePath;
+
+    // FRU inventory path on d-bus
+    const std::string m_objPath{};
+
+    // stream to perform operation on file
+    std::fstream m_vpdFileStream;
+
+    // file to store parsed json
+    const nlohmann::json m_jsonFile;
+
+    // VPD start offset
+    size_t m_vpdStartOffset;
+
+    // VPD in vector of bytes
+    types::BinaryVector m_vpdBytes;
+
+    // structure to hold informations about VPD Record-keyword to update
+    struct dataModificationInfos
+    {
+        types::BinaryVector newData;
+        const std::string keywordName;
+        const std::string recordName;
+
+        types::EccOffset recordEccOffset;
+        types::RecordOffset recordOffset;
+        types::KwDataOffset kwdDataOffset;
+
+        size_t recordEccLength;
+        types::RecordLength recordDataLength;
+        types::KwSize kwdDataLength;
+
+        // Initialized constructor
+        dataModificationInfos(const types::BinaryVector& dataToWrite,
+                              const std::string& keyword,
+                              const std::string& record) :
+            newData(dataToWrite),
+            keywordName(keyword), recordName(record), recordEccOffset(0),
+            recordOffset(0), kwdDataOffset(0), recordEccLength(0),
+            recordDataLength(0), kwdDataLength(0)
+        {}
+    } m_thisRecord;
+};
+} // namespace vpd

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -72,14 +72,16 @@ using InterfaceMap = std::map<std::string, PropertyMap>;
 using ObjectMap = std::map<sdbusplus::message::object_path, InterfaceMap>;
 
 using KwSize = uint8_t;
+using KwDataOffset = uint16_t;
 using RecordId = uint8_t;
 using RecordSize = uint16_t;
 using RecordType = uint16_t;
 using RecordOffset = uint16_t;
 using RecordLength = uint16_t;
-using ECCOffset = uint16_t;
-using ECCLength = uint16_t;
+using EccOffset = uint16_t;
+using EccLength = uint16_t;
 using PoundKwSize = uint16_t;
+using LE2ByteData = uint16_t;
 
 using RecordOffsetList = std::vector<uint32_t>;
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -271,5 +271,17 @@ size_t getVPDOffset(const nlohmann::json& parsedJson,
  * @return Parsed JSON.
  */
 nlohmann::json getParsedJson(const std::string& pathToJson);
+
+/**
+ * @brief API to get D-bus name for the keyword
+ *
+ * Some of the VPD keywords has different name in PIM when compared with its
+ * name from hardware. This method returns the D-bus name for the given keyword.
+ *
+ * @param[in] keyword - Keyword name
+ * @return D-bus name for the keyword
+ */
+std::string getDbusNameForThisKw(const std::string& keyword);
+
 } // namespace utils
 } // namespace vpd

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,8 @@ common_SOURCES = ['src/logger.cpp',
                   'src/keyword_vpd_parser.cpp',
                   'src/ddimm_parser.cpp',
                   'src/parser.cpp',
-                  'src/worker.cpp']
+                  'src/worker.cpp',
+                  'src/editor.cpp']
 
 vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1,0 +1,555 @@
+#include "editor.hpp"
+
+#include "vpdecc/vpdecc.h"
+
+#include "exceptions.hpp"
+#include "logger.hpp"
+#include "utils.hpp"
+
+namespace vpd
+{
+using namespace types;
+using namespace constants;
+
+types::LE2ByteData editor::get2BytesValue(BinaryVector::const_iterator iterator)
+{
+    types::LE2ByteData lowByte = *iterator;
+    types::LE2ByteData highByte = *(iterator + 1);
+    lowByte |= (highByte << 8);
+
+    return lowByte;
+}
+
+static void enableRebootGuard()
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager", "StartUnit");
+        method.append("reboot-guard-enable.service", "replace");
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::string errMsg =
+            "Bus call to enable BMC reboot failed for reason: ";
+        errMsg += e.what();
+
+        throw std::runtime_error(errMsg);
+    }
+}
+
+static void disableRebootGuard()
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager", "StartUnit");
+        method.append("reboot-guard-disable.service", "replace");
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::string errMsg =
+            "Bus call to disable BMC reboot failed for reason: ";
+        errMsg += e.what();
+
+        throw std::runtime_error(errMsg);
+    }
+}
+
+bool editor::eccCheckForVHDR()
+{
+    auto vpdPtr = m_vpdBytes.cbegin();
+
+    auto l_status =
+        vpdecc_check_data(const_cast<uint8_t*>(&vpdPtr[Offset::VHDR_RECORD]),
+                          Length::VHDR_RECORD_LENGTH,
+                          const_cast<uint8_t*>(&vpdPtr[Offset::VHDR_ECC]),
+                          Length::VHDR_ECC_LENGTH);
+    if (l_status == VPD_ECC_CORRECTABLE_DATA)
+    {
+        try
+        {
+            if (!m_vpdFileStream.is_open())
+            {
+                logging::logMessage("File not open");
+                return false;
+            }
+            m_vpdFileStream.seekp(m_vpdStartOffset + Offset::VHDR_RECORD,
+                                  std::ios::beg);
+            m_vpdFileStream.write(
+                reinterpret_cast<const char*>(&m_vpdBytes[Offset::VHDR_RECORD]),
+                Length::VHDR_RECORD_LENGTH);
+        }
+        catch (const std::fstream::failure& e)
+        {
+            logging::logMessage(
+                "Error while operating on file with exception: " +
+                std::string(e.what()));
+            return false;
+        }
+    }
+    else if (l_status != VPD_ECC_OK)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void editor::validateHeader()
+{
+    auto vpdItr = m_vpdBytes.cbegin();
+    std::advance(vpdItr, Offset::VHDR);
+    std::string recordName(vpdItr, vpdItr + Length::RECORD_NAME);
+    if (recordName.compare("VHDR"))
+        throw DataException("VHDR record not found");
+
+    // Check ECC
+    if (!eccCheckForVHDR())
+        throw EccException("ERROR: VHDR ECC check Failed");
+}
+
+bool editor::eccCheckForVtoc()
+{
+    auto vpdItr = m_vpdBytes.cbegin();
+    std::advance(vpdItr, Offset::VTOC_PTR);
+    auto vtocOffset = get2BytesValue(vpdItr);
+
+    std::advance(vpdItr, sizeof(RecordOffset));
+    auto vtocLength = get2BytesValue(vpdItr);
+
+    std::advance(vpdItr, sizeof(RecordLength));
+    auto vtocEccOffset = get2BytesValue(vpdItr);
+
+    std::advance(vpdItr, sizeof(EccOffset));
+    auto vtocEccLength = get2BytesValue(vpdItr);
+
+    vpdItr = m_vpdBytes.cbegin();
+    auto l_status = vpdecc_check_data(
+        const_cast<uint8_t*>(&vpdItr[vtocOffset]), vtocLength,
+        const_cast<uint8_t*>(&vpdItr[vtocEccOffset]), vtocEccLength);
+
+    if (l_status == VPD_ECC_CORRECTABLE_DATA)
+    {
+        try
+        {
+            if (!m_vpdFileStream.is_open())
+            {
+                logging::logMessage("File not open");
+                return false;
+            }
+            m_vpdFileStream.seekp(m_vpdStartOffset + vtocOffset, std::ios::beg);
+            m_vpdFileStream.write(
+                reinterpret_cast<const char*>(&m_vpdBytes[vtocOffset]),
+                vtocLength);
+        }
+        catch (const std::fstream::failure& e)
+        {
+            logging::logMessage(
+                "Error while operating on file with exception: " +
+                std::string(e.what()));
+            return false;
+        }
+    }
+    else if (l_status != VPD_ECC_OK)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void editor::validateVtoc()
+{
+    auto vpdItr = m_vpdBytes.cbegin();
+    std::advance(vpdItr, Offset::VTOC_PTR);
+    auto vtocOffset = get2BytesValue(vpdItr);
+
+    vpdItr = m_vpdBytes.cbegin();
+    std::advance(vpdItr, vtocOffset + sizeof(RecordId) + sizeof(RecordSize) +
+                             Length::KW_NAME + sizeof(KwSize));
+    std::string recordName(vpdItr, vpdItr + Length::RECORD_NAME);
+
+    if (recordName.compare("VTOC"))
+        throw DataException("VTOC record not found");
+
+    // Check ECC
+    if (!eccCheckForVtoc())
+        throw EccException("ERROR: VTOC ECC check Failed");
+}
+
+void editor::processVtoc()
+{
+    auto iterator = m_vpdBytes.cbegin();
+    std::advance(iterator, Offset::VTOC_PTR);
+    RecordOffset vtocOffset = get2BytesValue(iterator);
+
+    // jump to Length of PT kwd
+    iterator = m_vpdBytes.cbegin();
+    std::advance(iterator, vtocOffset + sizeof(RecordId) + sizeof(RecordSize) +
+                               Length::KW_NAME + sizeof(KwSize) +
+                               Length::RECORD_NAME + Length::KW_NAME);
+    uint8_t ptLength = *iterator;
+    std::advance(iterator, sizeof(KwSize));
+    auto end = std::next(iterator, ptLength);
+
+    // Look at each entry in the PT keyword for the record name
+    while (iterator < end)
+    {
+        std::string recordName(iterator, iterator + Length::RECORD_NAME);
+
+        std::advance(iterator, Length::RECORD_NAME + sizeof(RecordType));
+        auto recordOffset = get2BytesValue(iterator);
+
+        std::advance(iterator, Length::RECORD_OFFSET);
+        auto recordDataLength = get2BytesValue(iterator);
+
+        if (recordOffset == 0 || recordDataLength == 0)
+        {
+            throw(DataException("Invalid Record length or offset."));
+        }
+
+        std::advance(iterator, Length::RECORD_LENGTH);
+        auto recordEccOffset = get2BytesValue(iterator);
+
+        std::advance(iterator, Length::RECORD_ECC_OFFSET);
+        auto eccLength = get2BytesValue(iterator);
+
+        if (eccLength == 0 || recordEccOffset == 0)
+        {
+            throw(EccException("Invalid ECC length or offset."));
+        }
+
+        if (!recordName.compare(m_thisRecord.recordName))
+        {
+            m_thisRecord.recordOffset = recordOffset;
+            m_thisRecord.recordDataLength = recordDataLength;
+            m_thisRecord.recordEccOffset = recordEccOffset;
+            m_thisRecord.recordEccLength = eccLength;
+        }
+
+        auto vpdItr = m_vpdBytes.cbegin();
+        if (vpdecc_check_data(const_cast<uint8_t*>(&vpdItr[recordOffset]),
+                              recordDataLength,
+                              const_cast<uint8_t*>(&vpdItr[recordEccOffset]),
+                              eccLength) != VPD_ECC_OK)
+        {
+            throw EccException("Ecc check failed for record");
+        }
+
+        // Jump to next record
+        std::advance(iterator, sizeof(EccLength));
+    }
+
+    if (!m_thisRecord.recordOffset || !m_thisRecord.recordDataLength ||
+        !m_thisRecord.recordEccOffset || !m_thisRecord.recordEccLength)
+    {
+        throw DataException("Record Not found");
+    }
+}
+
+void editor::getTheKwdOffsetAndLength()
+{
+    constexpr auto skipBeg = sizeof(RecordId) + sizeof(RecordSize) +
+                             Length::KW_NAME + sizeof(KwSize) +
+                             Length::RECORD_NAME;
+
+    auto iterator = m_vpdBytes.cbegin();
+    std::advance(iterator, m_thisRecord.recordOffset + skipBeg);
+
+    auto end = iterator;
+    std::advance(end, m_thisRecord.recordDataLength);
+    std::size_t dataLength = 0;
+
+    while (iterator < end)
+    {
+        // Note keyword name
+        std::string thisKwName(iterator, iterator + Length::KW_NAME);
+
+        // Check if the Keyword starts with '#'
+        char kwNameStart = *iterator;
+        std::advance(iterator, Length::KW_NAME);
+
+        // if keyword starts with #
+        if (constants::POUND_KW == kwNameStart)
+        {
+            // Note existing keyword data length
+            dataLength = get2BytesValue(iterator);
+
+            // Jump past 2Byte keyword length + data
+            std::advance(iterator, sizeof(types::PoundKwSize));
+        }
+        else
+        {
+            // Note existing keyword data length
+            dataLength = *iterator;
+
+            // Jump past keyword length and data
+            std::advance(iterator, sizeof(KwSize));
+        }
+
+        if (m_thisRecord.keywordName == thisKwName)
+        {
+            m_thisRecord.kwdDataOffset = std::distance(m_vpdBytes.cbegin(),
+                                                       iterator);
+            m_thisRecord.kwdDataLength = dataLength;
+            return;
+        }
+
+        // jump the data of current kwd to point to next kwd name
+        std::advance(iterator, dataLength);
+    }
+
+    throw DataException("Keyword not found");
+}
+
+void editor::writeNewDataToVpd()
+{
+    auto dataLength = m_thisRecord.newData.size() <= m_thisRecord.kwdDataLength
+                          ? m_thisRecord.newData.size()
+                          : m_thisRecord.kwdDataLength;
+    auto dataStart = m_thisRecord.newData.cbegin();
+    auto dataEnd = dataStart;
+    std::advance(dataEnd, dataLength);
+
+    auto iteratoreToWriteToVpd = m_vpdBytes.begin();
+    std::advance(iteratoreToWriteToVpd, m_thisRecord.kwdDataOffset);
+
+    std::copy(dataStart, dataEnd, iteratoreToWriteToVpd);
+
+    m_vpdFileStream.seekp(m_vpdStartOffset + m_thisRecord.kwdDataOffset,
+                          std::ios::beg);
+
+    dataStart = m_thisRecord.newData.cbegin();
+    dataEnd = dataStart;
+    std::advance(dataEnd, dataLength);
+    std::copy(dataStart, dataEnd,
+              std::ostreambuf_iterator<char>(m_vpdFileStream));
+}
+
+void editor::updateRecordEcc()
+{
+    auto itrToRecordData = m_vpdBytes.cbegin();
+    std::advance(itrToRecordData, m_thisRecord.recordOffset);
+
+    auto itrToRecordEcc = m_vpdBytes.cbegin();
+    std::advance(itrToRecordEcc, m_thisRecord.recordEccOffset);
+
+    auto l_status = vpdecc_create_ecc(const_cast<uint8_t*>(&itrToRecordData[0]),
+                                      m_thisRecord.recordDataLength,
+                                      const_cast<uint8_t*>(&itrToRecordEcc[0]),
+                                      &m_thisRecord.recordEccLength);
+    if (l_status != VPD_ECC_OK)
+    {
+        throw EccException("Ecc update failed");
+    }
+
+    auto end = itrToRecordEcc;
+    std::advance(end, m_thisRecord.recordEccLength);
+
+    m_vpdFileStream.seekp(m_vpdStartOffset + m_thisRecord.recordEccOffset,
+                          std::ios::beg);
+    std::copy(itrToRecordEcc, end,
+              std::ostreambuf_iterator<char>(m_vpdFileStream));
+}
+
+void editor::updateCI(const std::string& objectPath)
+{
+    types::ObjectMap allObjects;
+    for (const auto& [interface, iFaceValue] :
+         m_jsonFile["commonInterfaces"].items())
+    {
+        for (const auto& [property, value] : iFaceValue.items())
+        {
+            if (value.type() != nlohmann::json::value_t::object)
+                continue;
+            if ((value.value("recordName", "") == m_thisRecord.recordName) &&
+                (value.value("keywordName", "") == m_thisRecord.keywordName))
+            {
+                types::PropertyMap propMap;
+                types::InterfaceMap interfaces;
+
+                std::string kwdData(m_thisRecord.newData.begin(),
+                                    m_thisRecord.newData.end());
+
+                propMap.emplace(property, std::move(kwdData));
+                interfaces.emplace(interface, std::move(propMap));
+                allObjects.emplace(objectPath, std::move(interfaces));
+            }
+        }
+    }
+    utils::callPIM(std::move(allObjects));
+}
+
+void editor::updateEI(const nlohmann::json& singleEEPROM,
+                      const std::string& objPath)
+{
+    types::ObjectMap allObjects;
+
+    for (const auto& [extraInterface, iFaceValue] :
+         singleEEPROM["extraInterfaces"].items())
+    {
+        if (iFaceValue == NULL)
+            continue;
+
+        for (const auto& [property, value] : iFaceValue.items())
+        {
+            if (value.type() != nlohmann::json::value_t::object)
+                continue;
+
+            if ((value.value("recordName", "") == m_thisRecord.recordName) &&
+                (value.value("keywordName", "") == m_thisRecord.keywordName))
+            {
+                types::PropertyMap propMap;
+                types::InterfaceMap interfaces;
+
+                std::string kwdData(m_thisRecord.newData.begin(),
+                                    m_thisRecord.newData.end());
+                utils::encodeKeyword(kwdData, value.value("encoding", ""));
+
+                propMap.emplace(property, std::move(kwdData));
+                interfaces.emplace(extraInterface, std::move(propMap));
+                allObjects.emplace(objPath, std::move(interfaces));
+            }
+        }
+    }
+    utils::callPIM(std::move(allObjects));
+}
+
+void editor::updateCache()
+{
+    if (!m_jsonFile["frus"].contains(m_vpdFilePath))
+    {
+        std::cerr << m_vpdFilePath << " not present in json file \n";
+        return;
+    }
+    const std::vector<nlohmann::json>& allEEPROMs =
+        m_jsonFile["frus"][m_vpdFilePath]
+            .get_ref<const nlohmann::json::array_t&>();
+
+    types::ObjectMap allObjects;
+
+    for (const auto& thisEEPROM : allEEPROMs)
+    {
+        types::PropertyMap properties;
+        types::InterfaceMap interfaces;
+
+        // by default inherit property is true
+        bool isInherit = true;
+        if (thisEEPROM.contains("inherit"))
+            isInherit = thisEEPROM["inherit"].get<bool>();
+
+        if (isInherit)
+        {
+            properties.emplace(
+                utils::getDbusNameForThisKw(m_thisRecord.keywordName),
+                m_thisRecord.newData);
+            interfaces.emplace(
+                (std::string{"com.ibm.ipzvpd."} + m_thisRecord.recordName),
+                std::move(properties));
+            allObjects.emplace((thisEEPROM["inventoryPath"].get<std::string>()),
+                               std::move(interfaces));
+
+            updateCI(thisEEPROM["inventoryPath"]
+                         .get_ref<const nlohmann::json::string_t&>());
+        }
+        updateEI(thisEEPROM, thisEEPROM["inventoryPath"]
+                                 .get_ref<const nlohmann::json::string_t&>());
+
+        if (thisEEPROM.contains("copyRecords"))
+        {
+            if (find(thisEEPROM["copyRecords"].begin(),
+                     thisEEPROM["copyRecords"].end(),
+                     m_thisRecord.recordName) !=
+                thisEEPROM["copyRecords"].end())
+            {
+                properties.emplace(m_thisRecord.keywordName,
+                                   m_thisRecord.newData);
+                interfaces.emplace(
+                    (std::string{"com.ibm.ipzvpd."} + m_thisRecord.recordName),
+                    std::move(properties));
+                allObjects.emplace(
+                    (thisEEPROM["inventoryPath"].get<std::string>()),
+                    std::move(interfaces));
+            }
+        }
+    }
+    // Notify PIM
+    utils::callPIM(std::move(allObjects));
+}
+
+void editor::modifyVpd(const bool& isCacheUpdateRequired)
+{
+    std::cout << "DBG Entered Modify vpd:\n";
+
+    try
+    {
+        // To avoid any data corruption,restrict the BMC from rebooting when VPD
+        // is being written.
+        enableRebootGuard();
+
+        // Read VPD offset if applicable.
+        if (!m_jsonFile.empty())
+        {
+            m_vpdStartOffset = utils::getVPDOffset(m_jsonFile, m_vpdFilePath);
+        }
+
+        m_vpdFileStream.exceptions(std::ifstream::badbit |
+                                   std::ifstream::failbit);
+
+        utils::getVpdDataInVector(m_vpdFileStream, m_vpdFilePath, m_vpdBytes,
+                                  m_vpdStartOffset);
+
+        if (!m_vpdBytes.empty())
+        {
+            // Validate Header part
+            validateHeader();
+            // Validate VTOC data
+            validateVtoc();
+
+            // Process VTOC to validate ECC for Records and get the offset and
+            // Length for Record and ECC.
+            processVtoc();
+
+            // Check Record's fields are initialised
+            // and Find the keyword offset and data length
+            getTheKwdOffsetAndLength();
+
+            // Write new data to the VPD
+            writeNewDataToVpd();
+
+            // Update the Record's ECC for new data
+            updateRecordEcc();
+
+            // Update the cache
+            if (isCacheUpdateRequired)
+            {
+                // update the cache once data has been updated
+                updateCache();
+            }
+
+            // Once VPD data and Ecc update is done, disable BMC boot guard.
+            disableRebootGuard();
+            return;
+        }
+        else
+        {
+            throw Exception("Invalid cast");
+        }
+    }
+    catch (const Exception& e)
+    {
+        // Disable reboot guard.
+        disableRebootGuard();
+        throw Exception(e.what());
+    }
+
+    std::cout << "DBG Existing Modify VPd:\n";
+}
+} // namespace vpd

--- a/src/ipz_parser.cpp
+++ b/src/ipz_parser.cpp
@@ -162,7 +162,7 @@ bool IpzVpdParser::vtocEccCheck()
     auto vtocECCOffset = readUInt16LE(vpdPtr);
 
     // Get the ECC length
-    std::advance(vpdPtr, sizeof(types::ECCOffset));
+    std::advance(vpdPtr, sizeof(types::EccOffset));
     auto vtocECCLength = readUInt16LE(vpdPtr);
 
     // Reset pointer to start of the vpd,
@@ -220,7 +220,7 @@ bool IpzVpdParser::recordEccCheck(types::BinaryVector::const_iterator iterator)
     std::advance(iterator, sizeof(types::RecordLength));
     auto eccOffset = readUInt16LE(iterator);
 
-    std::advance(iterator, sizeof(types::ECCOffset));
+    std::advance(iterator, sizeof(types::EccOffset));
     auto eccLength = readUInt16LE(iterator);
 
     if (eccLength == 0 || eccOffset == 0)
@@ -366,7 +366,7 @@ types::RecordOffsetList
         // Jump record size, record length, ECC offset and ECC length
         std::advance(itrToPT,
                      sizeof(types::RecordOffset) + sizeof(types::RecordLength) +
-                         sizeof(types::ECCOffset) + sizeof(types::ECCLength));
+                         sizeof(types::EccOffset) + sizeof(types::EccLength));
     }
 
     return recordOffsets;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -482,5 +482,19 @@ nlohmann::json getParsedJson(const std::string& pathToJson)
         throw std::runtime_error("Failed to parse JSON file");
     }
 }
+
+std::string getDbusNameForThisKw(const std::string& keyword)
+{
+    if (keyword[0] == constants::POUND_KW)
+    {
+        return (std::string(constants::POUND_KW_PREFIX) + keyword[1]);
+    }
+    else if (isdigit(keyword[0]))
+    {
+        return (std::string(constants::NUMERIC_KW_PREFIX) + keyword);
+    }
+    return keyword;
+}
+
 } // namespace utils
 } // namespace vpd


### PR DESCRIPTION
P11: Editor Class Support
This commit added editing service for vpd.
The data will be updated on hardware file and accordingly ECC
will be updated. If requested, will update the data on dbus.

Test:
Tested patch with dummy write call in manager code.
File got updated-
000000a0  38 53 4e 0c 41 41 41 41  41 41 42 42 42 42 42 42  |8SN.AAAAAABBBBBB|
dbus updated-
get-property on:
vpd.VINI" "SN"
ay 12 65 65 65 65 65 65 66 66 66 66 66 66

Updated partly-
000000a0  38 53 4e 0c 59 41 33 30  55 46 42 42 42 42 42 42  |8SN.YA30UFBBBBBB|
get-property on vpd.VINI" "SN"
ay 12 89 65 51 48 85 70 66 66 66 66 66 66

Change-Id: Idae70a665f51ce6d32b2ae45bd1aa71f72513c3f