### PR TITLE
IPZ:Public method to write keyword on hardware

### DIFF
--- a/include/types.hpp
+++ b/include/types.hpp
@@ -132,6 +132,8 @@ using RecordData = std::tuple<RecordOffset, RecordLength, ECCOffset, ECCLength>;
 
 using DbusInvalidArgument =
     sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+using DbusNotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+
 using InvalidArgument = phosphor::logging::xyz::openbmc_project::Common::InvalidArgument;
 
 namespace DeviceError = sdbusplus::xyz::openbmc_project::Common::Device::Error;


### PR DESCRIPTION
IPZ:Public method to write keyword on hardware
API to perform write operation on IPZ type VPD keyword on hardware.
This API is exposed as public, as it can be used by Manager class
and any other classes to perform VPD write on hardware operation.

Test:
Tested that IPZ type keyword is getting updated on hardware.
vpd-tool -r -H -O /sys/bus/i2c/drivers/at24/7-0050/eeprom -R VINI -K DR
{
    "/sys/bus/i2c/drivers/at24/7-0050/eeprom": {
        "DR": "CEC OP PANEL    "
    }
}
vpd-tool -r -O /system/chassis/motherboard/base_op_panel_blyth -R VINI -K DR
{
    "/system/chassis/motherboard/base_op_panel_blyth": {
        "DR": "CEC OP PANEL    "
    }
}

busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth" "(ssay)" "VINI" "DR" 2 0x43 0x45

vpd-tool -r -O /system/chassis/motherboard/base_op_panel_blyth -R VINI -K DR
{
    "/system/chassis/motherboard/base_op_panel_blyth": {
        "DR": "bcC OP PANEL    "
    }
}

vpd-tool -r -H -O /sys/bus/i2c/drivers/at24/7-0050/eeprom -R VINI -K DR
{
    "/sys/bus/i2c/drivers/at24/7-0050/eeprom": {
        "DR": "bcC OP PANEL    "
    }
}