### PR TITLE
Remove unused json parsing meson config option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,10 +78,6 @@ if get_option('ibm_system').enabled()
     parser_build_arguments += ['-DIBM_SYSTEM']
 endif
 
-if get_option('use_json').enabled()
-    parser_build_arguments += ['-DPARSER_USE_JSON'] 
-endif
-
 vpd_manager_exe = executable(
                 'vpd-manager',
                 vpd_manager_SOURCES,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,4 +10,3 @@ option('SYSTEM_VPD_FILE_PATH', type: 'string', value: '/sys/bus/i2c/drivers/at24
 option('VPD_SYMLIMK_PATH', type: 'string', value: '/var/lib/vpd',  description: 'Symlink folder for VPD invnetory JSONs')
 option('PIM_PATH_PREFIX', type: 'string', value: '/xyz/openbmc_project/inventory', description: 'Prefix for PIM inventory paths.')
 option('ibm_system', type: 'feature', value : 'disabled', description: 'Enable code specific to IBM systems.')
-option('use_json', type: 'feature', value : 'disabled', description: 'enable when json is passed to vpd_parser_app along with vpd file')

--- a/src/vpd_parser_main.cpp
+++ b/src/vpd_parser_main.cpp
@@ -43,10 +43,8 @@ int main(int argc, char** argv)
         app.add_option("-f, --file", vpdFilePath, "VPD file path")->required();
 
         std::string configFilePath{};
-#ifdef PARSER_USE_JSON
+
         app.add_option("-c,--config", configFilePath, "Path to JSON config");
-        vpd::logging::logMessage("Config file path recieved" + configFilePath);
-#endif
 
         CLI11_PARSE(app, argc, argv);
 
@@ -64,7 +62,8 @@ int main(int argc, char** argv)
         // Below are two different ways of parsing the VPD.
         if (!configFilePath.empty())
         {
-            vpd::logging::logMessage("Processing with config JSON");
+            vpd::logging::logMessage("Processing with config file - " +
+                                     configFilePath);
 
             std::shared_ptr<vpd::Worker> objWorker =
                 std::make_shared<vpd::Worker>(configFilePath);


### PR DESCRIPTION
Removes the unnecessary macro definition "PARSER_USE_JSON" and meson option use_json. The PARSER_USE_JSON macro check is not needed since the -c config option of the vpd-parser application is optional.

Test:
a) When vpd parser exe is executed without config json path.

sh-5.2# ./vpd-parser -f /sys/bus/i2c/drivers/at24/8-0051/eeprom
FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/src/vpd_parser_main.cpp, Line: 48, Func: int main(int, char**), Config file path recieved
FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/src/vpd_parser_main.cpp, Line: 52, Func: int main(int, char**), VPD file path recieved/sys/bus/i2c/drivers/at24/8-0051/eeprom
IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/8-0051/eeprom

b) When vpd parser exe is executed with config json path.

sh-5.2# ./vpd-parser -f /sys/bus/i2c/drivers/at24/8-0051/eeprom -c /var/lib/vpd/vpd_inventory.json
FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/src/vpd_parser_main.cpp, Line: 48, Func: int main(int, char**), Config file path recieved
FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/src/vpd_parser_main.cpp, Line: 52, Func: int main(int, char**), VPD file path recieved/sys/bus/i2c/drivers/at24/8-0051/eeprom
FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/src/vpd_parser_main.cpp, Line: 66, Func: int main(int, char**), Processing with config JSON
FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/src/worker.cpp, Line: 34, Func: vpd::Worker::Worker(std::string), Sym Link already present
IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/8-0051/eeprom