### PR TITLE
Templated BIOS handling

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -4,16 +4,83 @@
 
 namespace vpd
 {
+
 /**
- * @brief A class to operate upon and back up some of the BIOS attributes.
+ * @brief Interface class for BIOS handling.
  *
- * The class initiates call backs to listen to PLDM service and changes in some
- * of the BIOS attributes.
- * On a factory reset, BIOS attributes are initialized by PLDM. this class waits
- * until PLDM has grabbed a bus name before attempting any syncs.
- *
- * It also initiates API to back up those data in VPD keywords.
+ * The class layout has the virtual methods required to be implemented by any
+ * concrete class that intends to use the feature provided via BIOS handler
+ * class.
  */
+class BiosHandlerInterface
+{
+  public:
+    /**
+     * @brief API to back up or restore BIOS attributes.
+     *
+     * Concrete class should implement the API and read the backed up data from
+     * its designated location and take a call if it should be backed up or
+     * restored.
+     */
+    virtual void backUpOrRestoreBiosAttributes() = 0;
+
+    /**
+     * @brief Callback API to be triggered on BIOS attribute change.
+     *
+     * Concrete class should implement the API to extract the attribute and its
+     * value from DBus message broadcasted on BIOS attribute change.
+     * The definition should be overridden in concrete class to deal with BIOS
+     * attributes interested in.
+     *
+     * @param[in] i_msg - The callback message.
+     */
+    virtual void biosAttributesCallback(sdbusplus::message_t& i_msg) = 0;
+};
+
+/**
+ * @brief IBM specifc BIOS handler class.
+ */
+class IbmBiosHandler : public BiosHandlerInterface
+{
+  public:
+    /**
+     * @brief API to back up or restore BIOS attributes.
+     *
+     * The API will read the backed up data from the VPD keyword and based on
+     * its value, either backs up or restores the data.
+     */
+    virtual void backUpOrRestoreBiosAttributes();
+
+    /**
+     * @brief Callback API to be triggered on BIOS attribute change.
+     *
+     * The API to extract the required attribute and its value from DBus message
+     * broadcasted on BIOS attribute change.
+     *
+     * @param[in] i_msg - The callback message.
+     */
+    virtual void biosAttributesCallback(sdbusplus::message_t& i_msg);
+};
+
+/**
+ * @brief A class to operate upon BIOS attributes.
+ *
+ * The class along with specific BIOS handler class(es), provides a feature
+ * where specific BIOS attributes identified by the concrete specific class can
+ * be listened for any change and can be backed up to a desired location or
+ * restored back to the BIOS table.
+ *
+ * To use the feature, "BiosHandlerInterface" should be implemented by a
+ * concrete class and the same should be used to instantiate BiosHandler.
+ *
+ * This class registers call back to listen to PLDM service as it is being used
+ * for reading/writing BIOS attributes.
+ *
+ * The feature can be used in a factory reset scenario where backed up values
+ * can be used to restore BIOS.
+ *
+ */
+template <typename T>
 class BiosHandler
 {
   public:
@@ -33,6 +100,7 @@ class BiosHandler
         const std::shared_ptr<sdbusplus::asio::connection>& i_connection) :
         m_asioConn(i_connection)
     {
+        m_specificBiosHandler = std::make_shared<T>();
         checkAndListenPldmService();
     }
 
@@ -47,7 +115,19 @@ class BiosHandler
      */
     void checkAndListenPldmService();
 
+    /**
+     * @brief Register listener for BIOS attribute property change.
+     *
+     * The VPD manager needs to listen for property change of certain BIOS
+     * attributes that are backed in VPD. When the attributes change, the new
+     * value is written back to the VPD keywords that backs them up.
+     */
+    void listenBiosAttributes();
+
     // Reference to the connection.
     const std::shared_ptr<sdbusplus::asio::connection>& m_asioConn;
+
+    // shared pointer to specific BIOS handler.
+    std::shared_ptr<T> m_specificBiosHandler;
 };
 } // namespace vpd

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -87,6 +87,10 @@ constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto kwdCCIN = "CC";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto pldmServiceName = "xyz.openbmc_project.PLDM";
+constexpr auto pimServiceName = "xyz.openbmc_project.Inventory.Manager";
+constexpr auto biosConfigMgrObjPath =
+    "/xyz/openbmc_project/bios_config/manager";
+constexpr auto biosConfigMgrService = "xyz.openbmc_project.BIOSConfig.Manager";
 
 static constexpr auto BD_YEAR_END = 4;
 static constexpr auto BD_MONTH_END = 7;

--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "bios_handler.hpp"
 #include "constants.hpp"
 #include "gpio_monitor.hpp"
 #include "types.hpp"
@@ -273,9 +272,6 @@ class Manager
 
     // Shared pointer to GpioMonitor class
     std::shared_ptr<GpioMonitor> m_gpioMonitor;
-
-    // Shared pointer to BIOS handler class
-    std::shared_ptr<BiosHandler> m_biosHandler;
 };
 
 } // namespace vpd

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -14,6 +14,13 @@ namespace vpd
 {
 namespace types
 {
+
+using BiosProperty = std::tuple<
+    std::string, bool, std::string, std::string, std::string,
+    std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
+    std::vector<std::tuple<std::string, std::variant<int64_t, std::string>>>>;
+using BiosBaseTable = std::variant<std::map<std::string, BiosProperty>>;
+using BiosBaseTableType = std::map<std::string, BiosBaseTable>;
 using BinaryVector = std::vector<uint8_t>;
 
 // This covers mostly all the data type supported over Dbus for a property.

--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -8,7 +8,11 @@
 
 namespace vpd
 {
-void BiosHandler::checkAndListenPldmService()
+// Template declaration to define APIs.
+template class BiosHandler<IbmBiosHandler>;
+
+template <typename T>
+void BiosHandler<T>::checkAndListenPldmService()
 {
     // Setup a call back match on NameOwnerChanged to determine when PLDM is up.
     static std::shared_ptr<sdbusplus::bus::match_t> l_nameOwnerMatch =
@@ -37,6 +41,10 @@ void BiosHandler::checkAndListenPldmService()
             // TODO: Restore BIOS attribute from here.
             //  We don't need the match anymore
             l_nameOwnerMatch.reset();
+            m_specificBiosHandler->backUpOrRestoreBiosAttributes();
+
+            // Start listener now that we have done the restore.
+            listenBiosAttributes();
         }
     });
 
@@ -45,7 +53,42 @@ void BiosHandler::checkAndListenPldmService()
     if (dbusUtility::isServiceRunning(constants::pldmServiceName))
     {
         l_nameOwnerMatch.reset();
-        // TODO: retore BIOS attribute from here.
+        m_specificBiosHandler->backUpOrRestoreBiosAttributes();
+
+        // Start listener now that we have done the restore.
+        listenBiosAttributes();
     }
+}
+
+template <typename T>
+void BiosHandler<T>::listenBiosAttributes()
+{
+    static std::shared_ptr<sdbusplus::bus::match_t> l_biosMatch =
+        std::make_shared<sdbusplus::bus::match_t>(
+            *m_asioConn,
+            sdbusplus::bus::match::rules::propertiesChanged(
+                constants::biosConfigMgrObjPath,
+                constants::biosConfigMgrService),
+            [this](sdbusplus::message_t& l_msg) {
+        m_specificBiosHandler->biosAttributesCallback(l_msg);
+    });
+}
+
+void IbmBiosHandler::biosAttributesCallback(sdbusplus::message_t& i_msg)
+{
+    if (i_msg.is_method_error())
+    {
+        logging::logMessage("Error in reading BIOS attribute signal. ");
+        return;
+    }
+
+    /*
+    TODO: Process specific BIOS attributes
+    */
+}
+
+void IbmBiosHandler::backUpOrRestoreBiosAttributes()
+{
+    // TODO: Implement IBM specific logic to back up and restore.
 }
 } // namespace vpd

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -44,10 +44,7 @@ Manager::Manager(
         m_gpioMonitor = std::make_shared<GpioMonitor>(
             m_worker->getSysCfgJsonObj(), m_ioContext);
 
-        // Create an instance of the BIOS handler
-        m_biosHandler = std::make_shared<BiosHandler>(m_asioConnection);
 #endif
-
         // Register methods under com.ibm.VPD.Manager interface
         iFace->register_method(
             "WriteKeyword",

--- a/src/manager_main.cpp
+++ b/src/manager_main.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#include "bios_handler.hpp"
 #include "logger.hpp"
 #include "manager.hpp"
 
@@ -27,6 +28,10 @@ int main(int, char**)
 
         auto vpdManager = std::make_shared<vpd::Manager>(io_con, interface,
                                                          connection);
+
+        auto biosHandler =
+            std::make_shared<vpd::BiosHandler<vpd::IbmBiosHandler>>(connection);
+
         interface->initialize();
 
         vpd::logging::logMessage("Start VPD-Manager event loop");


### PR DESCRIPTION
The commit converts the base BIOSHandler class to a templated class to allow extendability where multiple concrete class can be implemented to handle their own set of BIOS attributes and have their custom back up location.