### PR TITLE
Update D-bus inventory path in rainier 2U JSONs

### DIFF
--- a/configuration/ibm/50001001.json
+++ b/configuration/ibm/50001001.json
@@ -37,7 +37,7 @@
     "frus": {
         "/sys/bus/i2c/drivers/at24/8-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard",
                 "isSystemVpd": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Board.Motherboard": null,
@@ -50,7 +50,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -59,7 +59,7 @@
                 }
             },
             {
-                "inventoryPath": "/system",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system",
                 "inherit": false,
                 "isSystemVpd": true,
                 "copyRecords": ["VSYS"],
@@ -88,7 +88,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis",
                 "isSystemVpd": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Chassis": null,
@@ -102,7 +102,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -119,7 +119,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -136,7 +136,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -153,7 +153,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -170,7 +170,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -187,7 +187,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -204,7 +204,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -221,7 +221,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -238,7 +238,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -255,7 +255,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -272,7 +272,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -289,7 +289,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot12",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -305,7 +305,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot12/pcie_card12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot12/pcie_card12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
@@ -321,7 +321,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/powersupply0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -332,7 +332,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/powersupply1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -343,7 +343,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -373,7 +373,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -403,7 +403,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -433,7 +433,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -463,7 +463,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -493,7 +493,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -523,7 +523,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/tod_battery",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tod_battery",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Battery": null,
                     "com.ibm.ipzvpd.Location": {
@@ -535,7 +535,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -548,7 +548,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -561,7 +561,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -574,7 +574,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -587,7 +587,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -600,7 +600,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -613,7 +613,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -626,7 +626,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -639,7 +639,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -652,7 +652,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -665,7 +665,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -678,7 +678,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -691,7 +691,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -704,7 +704,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -717,7 +717,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector15",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector15",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -730,7 +730,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector17",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector17",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -743,7 +743,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector18",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector18",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -758,7 +758,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/8-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Bmc": null,
                     "com.ibm.ipzvpd.Location": {
@@ -770,7 +770,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/ethernet0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/ethernet0",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -792,7 +792,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/ethernet1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/ethernet1",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -814,7 +814,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/usb0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/usb0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -827,7 +827,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/displayport0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/displayport0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -840,7 +840,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/usb1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/usb1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -855,7 +855,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/0-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/tpm_wilson",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tpm_wilson",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Tpm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -869,7 +869,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/7-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/base_op_panel_blyth",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                 "essentialFru": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Panel": null,
@@ -884,7 +884,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/7-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/lcd_op_panel_hill",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -921,7 +921,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/9-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/vdd_vrm0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -935,7 +935,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/10-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/vdd_vrm1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm1",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -949,7 +949,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi12.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi13.0/eeprom",
                 "cpuType": "primary",
                 "powerOffOnly": true,
@@ -966,7 +966,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -975,7 +975,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -984,7 +984,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -993,7 +993,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1002,7 +1002,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1011,7 +1011,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1020,7 +1020,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1029,7 +1029,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1038,7 +1038,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1047,7 +1047,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1056,7 +1056,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1065,7 +1065,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1074,7 +1074,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1083,7 +1083,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1092,7 +1092,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1103,7 +1103,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi22.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi23.0/eeprom",
                 "powerOffOnly": true,
                 "offset": 196608,
@@ -1119,7 +1119,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1128,7 +1128,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1137,7 +1137,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1146,7 +1146,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1155,7 +1155,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1164,7 +1164,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1173,7 +1173,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1182,7 +1182,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1191,7 +1191,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1200,7 +1200,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1209,7 +1209,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1218,7 +1218,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1227,7 +1227,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1236,7 +1236,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1245,7 +1245,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1256,7 +1256,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi32.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi33.0/eeprom",
                 "powerOffOnly": true,
                 "offset": 196608,
@@ -1272,7 +1272,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1281,7 +1281,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1290,7 +1290,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1299,7 +1299,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1308,7 +1308,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1317,7 +1317,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1326,7 +1326,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1335,7 +1335,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1344,7 +1344,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1353,7 +1353,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1362,7 +1362,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1371,7 +1371,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1380,7 +1380,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1389,7 +1389,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1398,7 +1398,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1409,7 +1409,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi42.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi43.0/eeprom",
                 "powerOffOnly": true,
                 "offset": 196608,
@@ -1425,7 +1425,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1434,7 +1434,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1443,7 +1443,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1452,7 +1452,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1461,7 +1461,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1470,7 +1470,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1479,7 +1479,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1488,7 +1488,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1497,7 +1497,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1506,7 +1506,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1515,7 +1515,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1524,7 +1524,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1533,7 +1533,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1542,7 +1542,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1551,7 +1551,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1562,7 +1562,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/4-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
                 "pcaChipAddress": "4-0060",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -1604,7 +1604,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1619,7 +1619,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1636,7 +1636,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/5-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "pcaChipAddress": "5-0060",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -1678,7 +1678,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1693,7 +1693,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1710,7 +1710,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/5-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "pcaChipAddress": "5-0061",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -1752,7 +1752,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1767,7 +1767,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1784,7 +1784,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/11-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "pcaChipAddress": "11-0060",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -1826,7 +1826,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1841,7 +1841,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1856,7 +1856,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1871,7 +1871,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1886,7 +1886,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1901,7 +1901,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1918,7 +1918,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/4-0052/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot2/pcie_card2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "pcaChipAddress": "4-0062",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -1961,7 +1961,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/6-0053/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot6/pcie_card6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
                 "preAction": {
@@ -1996,7 +1996,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/6-0052/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot7/pcie_card7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "pcaChipAddress": "6-0062",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -2039,7 +2039,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/6-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot9/pcie_card9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "pcaChipAddress": "6-0060",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -2082,7 +2082,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/11-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "pcaChipAddress": "11-0061",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -2124,7 +2124,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector0",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2139,7 +2139,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector1",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2154,7 +2154,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector2",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2169,7 +2169,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector3",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2186,7 +2186,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/4-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot1/pcie_card1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
                 "pcaChipAddress": "4-0061",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -2229,7 +2229,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/6-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "pcaChipAddress": "6-0061",
                 "replaceableAtStandby": true,
                 "concurrentlyMaintainable": true,
@@ -2271,7 +2271,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector0",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2286,7 +2286,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector1",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2301,7 +2301,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector2",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2316,7 +2316,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector3",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2333,7 +2333,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/13-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
                     "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
@@ -2346,7 +2346,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2363,7 +2363,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme2/dp0_drive2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2/dp0_drive2",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2381,7 +2381,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme3",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2398,7 +2398,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme3/dp0_drive3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme3/dp0_drive3",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2416,7 +2416,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme4",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2433,7 +2433,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme4/dp0_drive4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme4/dp0_drive4",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2451,7 +2451,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme5",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2468,7 +2468,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme5/dp0_drive5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme5/dp0_drive5",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2486,7 +2486,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2499,7 +2499,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2512,7 +2512,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2525,7 +2525,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2538,7 +2538,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp0_cable0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp0_cable0",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2549,7 +2549,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp0_cable1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp0_cable1",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2562,7 +2562,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/14-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
                     "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
@@ -2575,7 +2575,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2592,7 +2592,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme2/dp1_drive2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2/dp1_drive2",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2610,7 +2610,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme3",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2627,7 +2627,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme3/dp1_drive3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme3/dp1_drive3",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2645,7 +2645,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme4",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2662,7 +2662,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme4/dp1_drive4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme4/dp1_drive4",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2680,7 +2680,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme5",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2697,7 +2697,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme5/dp1_drive5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme5/dp1_drive5",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2715,7 +2715,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2728,7 +2728,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2741,7 +2741,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2754,7 +2754,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2767,7 +2767,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp1_cable0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp1_cable0",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2778,7 +2778,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp1_cable1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp1_cable1",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2791,7 +2791,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/111-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2806,7 +2806,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2815,7 +2815,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2824,7 +2824,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2833,7 +2833,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2844,7 +2844,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/110-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2859,7 +2859,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2868,7 +2868,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2877,7 +2877,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2886,7 +2886,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2897,7 +2897,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/214-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2912,7 +2912,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2921,7 +2921,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2930,7 +2930,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2939,7 +2939,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2950,7 +2950,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/210-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2965,7 +2965,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2974,7 +2974,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2983,7 +2983,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2992,7 +2992,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3003,7 +3003,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/202-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3018,7 +3018,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3027,7 +3027,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3036,7 +3036,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3045,7 +3045,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3056,7 +3056,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/311-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3071,7 +3071,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3080,7 +3080,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3089,7 +3089,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3098,7 +3098,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3109,7 +3109,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/310-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3124,7 +3124,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3133,7 +3133,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3142,7 +3142,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3151,7 +3151,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3162,7 +3162,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/312-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3177,7 +3177,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3186,7 +3186,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3195,7 +3195,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3204,7 +3204,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3215,7 +3215,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/402-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3230,7 +3230,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3239,7 +3239,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3248,7 +3248,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3257,7 +3257,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3268,7 +3268,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/410-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3283,7 +3283,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3292,7 +3292,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3301,7 +3301,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3310,7 +3310,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3321,7 +3321,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/112-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3336,7 +3336,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3345,7 +3345,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3354,7 +3354,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3363,7 +3363,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3374,7 +3374,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/115-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3389,7 +3389,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3398,7 +3398,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3407,7 +3407,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3416,7 +3416,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3427,7 +3427,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/100-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3442,7 +3442,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3451,7 +3451,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3460,7 +3460,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3469,7 +3469,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3480,7 +3480,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/101-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3495,7 +3495,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3504,7 +3504,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3513,7 +3513,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3522,7 +3522,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3533,7 +3533,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/114-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3548,7 +3548,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3557,7 +3557,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3566,7 +3566,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3575,7 +3575,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3586,7 +3586,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/113-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3601,7 +3601,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3610,7 +3610,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3619,7 +3619,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3628,7 +3628,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3639,7 +3639,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/216-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3654,7 +3654,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3663,7 +3663,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3672,7 +3672,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3681,7 +3681,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3692,7 +3692,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/203-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3707,7 +3707,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3716,7 +3716,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3725,7 +3725,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3734,7 +3734,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3745,7 +3745,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/217-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3760,7 +3760,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3769,7 +3769,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3778,7 +3778,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3787,7 +3787,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3798,7 +3798,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/211-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3813,7 +3813,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3822,7 +3822,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3831,7 +3831,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3840,7 +3840,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3851,7 +3851,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/215-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3866,7 +3866,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3875,7 +3875,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3884,7 +3884,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3893,7 +3893,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3904,7 +3904,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/315-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3919,7 +3919,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3928,7 +3928,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3937,7 +3937,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3946,7 +3946,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3957,7 +3957,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/300-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3972,7 +3972,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3981,7 +3981,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3990,7 +3990,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3999,7 +3999,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4010,7 +4010,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/313-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4025,7 +4025,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4034,7 +4034,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4043,7 +4043,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4052,7 +4052,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4063,7 +4063,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/314-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4078,7 +4078,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4087,7 +4087,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4096,7 +4096,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4105,7 +4105,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4116,7 +4116,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/301-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4131,7 +4131,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4140,7 +4140,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4149,7 +4149,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4158,7 +4158,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4169,7 +4169,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/417-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4184,7 +4184,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4193,7 +4193,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4202,7 +4202,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4211,7 +4211,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4222,7 +4222,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/403-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4237,7 +4237,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4246,7 +4246,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4255,7 +4255,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4264,7 +4264,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4275,7 +4275,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/416-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4290,7 +4290,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4299,7 +4299,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4308,7 +4308,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4317,7 +4317,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4328,7 +4328,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/411-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4343,7 +4343,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4352,7 +4352,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4361,7 +4361,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4370,7 +4370,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4381,7 +4381,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/415-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4396,7 +4396,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4405,7 +4405,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4414,7 +4414,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4423,7 +4423,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4434,7 +4434,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/414-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4449,7 +4449,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4458,7 +4458,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4467,7 +4467,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4476,7 +4476,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {

--- a/configuration/ibm/50001001_v2.json
+++ b/configuration/ibm/50001001_v2.json
@@ -59,7 +59,7 @@
     "frus": {
         "/sys/bus/i2c/drivers/at24/8-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard",
                 "isSystemVpd": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Board.Motherboard": null,
@@ -72,7 +72,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -81,7 +81,7 @@
                 }
             },
             {
-                "inventoryPath": "/system",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system",
                 "inherit": false,
                 "isSystemVpd": true,
                 "copyRecords": ["VSYS"],
@@ -110,7 +110,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis",
                 "isSystemVpd": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Chassis": null,
@@ -124,7 +124,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -141,7 +141,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -158,7 +158,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -175,7 +175,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -192,7 +192,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -209,7 +209,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -226,7 +226,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -243,7 +243,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -260,7 +260,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -277,7 +277,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -294,7 +294,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -311,7 +311,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot12",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -327,7 +327,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot12/pcie_card12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot12/pcie_card12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
@@ -343,7 +343,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/powersupply0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -354,7 +354,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/powersupply1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -365,7 +365,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -395,7 +395,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -425,7 +425,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -455,7 +455,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -485,7 +485,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -515,7 +515,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/fan5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5",
                 "inherit": false,
                 "embedded": false,
                 "synthesized": true,
@@ -545,7 +545,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/tod_battery",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tod_battery",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Battery": null,
                     "com.ibm.ipzvpd.Location": {
@@ -557,7 +557,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -570,7 +570,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -583,7 +583,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -596,7 +596,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -609,7 +609,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -622,7 +622,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -635,7 +635,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -648,7 +648,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -661,7 +661,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -674,7 +674,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -687,7 +687,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -700,7 +700,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -713,7 +713,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -726,7 +726,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -739,7 +739,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector15",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector15",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -752,7 +752,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector17",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector17",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -765,7 +765,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/connector18",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector18",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -780,7 +780,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/8-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Bmc": null,
                     "com.ibm.ipzvpd.Location": {
@@ -792,7 +792,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/ethernet0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/ethernet0",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -814,7 +814,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/ethernet1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/ethernet1",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -836,7 +836,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/usb0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/usb0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -849,7 +849,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/displayport0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/displayport0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -862,7 +862,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/ebmc_card_bmc/usb1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/usb1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -877,7 +877,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/0-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/tpm_wilson",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tpm_wilson",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Tpm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -891,7 +891,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/7-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/base_op_panel_blyth",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                 "essentialFru": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Panel": null,
@@ -906,7 +906,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/7-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/lcd_op_panel_hill",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "devAddress": "7-0051",
                 "driverType": "at24",
                 "busType": "i2c",
@@ -939,7 +939,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/9-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/vdd_vrm0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -953,7 +953,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/10-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/vdd_vrm1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm1",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -967,7 +967,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi12.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi13.0/eeprom",
                 "cpuType": "primary",
                 "powerOffOnly": true,
@@ -984,7 +984,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -993,7 +993,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1002,7 +1002,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1011,7 +1011,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1020,7 +1020,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1029,7 +1029,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1038,7 +1038,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1047,7 +1047,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1056,7 +1056,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1065,7 +1065,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1074,7 +1074,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1083,7 +1083,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1092,7 +1092,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1101,7 +1101,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1110,7 +1110,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu0/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1121,7 +1121,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi22.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi23.0/eeprom",
                 "powerOffOnly": true,
                 "offset": 196608,
@@ -1137,7 +1137,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1146,7 +1146,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1155,7 +1155,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1164,7 +1164,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1173,7 +1173,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1182,7 +1182,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1191,7 +1191,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1200,7 +1200,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1209,7 +1209,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1218,7 +1218,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1227,7 +1227,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1236,7 +1236,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1245,7 +1245,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1254,7 +1254,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1263,7 +1263,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm0/cpu1/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1274,7 +1274,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi32.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi33.0/eeprom",
                 "powerOffOnly": true,
                 "offset": 196608,
@@ -1290,7 +1290,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1299,7 +1299,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1308,7 +1308,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1317,7 +1317,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1326,7 +1326,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1335,7 +1335,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1344,7 +1344,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1353,7 +1353,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1362,7 +1362,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1371,7 +1371,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1380,7 +1380,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1389,7 +1389,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1398,7 +1398,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1407,7 +1407,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1416,7 +1416,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu0/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1427,7 +1427,7 @@
         ],
         "/sys/bus/spi/drivers/at25/spi42.0/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1",
                 "redundantEeprom": "/sys/bus/spi/drivers/at25/spi43.0/eeprom",
                 "powerOffOnly": true,
                 "offset": 196608,
@@ -1443,7 +1443,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1452,7 +1452,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1461,7 +1461,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1470,7 +1470,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1479,7 +1479,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1488,7 +1488,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1497,7 +1497,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit6",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1506,7 +1506,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit7",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1515,7 +1515,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit8",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1524,7 +1524,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit9",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1533,7 +1533,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit10",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1542,7 +1542,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit11",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1551,7 +1551,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit12",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1560,7 +1560,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit13",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1569,7 +1569,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dcm1/cpu1/unit14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit14",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -1580,7 +1580,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/20-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
                 "devAddress": "20-0050",
                 "pcaChipAddress": "20-0060",
                 "replaceableAtStandby": true,
@@ -1621,7 +1621,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1637,7 +1637,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1655,7 +1655,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/23-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "devAddress": "23-0050",
                 "pcaChipAddress": "23-0060",
                 "replaceableAtStandby": true,
@@ -1696,7 +1696,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1712,7 +1712,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1730,7 +1730,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/24-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "devAddress": "24-0051",
                 "pcaChipAddress": "24-0061",
                 "replaceableAtStandby": true,
@@ -1771,7 +1771,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1787,7 +1787,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1805,7 +1805,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/29-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "devAddress": "29-0050",
                 "pcaChipAddress": "29-0060",
                 "replaceableAtStandby": true,
@@ -1846,7 +1846,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1862,7 +1862,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["2CE2", "58FF", "6B92", "6B99"],
@@ -1878,7 +1878,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1894,7 +1894,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1910,7 +1910,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1926,7 +1926,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -1944,7 +1944,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/22-0052/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot2/pcie_card2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "devAddress": "22-0052",
                 "pcaChipAddress": "22-0062",
                 "replaceableAtStandby": true,
@@ -1986,7 +1986,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/25-0053/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot6/pcie_card6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "devAddress": "25-0053",
                 "replaceableAtStandby": true,
                 "busType": "i2c",
@@ -2020,7 +2020,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/26-0052/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot7/pcie_card7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "devAddress": "26-0052",
                 "pcaChipAddress": "26-0062",
                 "replaceableAtStandby": true,
@@ -2062,7 +2062,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/27-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot9/pcie_card9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "devAddress": "27-0050",
                 "pcaChipAddress": "27-0060",
                 "replaceableAtStandby": true,
@@ -2104,7 +2104,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/30-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "devAddress": "30-0051",
                 "pcaChipAddress": "30-0061",
                 "replaceableAtStandby": true,
@@ -2145,7 +2145,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector0",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2161,7 +2161,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector1",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2177,7 +2177,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector2",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2193,7 +2193,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector3",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2211,7 +2211,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/21-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot1/pcie_card1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
                 "devAddress": "21-0051",
                 "pcaChipAddress": "21-0061",
                 "replaceableAtStandby": true,
@@ -2253,7 +2253,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/28-0051/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "devAddress": "28-0051",
                 "pcaChipAddress": "28-0061",
                 "replaceableAtStandby": true,
@@ -2294,7 +2294,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector0",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2310,7 +2310,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector1",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2326,7 +2326,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector2",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2342,7 +2342,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector3",
                 "inherit": false,
                 "noprime": true,
                 "ccin": ["6B87"],
@@ -2360,7 +2360,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/13-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
                     "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
@@ -2373,7 +2373,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2390,7 +2390,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme2/dp0_drive2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2/dp0_drive2",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2408,7 +2408,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme3",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2425,7 +2425,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme3/dp0_drive3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme3/dp0_drive3",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2443,7 +2443,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme4",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2460,7 +2460,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme4/dp0_drive4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme4/dp0_drive4",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2478,7 +2478,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme5",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2495,7 +2495,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/nvme5/dp0_drive5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme5/dp0_drive5",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "13-0050",
@@ -2513,7 +2513,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2527,7 +2527,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2541,7 +2541,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2555,7 +2555,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane0/dp0_connector5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2569,7 +2569,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp0_cable0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp0_cable0",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2580,7 +2580,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp0_cable1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp0_cable1",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2593,7 +2593,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/14-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
                     "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
@@ -2606,7 +2606,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2623,7 +2623,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme2/dp1_drive2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2/dp1_drive2",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2641,7 +2641,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme3",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2658,7 +2658,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme3/dp1_drive3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme3/dp1_drive3",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2676,7 +2676,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme4",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2693,7 +2693,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme4/dp1_drive4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme4/dp1_drive4",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2711,7 +2711,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme5",
                 "inherit": false,
                 "extraInterfaces": {
                     "com.ibm.Control.Host.PCIeLink": null,
@@ -2728,7 +2728,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/nvme5/dp1_drive5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme5/dp1_drive5",
                 "inherit": false,
                 "embedded": false,
                 "devAddress": "14-0050",
@@ -2746,7 +2746,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2760,7 +2760,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2774,7 +2774,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector4",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2788,7 +2788,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/disk_backplane1/dp1_connector5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector5",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Connector": null,
@@ -2802,7 +2802,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp1_cable0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp1_cable0",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2813,7 +2813,7 @@
                 }
             },
             {
-                "inventoryPath": "/cables/dp1_cable1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/cables/dp1_cable1",
                 "inherit": false,
                 "noprime": true,
                 "extraInterfaces": {
@@ -2826,7 +2826,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/111-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2841,7 +2841,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2850,7 +2850,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2859,7 +2859,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2868,7 +2868,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm0/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2879,7 +2879,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/110-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2894,7 +2894,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2903,7 +2903,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2912,7 +2912,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2921,7 +2921,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm1/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2932,7 +2932,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/214-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2947,7 +2947,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2956,7 +2956,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2965,7 +2965,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2974,7 +2974,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm10/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -2985,7 +2985,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/210-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3000,7 +3000,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3009,7 +3009,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3018,7 +3018,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3027,7 +3027,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm9/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3038,7 +3038,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/202-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3053,7 +3053,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3062,7 +3062,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3071,7 +3071,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3080,7 +3080,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm8/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3091,7 +3091,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/311-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3106,7 +3106,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3115,7 +3115,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3124,7 +3124,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3133,7 +3133,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm16/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3144,7 +3144,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/310-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3159,7 +3159,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3168,7 +3168,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3177,7 +3177,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3186,7 +3186,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm17/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3197,7 +3197,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/312-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3212,7 +3212,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3221,7 +3221,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3230,7 +3230,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3239,7 +3239,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm18/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3250,7 +3250,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/402-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3265,7 +3265,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3274,7 +3274,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3283,7 +3283,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3292,7 +3292,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm24/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3303,7 +3303,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/410-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3318,7 +3318,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3327,7 +3327,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3336,7 +3336,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3345,7 +3345,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm25/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3356,7 +3356,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/112-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3371,7 +3371,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3380,7 +3380,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3389,7 +3389,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3398,7 +3398,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm2/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3409,7 +3409,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/115-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3424,7 +3424,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3433,7 +3433,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3442,7 +3442,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3451,7 +3451,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm4/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3462,7 +3462,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/100-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3477,7 +3477,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3486,7 +3486,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3495,7 +3495,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3504,7 +3504,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm5/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3515,7 +3515,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/101-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3530,7 +3530,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3539,7 +3539,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3548,7 +3548,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3557,7 +3557,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm7/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3568,7 +3568,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/114-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3583,7 +3583,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3592,7 +3592,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3601,7 +3601,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3610,7 +3610,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm6/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3621,7 +3621,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/113-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3636,7 +3636,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3645,7 +3645,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3654,7 +3654,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3663,7 +3663,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm3/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3674,7 +3674,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/216-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3689,7 +3689,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3698,7 +3698,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3707,7 +3707,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3716,7 +3716,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm15/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3727,7 +3727,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/203-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3742,7 +3742,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3751,7 +3751,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3760,7 +3760,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3769,7 +3769,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm14/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3780,7 +3780,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/217-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3795,7 +3795,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3804,7 +3804,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3813,7 +3813,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3822,7 +3822,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm11/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3833,7 +3833,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/211-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3848,7 +3848,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3857,7 +3857,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3866,7 +3866,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3875,7 +3875,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm13/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3886,7 +3886,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/215-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3901,7 +3901,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3910,7 +3910,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3919,7 +3919,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3928,7 +3928,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm12/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3939,7 +3939,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/315-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3954,7 +3954,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3963,7 +3963,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3972,7 +3972,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3981,7 +3981,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm20/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -3992,7 +3992,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/300-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4007,7 +4007,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4016,7 +4016,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4025,7 +4025,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4034,7 +4034,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm21/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4045,7 +4045,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/313-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4060,7 +4060,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4069,7 +4069,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4078,7 +4078,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4087,7 +4087,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm19/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4098,7 +4098,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/314-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4113,7 +4113,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4122,7 +4122,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4131,7 +4131,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4140,7 +4140,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm22/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4151,7 +4151,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/301-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4166,7 +4166,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4175,7 +4175,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4184,7 +4184,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4193,7 +4193,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm23/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4204,7 +4204,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/417-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4219,7 +4219,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4228,7 +4228,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4237,7 +4237,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4246,7 +4246,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm27/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4257,7 +4257,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/403-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4272,7 +4272,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4281,7 +4281,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4290,7 +4290,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4299,7 +4299,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm30/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4310,7 +4310,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/416-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4325,7 +4325,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4334,7 +4334,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4343,7 +4343,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4352,7 +4352,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm31/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4363,7 +4363,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/411-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4378,7 +4378,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4387,7 +4387,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4396,7 +4396,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4405,7 +4405,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm29/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4416,7 +4416,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/415-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4431,7 +4431,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4440,7 +4440,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4449,7 +4449,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4458,7 +4458,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm28/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4469,7 +4469,7 @@
         ],
         "/sys/bus/i2c/drivers/at24/414-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4484,7 +4484,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit0",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit0",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4493,7 +4493,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit1",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit1",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4502,7 +4502,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit2",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit2",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {
@@ -4511,7 +4511,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis/motherboard/dimm26/unit3",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit3",
                 "inherit": false,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item": {


### PR DESCRIPTION
This commit has an update in rainier 2U JSON to have complete D-bus inventory path with prefix /xyz/openbmc_project/inventory.