### PR TITLE
meson:include phosphor-dbus-interfaces dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ endif
 build_tests = get_option('tests')
 
 sdbusplus = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
+phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
 
 if not build_tests.disabled()
     subdir('test')
@@ -77,7 +78,7 @@ vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',
                     ] + common_SOURCES
 
-parser_dependencies = [sdbusplus, libgpiodcxx]
+parser_dependencies = [sdbusplus, libgpiodcxx, phosphor_dbus_interfaces]
 
 parser_build_arguments = []
 if get_option('ibm_system').enabled()


### PR DESCRIPTION
This commit includes phosphor-dbus-interfaces as dependency module in vpd binaries.