### PR TITLE
Update cxp port functional status on CM

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -711,11 +711,6 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path path)
     string chipAddress =
         jsonFile["frus"][vpdFilePath].at(0).value("pcaChipAddress", "");
 
-    // Unbind the LED driver for this FRU
-    cout << "Unbinding device- " << chipAddress << endl;
-    executeCmd(createBindUnbindDriverCmnd(chipAddress, "i2c", "leds-pca955x",
-                                          "/unbind"));
-
     // if the FRU is not present then log error
     if (readBusProperty(objPath, "xyz.openbmc_project.Inventory.Item",
                         "Present") == "false")
@@ -725,6 +720,44 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path path)
     }
     else
     {
+        // check if we have cxp-port populated for the given object path.
+        std::vector<std::string> interfaceList{
+            "xyz.openbmc_project.State.Decorator.OperationalStatus"};
+        MapperResponse subTree =
+            getObjectSubtreeForInterfaces(path, 0, interfaceList);
+
+        if (subTree.size() != 0)
+        {
+            for (auto [objectPath, serviceInterfaceMap] : subTree)
+            {
+                std::string subTreeObjPath{objectPath};
+                if (subTreeObjPath.find("cxp_top") != std::string::npos ||
+                    subTreeObjPath.find("cxp_bot") != std::string::npos)
+                {
+                    // Strip any inventory prefix in path
+                    if (subTreeObjPath.find(INVENTORY_PATH) == 0)
+                    {
+                        subTreeObjPath =
+                            subTreeObjPath.substr(sizeof(INVENTORY_PATH) - 1);
+                    }
+
+                    inventory::ObjectMap objectMap{
+                        {subTreeObjPath,
+                         {{"xyz.openbmc_project.State.Decorator."
+                           "OperationalStatus",
+                           {{"Functional", true}}}}}};
+
+                    // objectMap.emplace(objectPath, move(interfaceMap));
+                    common::utility::callPIM(move(objectMap));
+                }
+            }
+        }
+
+        // Unbind the LED driver for this FRU
+        cout << "Unbinding device- " << chipAddress << endl;
+        executeCmd(createBindUnbindDriverCmnd(chipAddress, "i2c",
+                                              "leds-pca955x", "/unbind"));
+
         // Set present property of FRU as false as it has been removed.
         // CC data for FRU is also removed as
         // a) FRU is not there so CC does not make sense.


### PR DESCRIPTION
If the PCIe Card going through CM hosts object path for cxp_top and cxp_bot as its subtree, then functional status for those ports also needs to be toggled along with that of card being concurrently maintained.

Change-Id: Ia693f368a3eb1b3bd6f9ee1e62eabecaa3198803