### PR TITLE
Skeleton class for GpioMonitor

### DIFF
--- a/include/gpioMonitor.hpp
+++ b/include/gpioMonitor.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
 #include <sdbusplus/asio/connection.hpp>
+
+#include <vector>
 
 namespace vpd
 {
@@ -89,4 +92,47 @@ class GpioEventHandler
     const std::string& m_inventoryPath;
 };
 
+class GpioMonitor
+{
+  public:
+    GpioMonitor() = delete;
+    ~GpioMonitor() = default;
+    GpioMonitor(const GpioMonitor&) = delete;
+    GpioMonitor& operator=(const GpioMonitor&) = delete;
+    GpioMonitor(GpioMonitor&&) = delete;
+    GpioMonitor& operator=(GpioMonitor&&) = delete;
+
+    /**
+     * @brief constructor
+     *
+     * @param[in] i_sysCfgJsonObj - System config JSON Object.
+     * @param[in] i_ioContext - pointer to IO context object.
+     */
+    GpioMonitor(const nlohmann::json i_sysCfgJsonObj,
+                const std::shared_ptr<boost::asio::io_context>& i_ioContext) :
+        m_sysCfgJsonObj(i_sysCfgJsonObj)
+    {
+        if (!m_sysCfgJsonObj.empty())
+        {
+            initHandlerForGpio(i_ioContext);
+        }
+    }
+
+  private:
+    /**
+     * @brief API to instantiate GpioEventHandler for GPIO pins.
+     *
+     * This API will extract the GPIO information from system config JSON
+     * and instantiate event handler for GPIO pins.
+     *
+     * @param[in] i_ioContext - Pointer to IO context object.
+     */
+    void initHandlerForGpio(
+        const std::shared_ptr<boost::asio::io_context>& i_ioContext);
+
+    // Array of event handlers for all the attachable FRUs.
+    std::vector<std::shared_ptr<GpioEventHandler>> m_gpioObjects;
+
+    const nlohmann::json& m_sysCfgJsonObj;
+};
 } // namespace vpd

--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "constants.hpp"
+#include "gpioMonitor.hpp"
 #include "types.hpp"
 #include "worker.hpp"
 
@@ -240,6 +241,9 @@ class Manager
 
     // Shared pointer to worker class
     std::shared_ptr<Worker> m_worker;
+
+    // Shared pointer to GpioMonitor class
+    std::shared_ptr<GpioMonitor> m_gpioMonitor;
 };
 
 } // namespace vpd

--- a/src/gpioMonitor.cpp
+++ b/src/gpioMonitor.cpp
@@ -19,4 +19,11 @@ void GpioEventHandler::setEventHandlerForGpioPresence(
     // ToDo Add implementation.
     (void)i_ioContext;
 }
+
+void GpioMonitor::initHandlerForGpio(
+    const std::shared_ptr<boost::asio::io_context>& i_ioContext)
+{
+    // ToDo Add implementation.
+    (void)i_ioContext;
+}
 } // namespace vpd

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -39,6 +39,10 @@ Manager::Manager(
 
         // set async timer to detect if VPD collection is done.
         SetTimerToDetectVpdCollectionStatus();
+
+        // Instantiate GpioMonitor class
+        m_gpioMonitor = std::make_shared<GpioMonitor>(
+            m_worker->getSysCfgJsonObj(), m_ioContext);
 #endif
 
         // Register methods under com.ibm.VPD.Manager interface


### PR DESCRIPTION
GPIO monitor class is responsible for gathering information about GPIO pins from the config JSON and instantiates the GpioEventhandler class