### PR TITLE
Check vector size before reading 11S format

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -17,9 +17,10 @@ static constexpr uint8_t ALT_KW_VPD_PAIR_START_TAG = 0x90;
 static constexpr uint8_t KW_VPD_END_TAG = 0x78;
 static constexpr uint8_t KW_VAL_PAIR_END_TAG = 0x79;
 
-static constexpr auto MEMORY_VPD_DATA_START = 416;
-static constexpr auto MEMORY_VPD_START_TAG = "11S";
-static constexpr auto FORMAT_11S_LEN = 3;
+static constexpr auto DDIMM_11S_BARCODE_START = 416;
+static constexpr auto DDIMM_11S_BARCODE_START_TAG = "11S";
+static constexpr auto DDIMM_11S_FORMAT_LEN = 3;
+static constexpr auto DDIMM_11S_BARCODE_LEN = 26;
 static constexpr auto PART_NUM_LEN = 7;
 static constexpr auto SERIAL_NUM_LEN = 12;
 static constexpr auto CCIN_LEN = 4;

--- a/include/parser_factory.hpp
+++ b/include/parser_factory.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "logger.hpp"
 #include "parser_interface.hpp"
 #include "types.hpp"
 

--- a/src/ddimm_parser.cpp
+++ b/src/ddimm_parser.cpp
@@ -230,7 +230,8 @@ void DdimmVpdParser::readKeywords(
 
     m_parsedVpdMap.emplace("MemorySizeInKB", l_dimmSize);
     // point the i_iterator to DIMM data and skip "11S"
-    advance(i_iterator, constants::MEMORY_VPD_DATA_START + 3);
+    advance(i_iterator, constants::DDIMM_11S_BARCODE_START +
+                            constants::DDIMM_11S_FORMAT_LEN);
     types::BinaryVector l_partNumber(i_iterator,
                                      i_iterator + constants::PART_NUM_LEN);
 


### PR DESCRIPTION
Reading ‘11S’ format initially in the vpdTypeCheck API was causing problem if any of the VPD file size is less than the MEMORY_VPD_DATA_START(416) size.

To solve the issue reading 11S format is moved down and vector size checked before accessing the location.