### PR TITLE
Define destructor for GpioEventHandler class

### DIFF
--- a/include/gpioMonitor.hpp
+++ b/include/gpioMonitor.hpp
@@ -19,7 +19,7 @@ class GpioEventHandler
 {
   public:
     GpioEventHandler() = delete;
-    ~GpioEventHandler() = delete;
+    ~GpioEventHandler() = default;
     GpioEventHandler(const GpioEventHandler&) = delete;
     GpioEventHandler& operator=(const GpioEventHandler&) = delete;
     GpioEventHandler(GpioEventHandler&&) = delete;


### PR DESCRIPTION
This commit defines the default destructor for GpioEventHandler class. Deleting the destructor causes compile-time issues, as destructor is invoked when the object goes out of scope to release member variables.

