### PR TITLE
BiosHandler:Fix compile time error

### DIFF
--- a/include/biosHandler.hpp
+++ b/include/biosHandler.hpp
@@ -29,8 +29,9 @@ class BiosHandler
      *
      * @param[in] connection - Asio connection object.
      */
-    BiosHandler(std::shared_ptr<sdbusplus::asio::connection>& connection) :
-        m_asioConn(connection)
+    BiosHandler(
+        const std::shared_ptr<sdbusplus::asio::connection>& i_connection) :
+        m_asioConn(i_connection)
     {
         checkAndListenPldmService();
     }
@@ -58,6 +59,6 @@ class BiosHandler
     bool isPldmServiceRunning();
 
     // Reference to the connection.
-    std::shared_ptr<sdbusplus::asio::connection>& m_asioConn;
+    const std::shared_ptr<sdbusplus::asio::connection>& m_asioConn;
 };
 } // namespace vpd


### PR DESCRIPTION
This commit fixes the compile time error in BiosHandler class for binding non const shared_ptr reference to const shared_ptr reference on sdbusplus asio connection object.