### PR TITLE
Implement read keyword through vpd-tool.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,8 @@ if not build_tests.disabled()
     subdir('test')
 endif
 
+subdir('vpd-tool')
+
 compiler = meson.get_compiler('cpp')
 
 conf_data = configuration_data()

--- a/vpd-tool/include/utils.hpp
+++ b/vpd-tool/include/utils.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "types.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <iostream>
+
+namespace vpd
+{
+namespace utils
+{
+/**
+ * @brief An API to read property from Dbus.
+ *
+ * The caller of the API needs to validate the validatity and correctness of the
+ * type and value of data returned. The API will just fetch and retun the data
+ * without any data validation.
+ *
+ * Note: It will be caller's responsibility to check for empty value returned
+ * and generate appropriate error if required.
+ *
+ * @param[in] i_serviceName - Name of the Dbus service.
+ * @param[in] i_objectPath - Object path under the service.
+ * @param[in] i_interface - Interface under which property exist.
+ * @param[in] i_property - Property whose value is to be read.
+ * @return - Value read from Dbus on success.
+ *           empty variant for any failure.
+ */
+inline types::DbusVariantType readDbusProperty(const std::string& i_serviceName,
+                                               const std::string& i_objectPath,
+                                               const std::string& i_interface,
+                                               const std::string& i_property)
+{
+    types::DbusVariantType l_propertyValue;
+
+    // Mandatory fields to make a dbus call.
+    if (i_serviceName.empty() || i_objectPath.empty() || i_interface.empty() ||
+        i_property.empty())
+    {
+        std::cout << "One of the parameter to make Dbus read call is empty."
+                  << std::endl;
+        return l_propertyValue;
+    }
+
+    try
+    {
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call(i_serviceName.c_str(), i_objectPath.c_str(),
+                                  "org.freedesktop.DBus.Properties", "Get");
+        l_method.append(i_interface, i_property);
+
+        auto result = l_bus.call(l_method);
+        result.read(l_propertyValue);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+    return l_propertyValue;
+}
+
+/**
+ * @brief An API to read keyword from hardware through DBus service.
+ *
+ * @param[in] i_serviceName - Name of the Dbus service hosting 'ReadKeyword'
+ * method.
+ * @param[in] i_objectPath - Object path under the service.
+ * @param[in] i_interface - Interface under which 'ReadKeyword' method exist.
+ * @param[in] i_eepromPath - EEPROM file path.
+ * @param[in] i_paramsToReadData - Property whose value is to be read.
+ * @return - Value read from Dbus on success.
+ *          empty variant for any failure's.
+ */
+inline types::DbusVariantType readKeywordFromHardware(
+    const std::string& i_serviceName, const std::string& i_objectPath,
+    const std::string& i_interface, const std::string& i_eepromPath,
+    const types::ReadVpdParams i_paramsToReadData)
+{
+    types::DbusVariantType l_propertyValue;
+
+    // Mandatory fields to make a dbus call.
+    if (i_serviceName.empty() || i_objectPath.empty() || i_interface.empty() ||
+        i_eepromPath.empty())
+    {
+        std::cout
+            << "One of the parameter to make Dbus ReadKeyword call is empty."
+            << std::endl;
+        return l_propertyValue;
+    }
+
+    try
+    {
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call(i_serviceName.c_str(), i_objectPath.c_str(),
+                                  i_interface.c_str(), "ReadKeyword");
+        l_method.append(i_eepromPath, i_paramsToReadData);
+        auto l_result = l_bus.call(l_method);
+        l_result.read(l_propertyValue);
+    }
+    catch (const sdbusplus::exception::SdBusError& l_error)
+    {
+        std::cout << l_error.what() << std::endl;
+    }
+    return l_propertyValue;
+}
+
+/**
+ * @brief An API to print json data on stdout.
+ *
+ * @param[in] i_output - JSON object.
+ */
+void printJson(const nlohmann::json& i_output)
+{
+    std::cout << i_output.dump(4) << std::endl;
+}
+
+/**
+ * @brief An API to convert hex value to string.
+ *
+ * If given data contains printable charecters, ASCII formated string value of
+ * the input data will be returned. Otherwise if the data has any non-printable
+ * value, returns the hex represented string value of the given data.
+ *
+ * @param[in] i_keywordValue - Date needs to be converted as string.
+ * @return - Returns the converted string value.
+ */
+std::string getPrintableValue(const types::BinaryVector& i_keywordValue)
+{
+    bool l_allPrintable =
+        std::all_of(i_keywordValue.begin(), i_keywordValue.end(),
+                    [](const auto& l_byte) { return std::isprint(l_byte); });
+
+    std::ostringstream l_oss;
+    if (l_allPrintable)
+    {
+        l_oss << std::string(i_keywordValue.begin(), i_keywordValue.end());
+    }
+    else
+    {
+        l_oss << "0x";
+        for (const auto& l_byte : i_keywordValue)
+        {
+            l_oss << std::setfill('0') << std::setw(2) << std::hex
+                  << static_cast<int>(l_byte);
+        }
+    }
+
+    return l_oss.str();
+}
+} // namespace utils
+} // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+namespace vpd
+{
+/**
+ * @brief Class to support read and write VPD.
+ *
+ * The class provides API's to read/update keyword value on DBUS and on the
+ * EEPROM file path. And also provides API's to dump DBus object critical
+ * information.
+ */
+class VpdTool
+{
+  public:
+    /**
+     * @brief Read keyword value.
+     *
+     * API to read VPD keyword's value from the given input path.
+     * If the provided path is EEPROM path, it reads keyword value from the
+     * hardware by invoking "ReadKeyword" method on "com.ibm.VPD.Manager"
+     * service. Othrwise if the provided path is DBus path, it reads keyword
+     * value from DBus.
+     *
+     * @param[in] i_fruPath - DBus object path or EEPROM path.
+     * @param[in] i_recordName - Record name.
+     * @param[in] i_keyword - Keyword name.
+     * @param[in] i_onHardware - True if i_fruPath is EEPROM path, false
+     * otherwise.
+     *
+     */
+    void readKeyword(const std::string& i_fruPath,
+                     const std::string& i_recordName,
+                     const std::string& i_keyword, bool i_onHardware);
+};
+} // namespace vpd

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -1,0 +1,11 @@
+sources = ['src/vpd_tool_main.cpp',
+          'src/vpd_tool.cpp']
+
+dependency_list = [sdbusplus]
+
+vpd_tool_exe = executable('vpd-tool',
+                          sources,
+                          include_directories : ['include/', '../include/'],
+                          dependencies: dependency_list,
+                          install: true
+                        )

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -1,0 +1,44 @@
+#include "vpd_tool.hpp"
+
+#include "utils.hpp"
+
+#include <iostream>
+
+namespace vpd
+{
+void VpdTool::readKeyword(const std::string& i_fruPath,
+                          const std::string& i_recordName,
+                          const std::string& i_keyword, bool i_onHardware)
+{
+    types::DbusVariantType l_keywordValue;
+    if (i_onHardware)
+    {
+        l_keywordValue = utils::readKeywordFromHardware(
+            "com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
+            "com.ibm.VPD.Manager", i_fruPath,
+            make_tuple(i_recordName, i_keyword));
+    }
+    else
+    {
+        constexpr auto l_inventoryPath = "/xyz/openbmc_project/inventory";
+        std::string l_fullObjectPath = l_inventoryPath + i_fruPath;
+
+        l_keywordValue = utils::readDbusProperty(
+            "xyz.openbmc_project.Inventory.Manager", l_fullObjectPath,
+            "com.ibm.ipzvpd." + i_recordName, i_keyword);
+    }
+
+    if (auto l_value = std::get_if<types::BinaryVector>(&l_keywordValue))
+    {
+        const std::string& l_strValue = utils::getPrintableValue(*l_value);
+
+        nlohmann::json l_output = nlohmann::json::object({});
+        nlohmann::json l_kwVal = nlohmann::json::object({});
+
+        l_kwVal.emplace(i_keyword, l_strValue);
+        l_output.emplace(i_fruPath, l_kwVal);
+
+        utils::printJson(l_output);
+    }
+}
+} // namespace vpd

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -1,0 +1,93 @@
+#include "vpd_tool.hpp"
+
+#include <CLI/CLI.hpp>
+
+#include <filesystem>
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    int l_retValue = 0;
+    try
+    {
+        CLI::App l_app{
+            "VPD Command line tool to dump the inventory and to read and "
+            "update the keywords"};
+
+        std::string l_objectPath{};
+        std::string l_recordName{};
+        std::string l_keyword{};
+        std::string l_filePath{};
+
+        auto l_objectOption = l_app.add_option("--object, -O", l_objectPath,
+                                               "Enter the Object Path");
+        auto l_recordOption = l_app.add_option("--record, -R", l_recordName,
+                                               "Enter the Record Name");
+        auto l_keywordOption = l_app.add_option("--keyword, -K", l_keyword,
+                                                "Enter the Keyword");
+
+        auto l_readOption =
+            l_app
+                .add_flag(
+                    "--readKeyword, -r",
+                    "Read the data of the given keyword. { "
+                    "vpd-tool-exe --readKeyword/-r --object/-O "
+                    "\"object-name\" --record/-R \"record-name\" --keyword/-K "
+                    "\"keyword-name\" }")
+                ->needs(l_objectOption)
+                ->needs(l_recordOption)
+                ->needs(l_keywordOption);
+
+        auto l_hardwareOption = l_app.add_flag(
+            "--Hardware, -H",
+            "This is a supplementary flag to read/write directly from/to hardware. "
+            "User should provide valid hardware/eeprom path (and not dbus object "
+            "path) in the -O/--object path. CAUTION: Developer Only Option.");
+
+        CLI11_PARSE(l_app, argc, argv);
+
+        if ((*l_keywordOption) && (l_keyword.size() != 2))
+        {
+            throw std::runtime_error("Keyword " + l_keyword +
+                                     " not supported.");
+        }
+
+        bool l_isHardwareOperation = false;
+        if (*l_hardwareOption)
+        {
+            l_isHardwareOperation = true;
+
+            if (!std::filesystem::exists(
+                    l_objectPath)) // if dbus object path is given or
+                                   // invalid eeprom path is given
+            {
+                std::string l_errorMsg = "Invalid EEPROM path : ";
+                l_errorMsg += l_objectPath;
+                l_errorMsg +=
+                    ". The given EEPROM path doesn't exist. Provide valid "
+                    "EEPROM path when -H flag is used. Refer help option. ";
+                throw std::runtime_error(l_errorMsg);
+            }
+        }
+
+        if (*l_readOption)
+        {
+            vpd::VpdTool l_vpdToolObj;
+            l_vpdToolObj.readKeyword(l_objectPath, l_recordName, l_keyword,
+                                     l_isHardwareOperation);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "One of the valid options is required.\nRefer "
+                "--help for list of options.");
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        std::cerr << l_ex.what() << std::endl;
+        l_retValue = -1;
+    }
+
+    return l_retValue;
+}


### PR DESCRIPTION
This commits adds the code for
* Showing help option to user, how to use vpd-tool application.
* Read record keyword’s value from DBus by providing the DBus object path and required info to read the keyword.
* Reading record keyword’s value from hardware by using EEPROM file path instead of object path. vpd-tool application calls ReadKeyword method hosted by vpd-manager DBus service with required params to read the keyword value from hardware.