### PR TITLE
Event logging framework

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -125,5 +125,9 @@ constexpr auto bmcStateInterface = "xyz.openbmc_project.State.BMC";
 constexpr auto currentBMCStateProperty = "CurrentBMCState";
 constexpr auto bmcReadyState = "xyz.openbmc_project.State.BMC.BMCState.Ready";
 
+static constexpr auto eventLoggingServiceName = "xyz.openbmc_project.Logging";
+static constexpr auto eventLoggingObjectPath = "/xyz/openbmc_project/logging";
+static constexpr auto eventLoggingInterface =
+    "xyz.openbmc_project.Logging.Create";
 } // namespace constants
 } // namespace vpd

--- a/include/event_logger.hpp
+++ b/include/event_logger.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "constants.hpp"
+#include "types.hpp"
+
+#include <iostream>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace vpd
+{
+/**
+ * @brief Class for logging events.
+ *
+ * Class handles logging PEL under 'logging' service.
+ * Provide separate async API's for calling out inventory_path, device_path and
+ * i2c bus.
+ */
+class EventLogger
+{
+  public:
+    /**
+     * @brief An API to create a PEL with inventory path callout.
+     *
+     * This API calls an async method to create PEL, and also handles inventory
+     * path callout.
+     *
+     * Note: If inventory path callout info is not provided, it will create a
+     * PEL without any callout. Currently only one callout is handled in this
+     * API.
+     *
+     * @todo: Symbolic FRU and procedure callout needs to be handled in this
+     * API.
+     *
+     * @param[in] i_errorType - Enum to map with event message name.
+     * @param[in] i_severity - Severity of the event.
+     * @param[in] i_callouts - Callout information, list of tuple having
+     * inventory path and priority as input [optional].
+     * @param[in] i_fileName - File name.
+     * @param[in] i_funcName - Function name.
+     * @param[in] i_internalRc - Internal return code.
+     * @param[in] i_userData1 - Additional user data [optional].
+     * @param[in] i_userData2 - Additional user data [optional].
+     * @param[in] i_symFru - Symblolic FRU callout data [optional].
+     * @param[in] i_procedure - Procedure callout data [optional].
+     *
+     * @todo Add another async API without having any callbacks.
+     */
+    static void createAsyncPelWithInventoryCallout(
+        const types::ErrorType i_errorType,
+        const types::SeverityType i_severity,
+        const std::vector<types::InventoryCalloutData>& i_callouts,
+        const std::string& i_fileName, const std::string& i_funcName,
+        const std::string& i_internalRc,
+        const std::optional<std::pair<std::string, std::string>> i_userData1,
+        const std::optional<std::pair<std::string, std::string>> i_userData2,
+        const std::optional<std::string> i_symFru,
+        const std::optional<std::string> i_procedure);
+
+    /**
+     * @brief An API to create a PEL with device path callout.
+     *
+     * @param[in] i_errorType - Enum to map with event message name.
+     * @param[in] i_severity - Severity of the event.
+     * @param[in] i_callouts - Callout information, list of tuple having device
+     * path and error number as input.
+     * @param[in] i_fileName - File name.
+     * @param[in] i_funcName - Function name.
+     * @param[in] i_internalRc - Internal return code.
+     * @param[in] i_userData1 - Additional user data [optional].
+     * @param[in] i_userData2 - Additional user data [optional].
+     */
+    static void createAsyncPelWithI2cDeviceCallout(
+        const types::ErrorType i_errorType,
+        const types::SeverityType i_severity,
+        const std::vector<types::DeviceCalloutData>& i_callouts,
+        const std::string& i_fileName, const std::string& i_funcName,
+        const std::string& i_internalRc,
+        const std::optional<std::pair<std::string, std::string>> i_userData1,
+        const std::optional<std::pair<std::string, std::string>> i_userData2);
+
+    /**
+     * @brief An API to create a PEL with I2c bus callout.
+     *
+     * @param[in] i_errorType - Enum to map with event message name.
+     * @param[in] i_severity - Severity of the event.
+     * @param[in] i_callouts - Callout information, list of tuple having i2c
+     * bus, i2c address and error number as input.
+     * @param[in] i_fileName - File name.
+     * @param[in] i_funcName - Function name.
+     * @param[in] i_internalRc - Internal return code.
+     * @param[in] i_userData1 - Additional user data [optional].
+     * @param[in] i_userData2 - Additional user data [optional].
+     */
+    static void createAsyncPelWithI2cBusCallout(
+        const types::ErrorType i_errorType,
+        const types::SeverityType i_severity,
+        const std::vector<types::I2cBusCalloutData>& i_callouts,
+        const std::string& i_fileName, const std::string& i_funcName,
+        const std::string& i_internalRc,
+        const std::optional<std::pair<std::string, std::string>> i_userData1,
+        const std::optional<std::pair<std::string, std::string>> i_userData2);
+
+  private:
+    static const std::unordered_map<types::SeverityType, std::string>
+        m_severityMap;
+    static const std::unordered_map<types::ErrorType, std::string>
+        m_errorMsgMap;
+    static const std::unordered_map<types::CalloutPriority, std::string>
+        m_priorityMap;
+};
+} // namespace vpd

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -135,5 +135,48 @@ using DbusInvalidArgument =
 using InvalidArgument = phosphor::logging::xyz::openbmc_project::Common::InvalidArgument;
 
 namespace DeviceError = sdbusplus::xyz::openbmc_project::Common::Device::Error;
+
+/* PEL Severity enum as defined in [xyz.openbmc_project.Logging.Entry.Level]log.hpp from 'phosphor-logging' repo. */
+enum SeverityType
+{
+    Notice,
+    Informational,
+    Debug,
+    Warning,
+    Critical,
+    Emergency,
+    Alert,
+    Error
+};
+
+/* PEL callout priority from 'phosphor-logging' pel_types.hpp. If any change in 'phosphor-logging', it needs update here as well. */
+enum CalloutPriority
+{
+    High,
+    Medium,
+    MediumGroupA,
+    MediumGroupB,
+    MediumGroupC,
+    Low
+};
+
+/* The Message property of the event entry for creating PEL, to introduce new message needs to be added in 'phosphor-logging' message_registry.json as well. */
+enum ErrorType
+{
+    DefaultValue,
+    InvalidVpdMessage,
+    VpdMismatch,
+    InvalidEeprom,
+    EccCheckFailed,
+    JsonFailure,
+    DbusFailure,
+    InvalidSystem,
+    EssentialFru,
+    GpioError
+};
+
+using InventoryCalloutData = std::tuple<std::string, CalloutPriority>;
+using DeviceCalloutData = std::tuple<std::string, std::string>;
+using I2cBusCalloutData = std::tuple<std::string, std::string, std::string>;
 } // namespace types
 } // namespace vpd

--- a/meson.build
+++ b/meson.build
@@ -77,7 +77,8 @@ common_SOURCES = ['src/logger.cpp',
                   'src/worker.cpp',
                   'src/backup_restore.cpp',
                   'src/gpio_monitor.cpp',
-                  'src/bios_handler.cpp']
+                  'src/bios_handler.cpp',
+                  'src/event_logger.cpp']
 
 vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',

--- a/src/event_logger.cpp
+++ b/src/event_logger.cpp
@@ -1,0 +1,113 @@
+#include "event_logger.hpp"
+
+#include "logger.hpp"
+
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/server.hpp>
+
+namespace vpd
+{
+const std::unordered_map<types::SeverityType, std::string>
+    EventLogger::m_severityMap = {
+        {types::SeverityType::Notice,
+         "xyz.openbmc_project.Logging.Entry.Level.Notice"},
+        {types::SeverityType::Informational,
+         "xyz.openbmc_project.Logging.Entry.Level.Informational"},
+        {types::SeverityType::Debug,
+         "xyz.openbmc_project.Logging.Entry.Level.Debug"},
+        {types::SeverityType::Warning,
+         "xyz.openbmc_project.Logging.Entry.Level.Warning"},
+        {types::SeverityType::Critical,
+         "xyz.openbmc_project.Logging.Entry.Level.Critical"},
+        {types::SeverityType::Emergency,
+         "xyz.openbmc_project.Logging.Entry.Level.Emergency"},
+        {types::SeverityType::Alert,
+         "xyz.openbmc_project.Logging.Entry.Level.Alert"},
+        {types::SeverityType::Error,
+         "xyz.openbmc_project.Logging.Entry.Level.Error"}};
+
+const std::unordered_map<types::ErrorType, std::string>
+    EventLogger::m_errorMsgMap = {
+        {types::ErrorType::DefaultValue, "com.ibm.VPD.Error.DefaultValue"},
+        {types::ErrorType::InvalidVpdMessage, "com.ibm.VPD.Error.InvalidVPD"},
+        {types::ErrorType::VpdMismatch, "com.ibm.VPD.Error.Mismatch"},
+        {types::ErrorType::InvalidEeprom,
+         "com.ibm.VPD.Error.InvalidEepromPath"},
+        {types::ErrorType::EccCheckFailed, "com.ibm.VPD.Error.EccCheckFailed"},
+        {types::ErrorType::JsonFailure, "com.ibm.VPD.Error.InvalidJson"},
+        {types::ErrorType::DbusFailure, "com.ibm.VPD.Error.DbusFailure"},
+        {types::ErrorType::InvalidSystem,
+         "com.ibm.VPD.Error.UnknownSystemType"},
+        {types::ErrorType::EssentialFru,
+         "com.ibm.VPD.Error.RequiredFRUMissing"},
+        {types::ErrorType::GpioError, "com.ibm.VPD.Error.GPIOError"}};
+
+const std::unordered_map<types::CalloutPriority, std::string>
+    EventLogger::m_priorityMap = {{types::CalloutPriority::High, "H"},
+                                  {types::CalloutPriority::Medium, "M"},
+                                  {types::CalloutPriority::MediumGroupA, "A"},
+                                  {types::CalloutPriority::MediumGroupB, "B"},
+                                  {types::CalloutPriority::MediumGroupC, "C"},
+                                  {types::CalloutPriority::Low, "L"}};
+
+void EventLogger::createAsyncPelWithInventoryCallout(
+    const types::ErrorType i_errorType, const types::SeverityType i_severity,
+    const std::vector<types::InventoryCalloutData>& i_callouts,
+    const std::string& i_fileName, const std::string& i_funcName,
+    const std::string& i_internalRc,
+    const std::optional<std::pair<std::string, std::string>> i_userData1,
+    const std::optional<std::pair<std::string, std::string>> i_userData2,
+    const std::optional<std::string> i_symFru,
+    const std::optional<std::string> i_procedure)
+{
+    // TODO, implementation needs to be added.
+    (void)i_errorType;
+    (void)i_severity;
+    (void)i_callouts;
+    (void)i_fileName;
+    (void)i_funcName;
+    (void)i_internalRc;
+    (void)i_userData1;
+    (void)i_userData2;
+    (void)i_symFru;
+    (void)i_procedure;
+}
+
+void EventLogger::createAsyncPelWithI2cDeviceCallout(
+    const types::ErrorType i_errorType, const types::SeverityType i_severity,
+    const std::vector<types::DeviceCalloutData>& i_callouts,
+    const std::string& i_fileName, const std::string& i_funcName,
+    const std::string& i_internalRc,
+    const std::optional<std::pair<std::string, std::string>> i_userData1,
+    const std::optional<std::pair<std::string, std::string>> i_userData2)
+{
+    // TODO, implementation needs to be added.
+    (void)i_errorType;
+    (void)i_severity;
+    (void)i_callouts;
+    (void)i_fileName;
+    (void)i_funcName;
+    (void)i_internalRc;
+    (void)i_userData1;
+    (void)i_userData2;
+}
+
+void EventLogger::createAsyncPelWithI2cBusCallout(
+    const types::ErrorType i_errorType, const types::SeverityType i_severity,
+    const std::vector<types::I2cBusCalloutData>& i_callouts,
+    const std::string& i_fileName, const std::string& i_funcName,
+    const std::string& i_internalRc,
+    const std::optional<std::pair<std::string, std::string>> i_userData1,
+    const std::optional<std::pair<std::string, std::string>> i_userData2)
+{
+    // TODO, implementation needs to be added.
+    (void)i_errorType;
+    (void)i_severity;
+    (void)i_callouts;
+    (void)i_fileName;
+    (void)i_funcName;
+    (void)i_internalRc;
+    (void)i_userData1;
+    (void)i_userData2;
+}
+} // namespace vpd


### PR DESCRIPTION
This commit adds the framework to log a PEL.
PelHandler class is introduced with public API, which can be used for logging a PEL wherever is needed in the vpd-manager application.