### PR TITLE
Default keyword value update for backup & restore

### DIFF
--- a/configuration/ibm/backup_restore_50001001.json
+++ b/configuration/ibm/backup_restore_50001001.json
@@ -12,7 +12,7 @@
             "sourceKeyword": "BR",
             "destinationRecord": "VSYS",
             "destinationKeyword": "BR",
-            "defaultValue": [20, 20],
+            "defaultValue": [32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -21,7 +21,7 @@
             "sourceKeyword": "TM",
             "destinationRecord": "VSYS",
             "destinationKeyword": "TM",
-            "defaultValue": [20, 20, 20, 20, 20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -30,7 +30,7 @@
             "sourceKeyword": "SE",
             "destinationRecord": "VSYS",
             "destinationKeyword": "SE",
-            "defaultValue": [20, 20, 20, 20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -39,7 +39,7 @@
             "sourceKeyword": "SU",
             "destinationRecord": "VSYS",
             "destinationKeyword": "SU",
-            "defaultValue": [20, 20, 20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -48,7 +48,7 @@
             "sourceKeyword": "RB",
             "destinationRecord": "VSYS",
             "destinationKeyword": "RB",
-            "defaultValue": [20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -57,7 +57,7 @@
             "sourceKeyword": "WN",
             "destinationRecord": "VSYS",
             "destinationKeyword": "WN",
-            "defaultValue": [20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -66,7 +66,7 @@
             "sourceKeyword": "RG",
             "destinationRecord": "VSYS",
             "destinationKeyword": "RG",
-            "defaultValue": [20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },
@@ -76,8 +76,8 @@
             "destinationRecord": "VSYS",
             "destinationKeyword": "FV",
             "defaultValue": [
-                20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
-                20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20
+                32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
+                32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32
             ],
             "isPelRequired": false,
             "isManufactureResetRequired": true
@@ -87,7 +87,7 @@
             "sourceKeyword": "FC",
             "destinationRecord": "VCEN",
             "destinationKeyword": "FC",
-            "defaultValue": [20, 20, 20, 20, 20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": false
         },
@@ -96,7 +96,7 @@
             "sourceKeyword": "SE",
             "destinationRecord": "VCEN",
             "destinationKeyword": "SE",
-            "defaultValue": [20, 20, 20, 20, 20, 20, 20],
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32],
             "isPelRequired": true,
             "isManufactureResetRequired": true
         },


### PR DESCRIPTION
Default keyword values from the backup and restore config JSON file was assumed that, it will be considered as hex value after parsing the config JSON file in the code.
But it was directly considered as decimal value instead as hex value after parsing JSON file and these default values were used for comparing against source and destination’s keywords hex values. This was causing invalid comparison.

To avoid this issue config JSON file is updated with proper default decimal values, which is the correct counter value of the hexadecimal needed for comparison with source and destination keyword value, in this commit.