### PR TITLE
Guard critical data

### DIFF
--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -4,6 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <mutex>
 #include <tuple>
 
 namespace vpd
@@ -391,5 +392,8 @@ class Worker
     // Note: This variable does not give information about successfull or failed
     // collection. It just states, if the VPD collection process is over or not.
     bool m_isAllFruCollected = false;
+
+    // Mutex to guard critical resource m_activeCollectionThreadCount.
+    std::mutex m_mutex;
 };
 } // namespace vpd

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1200,12 +1200,16 @@ void Worker::collectFrusFromJson()
             auto l_futureObject = std::async(&Worker::parseAndPublishVPD, this,
                                              vpdFilePath);
             // Thread launched.
+            m_mutex.lock();
             m_activeCollectionThreadCount++;
+            m_mutex.unlock();
 
             std::tuple<bool, std::string> l_threadInfo = l_futureObject.get();
 
             // thread returned.
+            m_mutex.lock();
             m_activeCollectionThreadCount--;
+            m_mutex.unlock();
 
             if (std::get<0>(l_threadInfo))
             {


### PR DESCRIPTION
Thread count information is being shared between all the threads. To avoid any race condition data corruption, the counter is guarded using mutex.