### PR TITLE
utils:API to get FRU EEPROM path from JSON

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -374,5 +374,22 @@ bool executePreAction(const nlohmann::json& i_parsedConfigJson,
 std::string
     getRedundantEepromPathFromJson(const nlohmann::json& i_sysCfgJsonObj,
                                    const std::string& i_vpdPath);
+
+/**
+ * @brief Get FRU EEPROM path from system config JSON
+ *
+ * Given either D-bus inventory path/FRU EEPROM path/redundant EEPROM path,
+ * this API returns FRU EEPROM path if present in JSON.
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object
+ * @param[in] i_vpdPath - Path to where VPD is stored.
+ *
+ * @throw std::runtime_error.
+ *
+ * @return On success return valid path, on failure return empty string.
+ */
+std::string getFruPathFromJson(const nlohmann::json& i_sysCfgJsonObj,
+                               const std::string& i_vpdPath);
+
 } // namespace utils
 } // namespace vpd

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -808,5 +808,43 @@ std::string
     }
     return std::string();
 }
+
+std::string getFruPathFromJson(const nlohmann::json& i_sysCfgJsonObj,
+                               const std::string& i_vpdPath)
+{
+    if (i_vpdPath.empty())
+    {
+        throw std::runtime_error("Path parameter is empty.");
+    }
+
+    if (!i_sysCfgJsonObj.contains("frus"))
+    {
+        throw std::runtime_error("Missing frus tag in system config JSON.");
+    }
+
+    // check if given path is FRU path
+    if (i_sysCfgJsonObj["frus"].contains(i_vpdPath))
+    {
+        return i_vpdPath;
+    }
+
+    const nlohmann::json& l_fruList =
+        i_sysCfgJsonObj["frus"].get_ref<const nlohmann::json::object_t&>();
+
+    for (const auto& l_fru : l_fruList.items())
+    {
+        const auto l_fruPath = l_fru.key();
+
+        // check if given path is redundant FRU path or inventory path
+        if (i_vpdPath == i_sysCfgJsonObj["frus"][l_fruPath].at(0).value(
+                             "redundantEeprom", "") ||
+            (i_vpdPath == i_sysCfgJsonObj["frus"][l_fruPath].at(0).value(
+                              "inventoryPath", "")))
+        {
+            return l_fruPath;
+        }
+    }
+    return std::string();
+}
 } // namespace utils
 } // namespace vpd


### PR DESCRIPTION
Given a D-bus inventory path/redundant EEPROM path/FRU EEPROM path
if present in JSON, this API returns the FRU EEPROM path taken from JSON.

Test cases covered:
1. Given a redundant EEPROM path, get back the FRU EEPROM path.
2. Given an inventory dbus path, get back the FRU EEPROM path
taken from JSON.
3. Given a FRU EEPROM path, get back the same.
4. Given any path if not present in JSON, get back the empty string.
