### PR TITLE
Update the pretty names of inventory items in JSON

### DIFF
--- a/config/ibm/50001001_v2.json
+++ b/config/ibm/50001001_v2.json
@@ -763,7 +763,7 @@
                         "LocationCode": "Ufcs-P0-T18"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "USB 3.0 por"
+                        "PrettyName": "USB 3.0 port"
                     }
                 }
             }

--- a/config/ibm/50003000.json
+++ b/config/ibm/50003000.json
@@ -52,7 +52,7 @@
                         "LocationCode": "Ufcs-P0"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "System backplanev"
+                        "PrettyName": "System backplane"
                     }
                 }
             },
@@ -4941,7 +4941,7 @@
                         "LocationCode": "Ufcs-P0-C65"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "Memory module 34"
+                        "PrettyName": "Memory module 33"
                     },
                     "xyz.openbmc_project.State.Decorator.Availability": {
                         "Available": false
@@ -5259,7 +5259,7 @@
                         "LocationCode": "Ufcs-P0-C71"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "DDIMM 39"
+                        "PrettyName": "Memory module 39"
                     },
                     "xyz.openbmc_project.State.Decorator.Availability": {
                         "Available": false
@@ -5418,7 +5418,7 @@
                         "LocationCode": "Ufcs-P0-C74"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "Memory module 40"
+                        "PrettyName": "Memory module 42"
                     },
                     "xyz.openbmc_project.State.Decorator.Availability": {
                         "Available": false


### PR DESCRIPTION
This commit corrects the pretty names of certain DIMMs that were mislabeled and fixes typo errors in the pretty names of inventory items

Signed-off-by: RekhaAparna01 <vrekhaaparna@ibm.com>