### PR TITLE
Invoke backup and restore API.

### DIFF
--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -606,5 +606,37 @@ inline std::string
     }
     return std::string();
 }
+
+/**
+ * @brief An API to check backup and restore VPD is required.
+ *
+ * The API checks if there is provision for backup and restore mentioned in the
+ * system config JSON, by looking "backupRestoreConfigPath" tag.
+ * Checks if the path mentioned is a hardware path, by checking if the file path
+ * exists and size of contents in the path.
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
+ *
+ * @return true if backup and restore is required, false otherwise.
+ */
+inline bool isBackupAndRestoreRequired(const nlohmann::json& i_sysCfgJsonObj)
+{
+    try
+    {
+        const std::string& l_backupAndRestoreCfgFilePath =
+            i_sysCfgJsonObj.value("backupRestoreConfigPath", "");
+        if (!l_backupAndRestoreCfgFilePath.empty() &&
+            std::filesystem::exists(l_backupAndRestoreCfgFilePath) &&
+            !std::filesystem::is_empty(l_backupAndRestoreCfgFilePath))
+        {
+            return true;
+        }
+    }
+    catch (std::exception& ex)
+    {
+        logging::logMessage(ex.what());
+    }
+    return false;
+}
 } // namespace jsonUtility
 } // namespace vpd

--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -368,6 +368,13 @@ class Worker
      */
     void enableMuxChips();
 
+    /**
+     * @brief An API to perform backup or restore of VPD.
+     *
+     * @param[in,out] io_srcVpdMap - Source VPD map.
+     */
+    void performBackupAndRestore(types::VPDMapVariant& io_srcVpdMap);
+
     // Parsed JSON file.
     nlohmann::json m_parsedJson{};
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -2,6 +2,7 @@
 
 #include "manager.hpp"
 
+#include "backup_restore.hpp"
 #include "constants.hpp"
 #include "exceptions.hpp"
 #include "logger.hpp"
@@ -180,6 +181,14 @@ void Manager::SetTimerToDetectVpdCollectionStatus()
             l_timer.cancel();
             m_interface->set_property("CollectionStatus",
                                       std::string("Completed"));
+
+            const nlohmann::json& l_sysCfgJsonObj =
+                m_worker->getSysCfgJsonObj();
+            if (jsonUtility::isBackupAndRestoreRequired(l_sysCfgJsonObj))
+            {
+                BackupAndRestore l_backupAndRestoreObj(l_sysCfgJsonObj);
+                l_backupAndRestoreObj.backupAndRestore();
+            }
         }
         else
         {

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -2,6 +2,7 @@
 
 #include "worker.hpp"
 
+#include "backup_restore.hpp"
 #include "configuration.hpp"
 #include "constants.hpp"
 #include "exceptions.hpp"
@@ -18,6 +19,7 @@
 #include <fstream>
 #include <future>
 #include <typeindex>
+#include <unordered_set>
 
 namespace vpd
 {
@@ -491,10 +493,10 @@ void Worker::setDeviceTreeAndJson()
     if (fitConfigVal.find(devTreeFromJson) != std::string::npos)
     { // fitconfig is updated and correct JSON is set.
 
-        if (isSystemVPDOnDBus())
+        if (isSystemVPDOnDBus() &&
+            jsonUtility::isBackupAndRestoreRequired(m_parsedJson))
         {
-            // TODO
-            //  Restore system VPD logic should initiate from here.
+            performBackupAndRestore(parsedVpdMap);
         }
 
         // proceed to publish system VPD.
@@ -1215,6 +1217,53 @@ void Worker::collectFrusFromJson()
                     std::to_string(m_activeCollectionThreadCount));
             }
         }}.detach();
+    }
+}
+
+// ToDo: Move the API under IBM_SYSTEM
+void Worker::performBackupAndRestore(types::VPDMapVariant& io_srcVpdMap)
+{
+    try
+    {
+        std::string l_backupAndRestoreCfgFilePath =
+            m_parsedJson.value("backupRestoreConfigPath", "");
+
+        nlohmann::json l_backupAndRestoreCfgJsonObj =
+            jsonUtility::getParsedJson(l_backupAndRestoreCfgFilePath);
+
+        if (!l_backupAndRestoreCfgJsonObj.empty() &&
+            ((l_backupAndRestoreCfgJsonObj.contains("source") &&
+              l_backupAndRestoreCfgJsonObj["source"].contains(
+                  "inventoryPath")) ||
+             (l_backupAndRestoreCfgJsonObj.contains("destination") &&
+              l_backupAndRestoreCfgJsonObj["destination"].contains(
+                  "inventoryPath"))))
+        {
+            BackupAndRestore l_backupAndRestoreObj(m_parsedJson);
+            auto [l_srcVpdVariant,
+                  l_dstVpdVariant] = l_backupAndRestoreObj.backupAndRestore();
+
+            // ToDo: Revisit is this check is required or not.
+            if (auto l_srcVpdMap =
+                    std::get_if<types::IPZVpdMap>(&l_srcVpdVariant);
+                l_srcVpdMap && !(*l_srcVpdMap).empty())
+            {
+                io_srcVpdMap = std::move(l_srcVpdVariant);
+            }
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        logging::logMessage(ex.what());
+        // ToDo: Uncomment when PEL implementation goes in.
+        /*std::string l_errorMsg(
+            "Exception caught while backup and restore VPD keyword's. Error: " +
+            std::string(ex.what()));
+        inventory::PelAdditionalData l_additionalData{};
+        l_additionalData.emplace("DESCRIPTION", l_errorMsg);
+        createPEL(l_additionalData,
+        PelSeverity::ERROR, errBackupAndRestore, nullptr);
+        */
     }
 }
 } // namespace vpd


### PR DESCRIPTION
This commit adds changes to invoke backupAndRestore API to backup and restore VPD keyword’s.

Depend on the system type backupAndRestore API gets triggered either before publishing system VPD to DBus or after collecting system VPD and also all FRU’s VPD.