### PR TITLE
VPD:collection: Fix BMC state check failure

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -84,6 +84,8 @@ static auto getBMCState()
     {
         // Ignore any error
         std::cerr << "Failed to get BMC state: " << e.what() << "\n";
+        // Since we failed set to not ready state
+        bmcState = "xyz.openbmc_project.State.BMC.BMCState.NotReady";
     }
     return bmcState;
 }


### PR DESCRIPTION
we use the BMC state to check if we need to do a recollection and in the case where the state manager is not up we get a failure. when we get a failure , since we do nto know the state we did not populate anything and so did not do a recollect , this caused certain preaction to not run and so some failure happened.we decided to set the state as not ready on any failure getting state so that the recollection will happen and we will have the preaction run.

Change-Id: I7887a5d45ae21ae16035a29609b74bbc30dfcdc1