### PR TITLE
Enable call to PIM

### DIFF
--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1120,11 +1120,11 @@ std::tuple<bool, std::string>
         logging::logMessage("Dbus sucessfully populated for FRU " +
                             i_vpdFilePath);
         // Notify PIM
-        /*    if (!dbusUtility::callPIM(move(objectInterfaceMap)))
-            {
-                throw std::runtime_error("Call to PIM failed for system
-           VPD");
-            }*/
+        if (!dbusUtility::callPIM(move(objectInterfaceMap)))
+        {
+            throw std::runtime_error(
+                "Call to PIM failed while publishing VPD.");
+        }
     }
     catch (const std::exception& ex)
     {


### PR DESCRIPTION
Whille implementation call to PIK was commented to avoid any unintentional system data corruption.
Enabling the call to publish data under PIM service.