### PR TITLE
IPZ:API to get record details from VHDR/VTOC PT kw

### DIFF
--- a/include/ipz_parser.hpp
+++ b/include/ipz_parser.hpp
@@ -182,20 +182,20 @@ class IpzVpdParser : public ParserInterface
         const types::RecordOffset& i_recordDataOffset);
 
     /**
-     * @brief Get record's details from VTOC's PT keyword value
+     * @brief Get record's details from PT keyword value
      *
-     * This API parses through VTOC's PT keyword value and returns the given
+     * This API parses through the PT keyword value and returns the given
      * record's offset, record's length, ECC offset and ECC length.
      *
-     * @param[in] i_record - Record's name.
-     * @param[in] i_vtocOffset - Offset to VTOC record
+     * @param[in] i_recordName - Record's name.
+     * @param[in] i_ptKeywordData - PT keyword data.
      *
      * @return On success return record's details, on failure return empty
      * buffer.
      */
     types::RecordData
-        getRecordDetailsFromVTOC(const types::Record& l_recordName,
-                                 const types::RecordOffset& i_vtocOffset);
+        getRecordDetailsFromPT(const types::Record& i_recordName,
+                               const types::BinaryVector& i_ptKeywordData);
 
     // Holds VPD data.
     const types::BinaryVector& m_vpdVector;


### PR DESCRIPTION
This commit modifies the IPZ parser API "getRecordDetailsFromVTOC" in such a way that the record details can be fetched either from VTOC's PT or VHDR's PT keyword.

Changes incurred:
1. Instead of fetching the PT value within the api "getRecordDetailsFromVTOC", get the PT value as input parameter.
2. Variable name changes wherever required.

These changes are required as PT keyword is not specific to just VTOC record. VHDR record also has PT keyword which provides VTOC record's details.