### PR TITLE
Bios handler class

### DIFF
--- a/include/biosHandler.hpp
+++ b/include/biosHandler.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace vpd
+{
+/**
+ * @brief A class to operate upon and back up some of the BIOS attributes.
+ *
+ * The class initiates call backs to listen to PLDM service and changes in some
+ * of the BIOS attributes.
+ * On a factory reset, BIOS attributes are initialized by PLDM. this class waits
+ * until PLDM has grabbed a bus name before attempting any syncs.
+ *
+ * It also initiates API to back up those data in VPD keywords.
+ */
+class BiosHandler
+{
+  public:
+    // deleted APIs
+    BiosHandler() = delete;
+    BiosHandler(const BiosHandler&) = delete;
+    BiosHandler& operator=(const BiosHandler&) = delete;
+    BiosHandler& operator=(BiosHandler&&) = delete;
+    ~BiosHandler() = default;
+
+    /**
+     * @brief Constructor.
+     *
+     * @param[in] connection - Asio connection object.
+     */
+    BiosHandler(std::shared_ptr<sdbusplus::asio::connection>& connection) :
+        m_asioConn(connection)
+    {
+        checkAndListenPldmService();
+    }
+
+  private:
+    /**
+     * @brief API to check if PLDM service is running and run BIOS sync.
+     *
+     * This API checks if the PLDM service is running and if yes it will start
+     * an immediate sync of BIOS attributes. If the service is not running, it
+     * registers a listener to be notified when the service starts so that a
+     * restore can be performed.
+     */
+    void checkAndListenPldmService();
+
+    /**
+     * @brief API to check if PLDM service is already up and running.
+     *
+     * PLDM service has no direct dependency on VPD-Manager service. Hence it
+     * can be up and running before VPD-Manager comes up. This API check if PLDM
+     * service is already up or not.
+     *
+     * @return bool - True if the PLDM service is running, false otherwise.
+     */
+    bool isPldmServiceRunning();
+
+    // Reference to the connection.
+    std::shared_ptr<sdbusplus::asio::connection>& m_asioConn;
+};
+} // namespace vpd

--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "biosHandler.hpp"
 #include "constants.hpp"
 #include "gpioMonitor.hpp"
 #include "types.hpp"
@@ -244,6 +245,9 @@ class Manager
 
     // Shared pointer to GpioMonitor class
     std::shared_ptr<GpioMonitor> m_gpioMonitor;
+
+    // Shared pointer to BIOS handler class
+    std::shared_ptr<BiosHandler> m_biosHandler;
 };
 
 } // namespace vpd

--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,8 @@ common_SOURCES = ['src/logger.cpp',
                   'src/parser.cpp',
                   'src/worker.cpp',
                   'src/backup_restore.cpp',
-                  'src/gpioMonitor.cpp']
+                  'src/gpioMonitor.cpp',
+                  'src/biosHandler.cpp']
 
 vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',

--- a/src/biosHandler.cpp
+++ b/src/biosHandler.cpp
@@ -1,0 +1,57 @@
+#include "biosHandler.hpp"
+
+#include "constants.hpp"
+#include "logger.hpp"
+
+#include <sdbusplus/bus/match.hpp>
+
+namespace vpd
+{
+void BiosHandler::checkAndListenPldmService()
+{
+    // Setup a call back match on NameOwnerChanged to determine when PLDM is up.
+    static std::shared_ptr<sdbusplus::bus::match_t> l_nameOwnerMatch =
+        std::make_shared<sdbusplus::bus::match_t>(
+            *m_asioConn,
+            sdbusplus::bus::match::rules::nameOwnerChanged(
+                "xyz.openbmc_project.PLDM"),
+            [this](sdbusplus::message_t& l_msg) {
+        if (l_msg.is_method_error())
+        {
+            logging::logMessage(
+                "Error in reading PLDM name owner changed signal.");
+            return;
+        }
+
+        std::string l_name;
+        std::string l_newOwner;
+        std::string l_oldOwner;
+
+        l_msg.read(l_name, l_oldOwner, l_newOwner);
+
+        if (!l_newOwner.empty() &&
+            (l_name.compare("xyz.openbmc_project.PLDM") ==
+             constants::STR_CMP_SUCCESS))
+        {
+            // TODO: Restore BIOS attribute from here.
+            //  We don't need the match anymore
+            l_nameOwnerMatch.reset();
+        }
+    });
+
+    // Based on PLDM service status reset owner match registered above and
+    // trigger BIOS attribute sync.
+    if (isPldmServiceRunning())
+    {
+        l_nameOwnerMatch.reset();
+        // TODO: retore BIOS attribute from here.
+    }
+}
+
+bool BiosHandler::isPldmServiceRunning()
+{
+    // TODO: implementation. Returning a dummy value till the implementation is
+    // in progress.
+    return true;
+}
+} // namespace vpd

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -43,6 +43,9 @@ Manager::Manager(
         // Instantiate GpioMonitor class
         m_gpioMonitor = std::make_shared<GpioMonitor>(
             m_worker->getSysCfgJsonObj(), m_ioContext);
+
+        // Create an instance of the BIOS handler
+        m_biosHandler = std::make_shared<BiosHandler>(m_asioConnection);
 #endif
 
         // Register methods under com.ibm.VPD.Manager interface


### PR DESCRIPTION
The commit introduces a new class called Bios Hander. It is required to back up some of the required BIOS attributes.
To achieve that, primarily, the class registers a callback to track the status of PLDM service and once found up and running, it syncs all the required attributes.