### PR TITLE
utils:API to get redundant EEPROM path from JSON

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -365,7 +365,7 @@ bool executePreAction(const nlohmann::json& i_parsedConfigJson,
  * API returns the redundant FRU path taken from "redundantEeprom" tag from
  * system config JSON.
  *
- * @param[in] i_sysCfgJsonObj - system config JSON object
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
  * @param[in] i_vpdPath - Path to where VPD is stored.
  *
  * @throw std::runtime_error.

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -358,5 +358,21 @@ bool executePreAction(const nlohmann::json& i_parsedConfigJson,
                       const std::string& i_vpdFilePath,
                       const std::string& i_flagToProcess);
 
+/**
+ * @brief Get redundant FRU path from system config JSON
+ *
+ * Given either D-bus inventory path/FRU path/redundant FRU path, this
+ * API returns the redundant FRU path taken from "redundantEeprom" tag from
+ * system config JSON.
+ *
+ * @param[in] i_sysCfgJsonObj - system config JSON object
+ * @param[in] i_vpdPath - Path to where VPD is stored.
+ *
+ * @throw std::runtime_error.
+ * @return On success return valid path, on failure return empty string.
+ */
+std::string
+    getRedundantEepromPathFromJson(const nlohmann::json& i_sysCfgJsonObj,
+                                   const std::string& i_vpdPath);
 } // namespace utils
 } // namespace vpd


### PR DESCRIPTION
Test cases covered:
1. Given a redundant EEPROM path, get back the same.
2. Given an inventory dbus path, get back the redundant EEPROM path taken from JSON.
3. Given a FRU EEPROM path, get back the redundant EEPROM path taken from JSON if present.
4. Given a FRU EEPROM path, if redundant EEPROM path is not present in JSON, get back the empty string.