### PR TITLE
Enable MUX by getting it out of hold state

### DIFF
--- a/configuration/ibm/50001001_v2.json
+++ b/configuration/ibm/50001001_v2.json
@@ -1,0 +1,4515 @@
+{
+    "device-tree": "conf-aspeed-bmc-ibm-rainier.dtb",
+    "commonInterfaces": {
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "PartNumber": {
+                "recordName": "VINI",
+                "keywordName": "PN"
+            },
+            "SerialNumber": {
+                "recordName": "VINI",
+                "keywordName": "SN"
+            },
+            "SparePartNumber": {
+                "recordName": "VINI",
+                "keywordName": "FN"
+            },
+            "Model": {
+                "recordName": "VINI",
+                "keywordName": "CC"
+            },
+            "BuildDate": {
+                "recordName": "VR10",
+                "keywordName": "DC",
+                "encoding": "DATE"
+            }
+        }
+    },
+    "muxes": [
+        {
+            "i2bus": "4",
+            "deviceaddress": "0xE0",
+            "holdidlepath": "/sys/bus/i2c/drivers/pca954x/4-0070/hold_idle"
+        },
+        {
+            "i2bus": "5",
+            "deviceaddress": "0xE0",
+            "holdidlepath": "/sys/bus/i2c/drivers/pca954x/5-0070/hold_idle"
+        },
+        {
+            "i2bus": "6",
+            "deviceaddress": "0xE0",
+            "holdidlepath": "/sys/bus/i2c/drivers/pca954x/6-0070/hold_idle"
+        },
+        {
+            "i2bus": "11",
+            "deviceaddress": "0xE0",
+            "holdidlepath": "/sys/bus/i2c/drivers/pca954x/11-0070/hold_idle"
+        }
+    ],
+    "frus": {
+        "/sys/bus/i2c/drivers/at24/8-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard",
+                "isSystemVpd": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Board.Motherboard": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System backplane"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Oscillator Reference Clock"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system",
+                "inherit": false,
+                "isSystemVpd": true,
+                "copyRecords": ["VSYS"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.System": null,
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "SerialNumber": {
+                            "recordName": "VSYS",
+                            "keywordName": "SE"
+                        },
+                        "Model": {
+                            "recordName": "VSYS",
+                            "keywordName": "TM"
+                        },
+                        "SubModel": {
+                            "recordName": "VSYS",
+                            "keywordName": "BR"
+                        }
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Umts"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis",
+                "isSystemVpd": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Global": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Chassis"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot6",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot7",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot8",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot9",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot11",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T18"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot12/pcie_card12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T18"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 12
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/powersupply0",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-E0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/powersupply1",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-E1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/fan0",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A0"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 50, 51, 55],
+                        "CC": [55, 66, 53, 71],
+                        "PN": [48, 50, 89, 75, 50, 48, 48],
+                        "DR": [70, 97, 110],
+                        "SN": [89, 83, 49, 48, 74, 80, 49, 50, 86, 48, 84, 89],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 0],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5G",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK200",
+                        "SparePartNumber": "02YK237",
+                        "SerialNumber": "YS10JP12V0TY"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/fan1",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A1"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 50, 51, 55],
+                        "CC": [55, 66, 53, 71],
+                        "PN": [48, 50, 89, 75, 50, 48, 48],
+                        "DR": [70, 97, 110],
+                        "SN": [89, 83, 49, 48, 74, 80, 49, 50, 86, 48, 84, 89],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 1],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5G",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK200",
+                        "SparePartNumber": "02YK237",
+                        "SerialNumber": "YS10JP12V0TY"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/fan2",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A2"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 50, 51, 55],
+                        "CC": [55, 66, 53, 71],
+                        "PN": [48, 50, 89, 75, 50, 48, 48],
+                        "DR": [70, 97, 110],
+                        "SN": [89, 83, 49, 48, 74, 80, 49, 50, 86, 48, 84, 89],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 2],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5G",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK200",
+                        "SparePartNumber": "02YK237",
+                        "SerialNumber": "YS10JP12V0TY"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/fan3",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A3"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 50, 51, 55],
+                        "CC": [55, 66, 53, 71],
+                        "PN": [48, 50, 89, 75, 50, 48, 48],
+                        "DR": [70, 97, 110],
+                        "SN": [89, 83, 49, 48, 74, 80, 49, 50, 86, 48, 84, 89],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 3],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5G",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK200",
+                        "SparePartNumber": "02YK237",
+                        "SerialNumber": "YS10JP12V0TY"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/fan4",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A4"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 50, 51, 55],
+                        "CC": [55, 66, 53, 71],
+                        "PN": [48, 50, 89, 75, 50, 48, 48],
+                        "DR": [70, 97, 110],
+                        "SN": [89, 83, 49, 48, 74, 80, 49, 50, 86, 48, 84, 89],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 4],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5G",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK200",
+                        "SparePartNumber": "02YK237",
+                        "SerialNumber": "YS10JP12V0TY"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/fan5",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A5"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 50, 51, 55],
+                        "CC": [55, 66, 53, 71],
+                        "PN": [48, 50, 89, 75, 50, 48, 48],
+                        "DR": [70, 97, 110],
+                        "SN": [89, 83, 49, 48, 74, 80, 49, 50, 86, 48, 84, 89],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 5],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5G",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK200",
+                        "SparePartNumber": "02YK237",
+                        "SerialNumber": "YS10JP12V0TY"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/tod_battery",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Battery": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-E0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Time-of-day battery"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P0 OP3B"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P0 OP3A"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P1 OP0B"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P1 OP0A"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Power signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-1 P0 OP3A"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector6",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-1 P1 OP0B"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector7",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T7"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector8",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T8"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector9",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T9"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector11",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Fan signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector13",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel display cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector14",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T14"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector15",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector17",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T17"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Fan signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/connector18",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T18"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/8-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Bmc": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "eBMC card"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/ethernet0",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Ethernet": null,
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item.NetworkInterface": {
+                        "MACAddress": {
+                            "recordName": "VCFG",
+                            "keywordName": "Z0",
+                            "encoding": "MAC"
+                        }
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "HMC port 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/ethernet1",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Ethernet": null,
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item.NetworkInterface": {
+                        "MACAddress": {
+                            "recordName": "VCFG",
+                            "keywordName": "Z1",
+                            "encoding": "MAC"
+                        }
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "HMC port 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/usb0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/displayport0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Display Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/usb1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 2.0 port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/0-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/tpm_wilson",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Tpm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C22"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Trusted platform module card"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/7-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/base_op_panel_blyth",
+                "essentialFru": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Panel": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-D0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/7-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/lcd_op_panel_hill",
+                "devAddress": "7-0051",
+                "driverType": "at24",
+                "busType": "i2c",
+                "presence": {
+                    "pollingRequired": true,
+                    "pin": "RUSSEL_OPPANEL_PRESENCE_N",
+                    "value": 0,
+                    "gpioI2CAddress": "0-0020"
+                },
+                "preAction": {
+                    "pin": "RUSSEL_FW_I2C_ENABLE_N",
+                    "value": 0,
+                    "gpioI2CAddress": "0-0020"
+                },
+                "postActionFail": {
+                    "pin": "RUSSEL_FW_I2C_ENABLE_N",
+                    "value": 1,
+                    "gpioI2CAddress": "0-0020"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Panel": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-D1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel display"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/9-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/vdd_vrm0",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Vrm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C14"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Voltage regulator module for system processor module 0"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/10-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/vdd_vrm1",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Vrm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C23"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Voltage regulator module for system processor module 1"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi12.0/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi13.0/eeprom",
+                "cpuType": "primary",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit6",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit7",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit8",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit9",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit10",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit11",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit13",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit14",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi22.0/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi23.0/eeprom",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit6",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit7",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit8",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit9",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit10",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit11",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit13",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit14",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi32.0/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi33.0/eeprom",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C24"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit6",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit7",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit8",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit9",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit10",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit11",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit13",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit14",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi42.0/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi43.0/eeprom",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C24"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit6",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit7",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit8",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit9",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit10",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit11",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit12",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit13",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit14",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/20-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0",
+                "devAddress": "20-0050",
+                "pcaChipAddress": "20-0060",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT0_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT0_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT0_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 20,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 0
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/23-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3",
+                "devAddress": "23-0050",
+                "pcaChipAddress": "23-0060",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT3_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT3_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT3_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 23,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_top",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_bot",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/24-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4",
+                "devAddress": "24-0051",
+                "pcaChipAddress": "24-0061",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT4_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT4_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT4_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 24,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_top",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_bot",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/29-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10",
+                "devAddress": "29-0050",
+                "pcaChipAddress": "29-0060",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT10_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT10_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT10_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 29,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/22-0052/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot2/pcie_card2",
+                "devAddress": "22-0052",
+                "pcaChipAddress": "22-0062",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT2_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT2_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT2_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 22,
+                        "Address": 82
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/25-0053/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot6/pcie_card6",
+                "devAddress": "25-0053",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT6_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT6_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT6_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/26-0052/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot7/pcie_card7",
+                "devAddress": "26-0052",
+                "pcaChipAddress": "26-0062",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT7_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT7_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT7_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 26,
+                        "Address": 82
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/27-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot9/pcie_card9",
+                "devAddress": "27-0050",
+                "pcaChipAddress": "27-0060",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT9_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT9_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT9_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 27,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/30-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11",
+                "devAddress": "30-0051",
+                "pcaChipAddress": "30-0061",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT11_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT11_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT11_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 30,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 11
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector0",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector1",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector2",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector3",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/21-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot1/pcie_card1",
+                "devAddress": "21-0051",
+                "pcaChipAddress": "21-0061",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT1_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT1_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT1_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "3-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 21,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/28-0051/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8",
+                "devAddress": "28-0051",
+                "pcaChipAddress": "28-0061",
+                "replaceableAtStandby": true,
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "SLOT8_EXPANDER_PRSNT_N",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "preAction": {
+                    "pin": "SLOT8_PRSNT_EN_RSVD",
+                    "value": 1,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "postActionFail": {
+                    "pin": "SLOT8_PRSNT_EN_RSVD",
+                    "value": 0,
+                    "gpioI2CAddress": "8-0061"
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 28,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector0",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector1",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector2",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector3",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/13-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme2/dp0_drive2",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "13-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme3/dp0_drive3",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "13-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 2"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme4/dp0_drive4",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "13-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 2"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 3"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme5/dp0_drive5",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "13-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 3"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp0_cable0",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp0_cable1",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/14-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 4"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme2/dp1_drive2",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "14-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 4"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 5"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme3/dp1_drive3",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "14-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 5"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 6"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme4/dp1_drive4",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "14-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 6"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 7"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme5/dp1_drive5",
+                "inherit": false,
+                "embedded": false,
+                "devAddress": "14-0050",
+                "busType": "i2c",
+                "driverType": "at24",
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 7"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector4",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector5",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp1_cable0",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp1_cable1",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/111-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm0",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 0"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm0/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm0/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm0/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm0/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/110-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm1",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 1"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm1/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm1/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm1/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm1/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/214-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm10",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C16"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 2"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm10/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm10/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm10/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm10/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/210-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm9",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C17"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 3"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm9/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm9/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm9/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm9/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/202-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm8",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C18"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 4"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm8/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm8/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm8/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm8/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/311-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm16",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C19"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 5"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm16/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm16/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm16/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm16/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/310-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm17",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C20"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 6"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm17/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm17/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm17/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm17/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/312-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm18",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C21"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 7"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm18/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm18/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm18/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm18/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/402-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm24",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C25"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 8"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm24/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm24/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm24/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm24/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/410-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm25",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C26"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 9"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm25/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm25/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm25/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm25/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/112-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm2",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C27"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 10"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm2/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm2/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm2/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm2/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/115-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm4",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C28"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 11"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm4/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm4/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm4/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm4/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/100-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm5",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C29"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 12"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm5/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm5/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm5/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm5/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/101-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm7",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C30"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 13"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm7/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm7/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm7/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm7/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/114-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm6",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C31"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 14"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm6/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm6/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm6/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm6/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/113-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm3",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C32"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 15"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm3/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm3/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm3/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm3/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/216-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm15",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C33"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 16"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm15/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm15/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm15/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm15/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/203-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm14",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C34"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 17"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm14/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm14/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm14/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm14/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/217-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm11",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C35"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 18"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm11/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm11/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm11/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm11/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/211-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm13",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C36"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 19"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm13/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm13/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm13/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm13/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/215-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm12",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C37"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 20"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm12/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm12/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm12/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm12/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/315-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm20",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C38"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 21"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm20/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm20/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm20/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm20/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/300-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm21",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C39"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 22"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm21/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm21/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm21/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm21/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/313-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm19",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C40"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 23"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm19/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm19/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm19/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm19/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/314-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm22",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C41"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 24"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm22/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm22/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm22/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm22/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/301-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm23",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C42"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 25"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm23/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm23/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm23/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm23/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/417-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm27",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C43"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 26"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm27/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm27/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm27/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm27/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/403-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm30",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C44"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 27"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm30/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm30/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm30/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm30/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/416-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm31",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C45"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 28"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm31/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm31/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm31/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm31/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/411-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm29",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C46"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 29"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm29/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm29/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm29/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm29/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/415-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm28",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C47"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 30"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm28/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm28/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm28/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm28/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/414-0050/eeprom": [
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm26",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C48"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 31"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm26/unit0",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm26/unit1",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm26/unit2",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/system/chassis/motherboard/dimm26/unit3",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -121,7 +121,7 @@ class Worker
      * If device tree change is required, it updates the "fitconfig" and reboots
      * the system. Else it is NOOP.
      *
-     * Note: In case of any error, exception is thrown. Caller need to handle.
+     * @throw std::runtime_error
      */
     void setDeviceTreeAndJson();
 
@@ -337,6 +337,16 @@ class Worker
      */
     bool processPreAction(const std::string& i_vpdFilePath,
                           const std::string& i_flagToProcess);
+
+    /**
+     * @brief Function to enable and bring MUX out of idle state.
+     *
+     * This finds all the MUX defined in the system json and enables them by
+     * setting the holdidle parameter to 0.
+     *
+     * @throw std::runtime_error
+     */
+    void enableMuxChips();
 
     // Parsed JSON file.
     nlohmann::json m_parsedJson{};


### PR DESCRIPTION
Based on system configuration, bring MUX(es) out of hold state by setting the holdidle to 0.
This is done to enable I2C lines beyond those MUXes.

This is being done as a part of initial set up as it required to be done only once.

The commit also implement changes to handle file system errors.