### PR TITLE
Manager:Public API to perform VPD write

### DIFF
--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -230,6 +230,34 @@ class Manager
      */
     bool isValidUnexpandedLocationCode(const std::string& i_locationCode);
 
+    /**
+     * @brief API to update keyword's value on hardware
+     *
+     * @param[in] i_fruPath - FRU path.
+     * @param[in] i_sysCfgJsonObj - JSON object.
+     * @param[in] i_paramsToWriteData - Data required to perform write.
+     *
+     * @return On success returns number of bytes written. On failure returns
+     * -1.
+     */
+    int updateKeywordOnHardware(
+        const types::Path& i_fruPath, const nlohmann::json& i_sysCfgJsonObj,
+        const types::WriteVpdParams i_paramsToWriteData);
+
+    /**
+     * @brief API to update keyword's value on D-bus.
+     *
+     * @param[in] i_inventoryObjPath - Inventory object path.
+     * @param[in] i_fruPath - FRU path.
+     * @param[in] i_paramsToWriteData - Data required to perform write.
+     *
+     * @return On success returns number of bytes written. On failure returns
+     * -1.
+     */
+    int updateKeywordOnDbus(const types::Path& i_inventoryObjPath,
+                            const types::Path& i_fruPath,
+                            const types::WriteVpdParams i_paramsToWriteData);
+
     // Shared pointer to asio context object.
     const std::shared_ptr<boost::asio::io_context>& m_ioContext;
 


### PR DESCRIPTION
This commit implements a public API in Manager class to
update given keyword's value on the given path and other
source paths if present in system config JSON.

This commit implements just the basic structure and order in which
update on different paths takes place.

Test:
Tested that the basic structure works without any runtime errors
busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/sys/bus/i2c/drivers/at24/0-0051/eeprom" "(ssay)" "VINI" "DR" 2 0x62 0x63
i -1