### PR TITLE
Fix string corruption

### DIFF
--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1182,7 +1182,7 @@ void Worker::collectFrusFromJson()
 
         logging::logMessage("Parsing triggered for FRU = " + vpdFilePath);
 
-        std::thread{[&vpdFilePath, this]() {
+        std::thread{[vpdFilePath, this]() {
             auto l_futureObject = std::async(&Worker::parseAndPublishVPD, this,
                                              vpdFilePath);
             // Thread launched.


### PR DESCRIPTION
Capturing string as reference was corrupting the string in some scenarios. Hence, passing string to lamda as a copy.