### PR TITLE
vpd-manager:Catch file exceptions while updating VPD on 1030

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -101,6 +101,7 @@ constexpr auto systemVpdFilePath = "/sys/bus/i2c/drivers/at24/8-0050/eeprom";
 constexpr auto i2cPathPrefix = "/sys/bus/i2c/drivers/at24/";
 constexpr auto spiPathPrefix = "/sys/bus/spi/drivers/at25/";
 constexpr auto invItemIntf = "xyz.openbmc_project.Inventory.Item";
+static constexpr std::uintmax_t MAX_VPD_SIZE = 65504;
 
 namespace lengths
 {

--- a/vpd-manager/editor_impl.cpp
+++ b/vpd-manager/editor_impl.cpp
@@ -564,17 +564,37 @@ void EditorImpl::updateKeyword(const Binary& kwdData, uint32_t offset,
         // prevent any data/ECC corruption in case BMC reboots while VPD update.
         enableRebootGuard();
 
-        // TODO: Figure out a better way to get max possible VPD size.
         Binary completeVPDFile;
-        completeVPDFile.resize(65504);
-        vpdFileStream.open(vpdFilePath,
-                           std::ios::in | std::ios::out | std::ios::binary);
+        vpdFileStream.exceptions(std::ifstream::badbit |
+                                 std::ifstream::failbit);
+        try
+        {
+            vpdFileStream.open(vpdFilePath,
+                               std::ios::in | std::ios::out | std::ios::binary);
 
-        vpdFileStream.seekg(startOffset, std::ios_base::cur);
-        vpdFileStream.read(reinterpret_cast<char*>(&completeVPDFile[0]), 65504);
-        completeVPDFile.resize(vpdFileStream.gcount());
-        vpdFileStream.clear(std::ios_base::eofbit);
+            auto vpdFileSize =
+                std::min(std::filesystem::file_size(vpdFilePath), MAX_VPD_SIZE);
 
+            if (vpdFileSize == 0)
+            {
+                std::cerr << "File size is 0 for " << vpdFilePath << std::endl;
+                throw std::runtime_error("File size is 0.");
+            }
+
+            completeVPDFile.resize(vpdFileSize);
+            vpdFileStream.seekg(startOffset, std::ios_base::cur);
+            vpdFileStream.read(reinterpret_cast<char*>(&completeVPDFile[0]),
+                               vpdFileSize);
+            vpdFileStream.clear(std::ios_base::eofbit);
+        }
+        catch (const std::system_error& fail)
+        {
+            std::cerr << "Exception in file handling [" << vpdFilePath
+                      << "] error : " << fail.what();
+            std::cerr << "Stream file size = " << vpdFileStream.gcount()
+                      << std::endl;
+            throw;
+        }
         vpdFile = completeVPDFile;
 
         if (objPath.empty() &&


### PR DESCRIPTION
This commit handles filestream exceptions on vpd-manager write operation.
This change handles exceptions like basic_ios::clear:iostream error which occurs during write operation on read-only VPD.

Test:
VRM VPD is write protected. when vpd-tool tries to write on VRM VPD, write operation gets aborted.

vpd-tool -w -O  /system/chassis/motherboard/vrm8 -R VINI -K PN --value Y

>>vpd-manager[4988]: Exception in file handling
[/sys/bus/i2c/drivers/at24/9-0052/eeprom] error : basic_ios::clear: iostream errorStream file size = 16384

vpd-tool -r -O /system/chassis/motherboard/vrm8 -R VINI -K PN {
    "/system/chassis/motherboard/vrm8": {
        "PN": "03GN277"
    }
}