### PR TITLE
Skeleton class for GPIO event handler

### DIFF
--- a/include/gpioMonitor.hpp
+++ b/include/gpioMonitor.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <sdbusplus/asio/connection.hpp>
+
+namespace vpd
+{
+/**
+ * @brief class for GPIO event handling.
+ *
+ * Responsible for detecting events and handling them. It continuously
+ * monitors the presence of the FRU. If any attachment or detachment is
+ * detected, it enables or disables the FRU's output GPIO and binds or
+ * unbinds the driver accordingly.
+ */
+class GpioEventHandler
+{
+  public:
+    GpioEventHandler() = delete;
+    ~GpioEventHandler() = delete;
+    GpioEventHandler(const GpioEventHandler&) = delete;
+    GpioEventHandler& operator=(const GpioEventHandler&) = delete;
+    GpioEventHandler(GpioEventHandler&&) = delete;
+    GpioEventHandler& operator=(GpioEventHandler&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] i_inputPin - GPIO input pin
+     * @param[in] i_inputValue - holds the value of input pin
+     * @param[in] i_outputPin - GPIO output pin
+     * @param[in] i_outputValue - value of the output pin
+     * @param[in] i_inventoryPath - inventory path of the FRU.
+     * @param[in] i_ioContext - pointer to the io context object
+     */
+    GpioEventHandler(
+        const std::string& i_presencePin, const bool& i_presenceValue,
+        const std::string& i_outputPin, const bool& i_outputValue,
+        const std::string& i_inventoryPath,
+        const std::shared_ptr<boost::asio::io_context>& i_ioContext) :
+        m_presencePin(i_presencePin),
+        m_presenceValue(i_presenceValue), m_outputPin(i_outputPin),
+        m_outputValue(i_outputValue), m_inventoryPath(i_inventoryPath)
+    {
+        setEventHandlerForGpioPresence(i_ioContext);
+    }
+
+  private:
+    /**
+     * @brief API to read the GPIO presence pin value.
+     *
+     *  @returns GPIO presence pin value.
+     */
+    bool getPresencePinValue();
+
+    /**
+     * @brief API to toggle the output GPIO pin.
+     *
+     * This API toggles the output GPIO pin based on the presence
+     * state of the FRU. If there is any change in the presence pin,
+     * it updates the output pin and binds or unbinds the driver
+     * accordingly.
+     */
+    void toggleGpio();
+
+    /**
+     * @brief An API to set event handler for FRUs GPIO presence.
+     *
+     * An API to set timer to call event handler to detect GPIO presence
+     * of the FRU.
+     *
+     * @param[in] i_ioContext - pointer to io context object
+     */
+    void setEventHandlerForGpioPresence(
+        const std::shared_ptr<boost::asio::io_context>& i_ioContext);
+
+    // Indicates presence/absence of fru
+    const std::string& m_presencePin;
+
+    // Value of GPIO input pin
+    const bool& m_presenceValue;
+
+    // GPIO pin to enable if fru is present
+    const std::string& m_outputPin;
+
+    // Value to set, to enable the output pin
+    const bool& m_outputValue;
+
+    // Inventory path of the FRU
+    const std::string& m_inventoryPath;
+};
+
+} // namespace vpd

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,8 @@ common_SOURCES = ['src/logger.cpp',
                   'src/isdimm_parser.cpp',
                   'src/parser.cpp',
                   'src/worker.cpp',
-                  'src/backup_restore.cpp']
+                  'src/backup_restore.cpp',
+                  'src/gpioMonitor.cpp']
 
 vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',

--- a/src/gpioMonitor.cpp
+++ b/src/gpioMonitor.cpp
@@ -1,0 +1,22 @@
+#include <gpioMonitor.hpp>
+
+namespace vpd
+{
+bool GpioEventHandler::getPresencePinValue()
+{
+    // ToDo Add implementation.
+    return true;
+}
+
+void GpioEventHandler::toggleGpio()
+{
+    // ToDo Add implementation.
+}
+
+void GpioEventHandler::setEventHandlerForGpioPresence(
+    const std::shared_ptr<boost::asio::io_context>& i_ioContext)
+{
+    // ToDo Add implementation.
+    (void)i_ioContext;
+}
+} // namespace vpd


### PR DESCRIPTION
GPIO event handler class monitors the presence of a FRU continuously. It is responsible for detecting the GPIO events and handling them. If it detects any change, it enables or disables the GPIOs output pin and binds or unbinds the driver accordingly.

Signed-off-by: RekhaAparna01 <vrekhaaparna@ibm.com>