### PR TITLE
Enable mux when setting symlink

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1480,6 +1480,12 @@ static void populateDbus(T& vpdMap, nlohmann::json& js, const string& filePath)
         ifstream inventoryJson(link);
         js = json::parse(inventoryJson);
         inventoryJson.close();
+
+        // enable the muxes again here to cover the case where during first boot
+        // after reset, system would have come up with default JSON
+        // configuration and have skipped enabling mux at the beginning.
+        // Default config JSON does not have mux entries.
+        doEnableAllMuxChips(js);
     }
 
     for (const auto& item : js["frus"][filePath])


### PR DESCRIPTION
Muxes, if required, are enabled again at the time of setting symlink to system specific JSON.

This is done to avoid the scenario where, if system comes up with the default JSON, which will not have entry for muxes and will skip enabling mux at the beginning, resulting in disabled mux.

This change ensures that if there is a change is system configuration JSON symlink, same is picked and checked for required muxes to get enabled.

Change-Id: I4e88f24f9ea5bd8e22fa90a50028686a67abc4a0