### PR TITLE
Publish DRAM Manufacturer ID

### DIFF
--- a/vpd-parser/isdimm_vpd_parser.hpp
+++ b/vpd-parser/isdimm_vpd_parser.hpp
@@ -99,6 +99,13 @@ class isdimmVpdParser : public ParserInterface
     auto getDDR4CCIN(const std::string& partNumber);
 
     /**
+     * @brief The function fetches manufacturer's ID of DIMM.
+     *
+     * @return manufacturer ID.
+     */
+    auto getDDR4ManufacturerId();
+
+    /**
      * @brief This function calculates DIMM size from SPD
      *
      * @param[in] iterator - iterator to buffer containing SPD
@@ -137,6 +144,13 @@ class isdimmVpdParser : public ParserInterface
      * @return allocated CCIN.
      */
     auto getDDR5CCIN(const std::string& partNumber);
+
+    /**
+     * @brief The function fetches manufacturer's ID of DIMM.
+     *
+     * @return manufacturer ID.
+     */
+    auto getDDR5ManufacturerId();
 
     // vdp file to be parsed
     const Binary& memVpd;

--- a/vpd-parser/memory_vpd_parser.cpp
+++ b/vpd-parser/memory_vpd_parser.cpp
@@ -42,6 +42,8 @@ static constexpr auto SDRAM_DENSITY_PER_DIE_UNDEFINED = 0;
 
 static constexpr auto PRIMARY_BUS_WIDTH_32_BITS = 32;
 static constexpr auto PRIMARY_BUS_WIDTH_UNUSED = 0;
+static constexpr auto DRAM_MANUFACTURER_ID_OFFSET = 0x228;
+static constexpr auto DRAM_MANUFACTURER_ID_LENGTH = 0x02;
 
 bool memoryVpdParser::checkValidValue(uint8_t l_ByteValue, uint8_t shift,
                                       uint8_t minValue, uint8_t maxValue)
@@ -364,10 +366,15 @@ kwdVpdMap memoryVpdParser::readKeywords(Binary::const_iterator iterator)
     advance(iterator, SERIAL_NUM_LEN);
     Binary ccin(iterator, iterator + CCIN_LEN);
 
+    Binary mfgId(DRAM_MANUFACTURER_ID_LENGTH);
+    std::copy_n((memVpd.cbegin() + DRAM_MANUFACTURER_ID_OFFSET),
+                DRAM_MANUFACTURER_ID_LENGTH, mfgId.begin());
+
     map.emplace("FN", partNumber);
     map.emplace("PN", move(partNumber));
     map.emplace("SN", move(serialNumber));
     map.emplace("CC", move(ccin));
+    map.emplace("DI", move(mfgId));
 
     return map;
 }


### PR DESCRIPTION
The commit publishes DRAM manufacturer ID over D-Bus.

Dependent PDI commit:
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/71554

Change-Id: I8acb8f311c83cfcbbd7cadc24e2e226f15824069