### PR TITLE
Manager:API to read keyword value from hardware

### DIFF
--- a/include/parser_interface.hpp
+++ b/include/parser_interface.hpp
@@ -27,6 +27,19 @@ class ParserInterface
     virtual types::VPDMapVariant parse() = 0;
 
     /**
+     * @brief Read keyword's value from hardware
+     *
+     * @param[in] types::ReadVpdParams - Parameters required to perform read.
+     *
+     * @return keyword's value on successful read. Exception on failure.
+     */
+    virtual types::DbusVariantType
+        readKeywordFromHardware(const types::ReadVpdParams)
+    {
+        return types::DbusVariantType();
+    }
+
+    /**
      * @brief Virtual destructor.
      */
     virtual ~ParserInterface() {}

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -3,6 +3,7 @@
 #include <phosphor-logging/elog-errors.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/server.hpp>
+#include <xyz/openbmc_project/Common/Device/error.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <tuple>
@@ -119,12 +120,6 @@ using DbusInvalidArgument =
     sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
 using InvalidArgument = phosphor::logging::xyz::openbmc_project::Common::InvalidArgument;
 
-enum class VpdTarget
-{
-        Cache = 0,
-        Hardware = 1,
-        CacheAndHardware = 2
-};
-
+namespace DeviceError = sdbusplus::xyz::openbmc_project::Common::Device::Error;
 } // namespace types
 } // namespace vpd


### PR DESCRIPTION
This commit implements the API to read keyword value from hardware in the class Manager.

This is required to perform VPD hardware read operation from
com.ibm.VPD.Manager service.

Test:
Test works as expected.