### PR TITLE
vpd-manager: Method to write IPZ keywords

### DIFF
--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -67,13 +67,11 @@ class Manager
      *
      * @param[in] i_path - D-bus object path/EEPROM path.
      * @param[in] i_data - Data to be updated.
-     * @param[in] i_target - Target location to update (0/1/2).
      *
-     * @return On failure this API throws an error, on success it returns
-     * nothing.
+     * @return On failure this API throws an error, on success it returns the
+     * number of bytes updated.
      */
-    void updateKeyword(const types::Path i_path, const types::VpdData i_data,
-                       const uint8_t i_target);
+    int updateKeyword(types::Path i_path, const types::VpdData i_data);
 
     /**
      * @brief Read keyword value.
@@ -181,6 +179,9 @@ class Manager
 
     // Shared pointer to worker class
     std::shared_ptr<Worker> m_worker;
+
+    // VPD JSON object
+    nlohmann::json m_jsonObj;
 };
 
 } // namespace vpd

--- a/include/parser_interface.hpp
+++ b/include/parser_interface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "logger.hpp"
 #include "types.hpp"
 
 #include <variant>
@@ -25,6 +26,21 @@ class ParserInterface
      * parsing logic.
      */
     virtual types::VPDMapVariant parse() = 0;
+
+    /**
+     * @brief Virtual function to perform write on VPD of any type.
+     *
+     * The API can be overridden by classes inheriting this ParserInterface
+     * class to implement VPD write operation.
+     *
+     * @return -1 on failure and n if n bytes are written.
+     */
+    virtual int write(const types::Path, const types::VpdData)
+    {
+        logging::logMessage(
+            "Write operation not supported for the given VPD type.");
+        return 0;
+    }
 
     /**
      * @brief Virtual destructor.

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -2,6 +2,7 @@
 
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/server.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 
 #include <tuple>
 #include <unordered_map>
@@ -11,6 +12,8 @@ namespace vpd
 {
 namespace types
 {
+namespace CommonError = sdbusplus::xyz::openbmc_project::Common::Error;
+
 using BinaryVector = std::vector<uint8_t>;
 
 // This covers mostly all the data type supported over Dbus for a property.

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -113,6 +113,11 @@ using KwData = std::tuple<Keyword, BinaryVector>;
 using ReadVpdParams = std::variant<std::tuple<Record, Keyword>, Keyword>;
 using VpdData = std::variant<IpzData, KwData>;
 
+namespace CommonError = sdbusplus::xyz::openbmc_project::Common::Error;
+
+/* Collection of FRU paths {Inventory path, Primary EEPROM path, Redundant EEPROM path} */
+using PathCollection = std::tuple<std::string, std::string, std::string>;
+
 enum class VpdTarget
 {
         Cache = 0,

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -358,5 +358,76 @@ bool executePreAction(const nlohmann::json& i_parsedConfigJson,
                       const std::string& i_vpdFilePath,
                       const std::string& i_flagToProcess);
 
+/**
+ * @brief Check if given path is D-bus inventory path.
+ *
+ * @param[in] i_path - FRU path
+ *
+ * @return true if d-bus inventory path, false otherwise.
+ */
+bool isDbusInvPath(const std::string& i_path);
+
+/**
+ * @brief Update keyword data on D-bus
+ *
+ * Update keyword on D-bus and persist the data in BMC's cache memory. Data can
+ * be of type IPZ/Keyword. Data has to be sent in the respective formats.
+ *
+ * IPZ format - Record, Keyword, Value
+ * Keyword format - Keyword, Value.
+ *
+ * @param[in] i_invPath - Inventory path
+ * @param[in] i_data - Data to be updated.
+ *
+ * @return 0 if update is successful, -1 otherwise.
+ */
+int updateDbus(const types::Path& i_invPath, const types::VpdData& i_data);
+
+/**
+ * @brief Update keyword on hardware
+ *
+ * Update keyword data on EEPROM. Data can be of type IPZ/Keyword. Data has to
+ * be sent in the respective formats.
+ *
+ * IPZ format - Record, Keyword, Value
+ * Keyword format - Keyword, Value.
+ *
+ * @param[in] i_hwPath - Hardware path
+ * @param[in] i_data - Data to be updated.
+ * @param[in] i_jsonObk - Parsed JSON object.
+ *
+ * @return 0 if update is successful, -1 otherwise
+ */
+int updateHardware(const types::Path& i_hwPath, const types::VpdData& i_data,
+                   const nlohmann::json& i_jsonObj);
+
+/**
+ * @brief Get FRU paths
+ *
+ * This api sends back the inventory path, primary hardware path and redundant
+ * hardware path if any one of the paths is given as input.
+ *
+ * @param[in] i_inputPath - Input FRU path. It can be either Inventory
+ * path/Primary EEPROM path/Redundant EEPROM path.
+ * @param[in,out] i_fruPaths - FRU paths.
+ * @param[in] i_jsonObj - JSON object.
+ *
+ * @return true if the paths are found from JSON, false otherwise.
+ */
+bool getFRUPaths(const std::string& i_inputPath,
+                 types::PathCollection& i_fruPaths,
+                 const nlohmann::json& i_jsonObj);
+
+/**
+ * @brief Remove prefix from inventory path
+ *
+ * Remove the prefix /xyz/openbmc_project/inventory from the given D-bus object
+ * path.
+ *
+ * @param[in] i_invPath - Inventory path
+ *
+ * @return truncated inventory path
+ */
+std::string getTruncatedInvPath(const std::string& i_invPath);
 } // namespace utils
 } // namespace vpd

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,14 @@ endif
 # sure we have control over its configuration
 build_tests = get_option('tests')
 
+phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces',
+    default_options: [ 'data_com_ibm=true', 'data_org_open_power=true' ],
+    fallback: ['phosphor-dbus-interfaces', 'phosphor_dbus_interfaces_dep'])
+
+phosphor_logging = dependency('phosphor-logging',
+    default_options: [ 'openpower-pel-extension=enabled' ],
+    fallback: ['phosphor-logging', 'phosphor_logging_dep'])
+
 sdbusplus = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
 
 if not build_tests.disabled()
@@ -77,7 +85,7 @@ vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',
                     ] + common_SOURCES
 
-parser_dependencies = [sdbusplus, libgpiodcxx]
+parser_dependencies = [sdbusplus, libgpiodcxx, phosphor_dbus_interfaces, phosphor_logging]
 
 parser_build_arguments = []
 if get_option('ibm_system').enabled()

--- a/src/ipz_parser.cpp
+++ b/src/ipz_parser.cpp
@@ -534,8 +534,8 @@ int IpzVpdParser::updateValue(types::BinaryVector::const_iterator& io_itrToVPD,
         std::string kwdName(itrToVPDStart, itrToVPDStart + Length::KW_NAME);
         if (constants::LAST_KW == kwdName)
         {
-            // We're done
-            break;
+            throw std::runtime_error(
+                "Keyword not found. Unable to perform write");
         }
 
         // Check for Pound keyword which starts with #

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -18,9 +18,6 @@ Parser::Parser(const std::string& vpdFilePath, nlohmann::json parsedJson) :
 
 types::VPDMapVariant Parser::parse()
 {
-    std::fstream vpdFileStream;
-    vpdFileStream.exceptions(std::ifstream::badbit | std::ifstream::failbit);
-
     // Read the VPD data into a vector.
     types::BinaryVector vpdVector;
     utils::getVpdDataInVector(m_vpdFilePath, vpdVector, m_vpdStartOffset);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -28,5 +28,4 @@ types::VPDMapVariant Parser::parse()
 
     return parser->parse();
 }
-
 } // namespace vpd

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -423,6 +423,8 @@ void getVpdDataInVector(const std::string& vpdFilePath,
     try
     {
         std::fstream vpdFileStream;
+        vpdFileStream.exceptions(std::ifstream::badbit |
+                                 std::ifstream::failbit);
         vpdFileStream.open(vpdFilePath, std::ios::in | std::ios::binary);
         auto vpdSizeToRead = std::min(std::filesystem::file_size(vpdFilePath),
                                       static_cast<uintmax_t>(65504));


### PR DESCRIPTION
Implement write IPZ type VPDs on both hardware and cache.

Test cases covered:
1. Write on hardware and cache given an inventory path
2. Write on hardware and cache given an EEPROM path
3. Write size lesser than actual keyword size given an inventory path
4. Write size lesser than actual keyword size given an EEPROM path
5. Write size more than actual keyword size given an inventory path
6. Write size more than actual keyword size given an EEPROM path
7. Write size equal to the actual keyword size given an inventory path
8. Write size equal to the actual keyword size given an EEPROM path
9. . Provide invalid record name/ keyword name/ inventory path/ eeprom path
10. Write on hardware and cache for frus whose startoffset is taken from JSON
11. Write on redundant eeproms if present