### PR TITLE
1060:vpd-tool:Check for read only FRUs before write

### DIFF
--- a/config/ibm/50003000.json
+++ b/config/ibm/50003000.json
@@ -571,6 +571,7 @@
         "/sys/bus/i2c/drivers/at24/9-0052/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm8",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -585,6 +586,7 @@
         "/sys/bus/i2c/drivers/at24/9-0051/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm9",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -599,6 +601,7 @@
         "/sys/bus/i2c/drivers/at24/9-0050/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm10",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -613,6 +616,7 @@
         "/sys/bus/i2c/drivers/at24/9-0053/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm11",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -627,6 +631,7 @@
         "/sys/bus/i2c/drivers/at24/10-0052/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm0",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -641,6 +646,7 @@
         "/sys/bus/i2c/drivers/at24/10-0050/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm1",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -655,6 +661,7 @@
         "/sys/bus/i2c/drivers/at24/10-0051/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm2",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -669,6 +676,7 @@
         "/sys/bus/i2c/drivers/at24/10-0053/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm3",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -683,6 +691,7 @@
         "/sys/bus/i2c/drivers/at24/11-0053/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm12",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -697,6 +706,7 @@
         "/sys/bus/i2c/drivers/at24/11-0051/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm13",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -711,6 +721,7 @@
         "/sys/bus/i2c/drivers/at24/11-0050/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm14",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -725,6 +736,7 @@
         "/sys/bus/i2c/drivers/at24/11-0052/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm15",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -739,6 +751,7 @@
         "/sys/bus/i2c/drivers/at24/13-0053/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm4",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -753,6 +766,7 @@
         "/sys/bus/i2c/drivers/at24/13-0050/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm5",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -767,6 +781,7 @@
         "/sys/bus/i2c/drivers/at24/13-0051/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm6",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -781,6 +796,7 @@
         "/sys/bus/i2c/drivers/at24/13-0052/eeprom": [
             {
                 "inventoryPath": "/system/chassis/motherboard/vrm7",
+                "readOnly": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Vrm": null,
                     "com.ibm.ipzvpd.Location": {

--- a/ibm_vpd_utils.hpp
+++ b/ibm_vpd_utils.hpp
@@ -567,5 +567,15 @@ void findBackupVPDPaths(std::string& backupEepromPath,
  */
 void getBackupRecordKeyword(std::string& record, std::string& keyword);
 
+/**
+ * @brief Check if EEPROM of the given VPD path is read only.
+ *
+ * @param[in] vpdPath - VPD path of the FRU.
+ * @param[in] jsObject - Inventory JSON object.
+ *
+ * @return true if EEPROM is read only, false otherwise.
+ */
+bool isReadOnlyEEPROM(const std::string& vpdPath,
+                      const nlohmann::json& jsObject);
 } // namespace vpd
 } // namespace openpower

--- a/vpd_tool.cpp
+++ b/vpd_tool.cpp
@@ -107,6 +107,11 @@ int main(int argc, char** argv)
 
     try
     {
+        if (objectPath.empty())
+        {
+            throw runtime_error("Given path is empty.");
+        }
+
         if ((*kw) && (keyword.size() != 2))
         {
             throw runtime_error("Keyword " + keyword + " not supported.");
@@ -128,6 +133,11 @@ int main(int argc, char** argv)
 
         if (*writeFlag)
         {
+            if (isReadOnlyEEPROM(objectPath, jsObject))
+            {
+                throw runtime_error("Read only EEPROM. Update not allowed.");
+            }
+
             if ((!*fileOption) && (!*valOption))
             {
                 throw runtime_error("Please provide the data that needs to be "


### PR DESCRIPTION
This commit fixes the issue where vpd-tool tries to perform write on request for the FRUs which are read only.

Test:
./vpd-tool -w -O /system/chassis/motherboard/vrm0 -R VINI -K CC --value 51F3
Read only FRU. Update not allowed.