### PR TITLE
IPZ:Private method to set keyword value

### DIFF
--- a/include/ipz_parser.hpp
+++ b/include/ipz_parser.hpp
@@ -197,8 +197,25 @@ class IpzVpdParser : public ParserInterface
         getRecordDetailsFromVTOC(const types::Record& l_recordName,
                                  const types::RecordOffset& i_vtocOffset);
 
+    /**
+     * @brief API to set record's keyword's value on hardware.
+     *
+     * @param[in] i_recordName - Record name.
+     * @param[in] i_keywordName - Keyword name.
+     * @param[in] i_keywordData - Keyword data.
+     * @param[in] i_recordDataOffset - Offset to record's data.
+     *
+     * @throw std::runtime_error
+     *
+     * @return On success returns number of bytes set. On failure returns -1.
+     */
+    int setKeywordValueInRecord(const types::Record& i_recordName,
+                                const types::Keyword& i_keywordName,
+                                const types::BinaryVector& i_keywordData,
+                                const types::RecordOffset& i_recordDataOffset);
+
     // Holds VPD data.
-    const types::BinaryVector& m_vpdVector;
+    types::BinaryVector m_vpdVector;
 
     // stores parsed VPD data.
     types::IPZVpdMap m_parsedVPDMap{};


### PR DESCRIPTION
Private API in IPZ parser class which sets the given keyword's value
on hardware, provided the record's name, keyword's name, keyword's data and
the record's offset.