### PR TITLE
Fix priming of inventory

### DIFF
--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -749,6 +749,13 @@ bool Worker::primeInventory(const std::string& i_vpdFilePath)
         types::InterfaceMap l_interfaces;
         sdbusplus::message::object_path l_fruObjectPath(l_Fru["inventoryPath"]);
 
+        if (l_Fru.contains("ccin"))
+        {
+            logging::logMessage(
+                "Skipping priming for FRUs that needs CCIN check.");
+            continue;
+        }
+
         // Add extra interfaces mentioned in the Json config file
         if (l_Fru.contains("extraInterfaces"))
         {


### PR DESCRIPTION
Priming of inventory functionality should not prime inventory paths for FRUs which are supposed to be published only if VPD has some specific CCIN.

Priming inventory is called when the VPD file is not found, hence it implies that there is no CCIN value available.