### PR TITLE
Implementation of Bios Backup and Restore

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include "types.hpp"
+
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/bus.hpp>
 
@@ -60,6 +62,56 @@ class IbmBiosHandler : public BiosHandlerInterface
      * @param[in] i_msg - The callback message.
      */
     virtual void biosAttributesCallback(sdbusplus::message_t& i_msg);
+
+  private:
+    /**
+     * @brief API to read given attribute from BIOS table.
+     *
+     * @param[in] attributeName - Attribute to be read.
+     * @return - Bios attribute type.
+     */
+    types::BiosAttributeValue
+        readBiosAttribute(const std::string& attributeName);
+
+    /**
+     * @brief API to process "hb_field_core_override" attribute.
+     *
+     * The API checks value stored in VPD. If found default then the BIOS value
+     * is saved to VPD else VPD value is restored in BIOS attribute.
+     */
+    void processFieldCoreOverride();
+
+    /**
+     * @brief API to process "hb_memory_mirror_mode" attribute.
+     *
+     * The API checks value stored in VPD. If found default then the BIOS value
+     * is saved to VPD else VPD value is restored in BIOS attribute.
+     */
+    void processMemoryMirrorMode();
+
+    /**
+     * @brief API to process "pvm_keep_and_clear" attribute.
+     *
+     * The API reads the value from VPD and restore it to the BIOS attribute
+     * in BIOS table.
+     */
+    void processKeepAndClear();
+
+    /**
+     * @brief API to process "pvm_create_default_lpar" attribute.
+     *
+     * The API reads the value from VPD and restore it to the BIOS attribute
+     * in BIOS table.
+     */
+    void processLpar();
+
+    /**
+     * @brief API to process "pvm_clear_nvram" attribute.
+     *
+     * The API reads the value from VPD and restore it to the BIOS attribute
+     * in BIOS table.
+     */
+    void processClearNvRam();
 };
 
 /**

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -84,6 +84,8 @@ constexpr auto pimPath = "/xyz/openbmc_project/inventory";
 constexpr auto pimIntf = "xyz.openbmc_project.Inventory.Manager";
 constexpr auto ipzVpdInf = "com.ibm.ipzvpd.";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
+constexpr auto vsysInf = "com.ibm.ipzvpd.VSYS";
+constexpr auto utilInf = "com.ibm.ipzvpd.UTIL";
 constexpr auto kwdCCIN = "CC";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto pldmServiceName = "xyz.openbmc_project.PLDM";
@@ -91,6 +93,16 @@ constexpr auto pimServiceName = "xyz.openbmc_project.Inventory.Manager";
 constexpr auto biosConfigMgrObjPath =
     "/xyz/openbmc_project/bios_config/manager";
 constexpr auto biosConfigMgrService = "xyz.openbmc_project.BIOSConfig.Manager";
+constexpr auto biosConfigMgrInterface =
+    "xyz.openbmc_project.BIOSConfig.Manager";
+constexpr auto systemVpdInvPath =
+    "/xyz/openbmc_project/inventory/system/chassis/motherboard";
+constexpr auto kwd_D0 = "D0";
+constexpr auto kwd_RG = "RG";
+constexpr auto kwd_D1 = "D1";
+
+// defined just for readability.
+static constexpr auto fourEmptySpace = "    ";
 
 static constexpr auto BD_YEAR_END = 4;
 static constexpr auto BD_MONTH_END = 7;

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -22,6 +22,9 @@ using BiosProperty = std::tuple<
 using BiosBaseTable = std::variant<std::map<std::string, BiosProperty>>;
 using BiosBaseTableType = std::map<std::string, BiosBaseTable>;
 using BinaryVector = std::vector<uint8_t>;
+using BiosAttributeValue = std::variant<int64_t, std::string>;
+using BiosGetAttrRetType =
+    std::tuple<std::string, BiosAttributeValue, BiosAttributeValue>;
 
 // This covers mostly all the data type supported over Dbus for a property.
 // clang-format off

--- a/include/utility/dbus_utility.hpp
+++ b/include/utility/dbus_utility.hpp
@@ -231,5 +231,31 @@ inline bool isServiceRunning(const std::string& i_serviceName)
 
     return l_retVal;
 }
+
+inline types::BiosAttributeValue
+    biosGetAttributeMethodCall(const std::string& i_attributeName)
+{
+    auto l_bus = sdbusplus::bus::new_default();
+    auto l_method = l_bus.new_method_call(
+        constants::biosConfigMgrService, constants::biosConfigMgrObjPath,
+        constants::biosConfigMgrInterface, "GetAttribute");
+    l_method.append(i_attributeName);
+
+    types::BiosGetAttrRetType l_attributeVal;
+    try
+    {
+        auto l_result = l_bus.call(l_method);
+        l_result.read(std::get<0>(l_attributeVal), std::get<1>(l_attributeVal),
+                      std::get<2>(l_attributeVal));
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        logging::logMessage(
+            "Failed to read BIOS Attribute: " + i_attributeName +
+            " with error " + std::string(l_ex.what()));
+    }
+
+    return std::get<1>(l_attributeVal);
+}
 } // namespace dbusUtility
 } // namespace vpd

--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -89,6 +89,198 @@ void IbmBiosHandler::biosAttributesCallback(sdbusplus::message_t& i_msg)
 
 void IbmBiosHandler::backUpOrRestoreBiosAttributes()
 {
-    // TODO: Implement IBM specific logic to back up and restore.
+    // process FCO
+    processFieldCoreOverride();
+
+    // process memory mirror mode
+    processMemoryMirrorMode();
+
+    // process keep and clear
+    processKeepAndClear();
+
+    // process LPAR
+    processLpar();
+
+    // process clear NVRAM
+    processClearNvRam();
+}
+
+types::BiosAttributeValue
+    IbmBiosHandler::readBiosAttribute(const std::string& i_attributeName)
+{
+    types::BiosAttributeValue l_attrValueVariant =
+        dbusUtility::biosGetAttributeMethodCall(i_attributeName);
+
+    return l_attrValueVariant;
+}
+
+void IbmBiosHandler::processFieldCoreOverride()
+{
+    // Read required keyword from VPD.
+    auto l_kwdValueVariant = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::vsysInf, constants::kwd_RG);
+
+    if (auto pVal = std::get_if<types::BinaryVector>(&l_kwdValueVariant))
+    {
+        // converting to string to compare to default value.
+        std::string l_fcoInVpd;
+        l_fcoInVpd.assign(reinterpret_cast<const char*>(pVal->data()),
+                          pVal->size());
+
+        // Check if field core override value is default in VPD.
+        if (l_fcoInVpd == constants::fourEmptySpace)
+        {
+            // TODO: Save the data to VPD.
+        }
+        else
+        {
+            // Restore the data in BIOS.
+            types::BiosAttributeValue l_attrValueVariant =
+                readBiosAttribute("hb_field_core_override");
+            if (auto pVal = std::get_if<int64_t>(&l_attrValueVariant))
+            {
+                auto l_fcoInBios = *pVal;
+                (void)l_fcoInBios;
+                // TODO: save data to BIOS
+
+                return;
+            }
+
+            logging::logMessage("Invalid type recieved for FCO from BIOS.");
+        }
+        return;
+    }
+
+    logging::logMessage("Invalid type recieved for FCO from VPD.");
+}
+
+void IbmBiosHandler::processMemoryMirrorMode()
+{
+    auto l_kwdValueVariant = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::utilInf, constants::kwd_D0);
+
+    if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    {
+        auto l_mmmValInVpd = *pVal;
+
+        // Check if memory mirror mode value is default in VPD.
+        if (l_mmmValInVpd.at(0) == 0)
+        {
+            // TODO: Save mmm to VPD.
+        }
+        else
+        {
+            types::BiosAttributeValue l_attrValueVariant =
+                readBiosAttribute("hb_memory_mirror_mode");
+
+            if (auto pVal = std::get_if<std::string>(&l_attrValueVariant))
+            {
+                std::string l_ammInBios = *pVal;
+                (void)l_ammInBios;
+                // TODO: save to BIOS.
+
+                return;
+            }
+
+            logging::logMessage(
+                "Invalid type recieved for memory mode from BIOS.");
+        }
+        return;
+    }
+    logging::logMessage("Invalid type recieved for memory mode from VPD.");
+}
+
+void IbmBiosHandler::processKeepAndClear()
+{
+    auto l_kwdValueVariant = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::utilInf, constants::kwd_D1);
+
+    if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    {
+        auto l_keepAndClearValInVpd = *pVal;
+
+        // No default checking is required for keep and clear. Save what is
+        // there in VPD.
+
+        types::BiosAttributeValue l_attrValueVariant =
+            readBiosAttribute("pvm_keep_and_clear");
+
+        if (auto pVal = std::get_if<std::string>(&l_attrValueVariant))
+        {
+            std::string l_keepAndClearInBios = *pVal;
+            (void)l_keepAndClearInBios;
+            // TODO save the value to BIOS.
+
+            return;
+        }
+
+        logging::logMessage(
+            "Invalid type recieved for keep and clear from BIOS.");
+
+        return;
+    }
+
+    logging::logMessage("Invalid type recieved for keep and clear from VPD.");
+}
+
+void IbmBiosHandler::processLpar()
+{
+    // Read required keyword from VPD.
+    auto l_kwdValueVariant = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::utilInf, constants::kwd_D1);
+
+    if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    {
+        auto l_createDefaultLparInVpd = *pVal;
+
+        types::BiosAttributeValue l_attrValueVariant =
+            readBiosAttribute("pvm_create_default_lpar");
+
+        if (auto pVal = std::get_if<std::string>(&l_attrValueVariant))
+        {
+            std::string l_createDefaultLparInBios = *pVal;
+            (void)l_createDefaultLparInBios;
+            // TODO save the value to BIOS.
+            return;
+        }
+
+        logging::logMessage(
+            "Invalid type recieved for create default Lpar from BIOS.");
+
+        return;
+    }
+
+    logging::logMessage(
+        "Invalid type recieved for create default Lpar from VPD.");
+}
+
+void IbmBiosHandler::processClearNvRam()
+{
+    // Read required keyword from VPD.
+    auto l_kwdValueVariant = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::utilInf, constants::kwd_D1);
+
+    if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    {
+        auto l_clearNvRamInVpd = *pVal;
+        types::BiosAttributeValue l_attrValueVariant =
+            readBiosAttribute("pvm_clear_nvram");
+        if (auto pVal = std::get_if<std::string>(&l_attrValueVariant))
+        {
+            std::string l_clearNvRamInBios = *pVal;
+            (void)l_clearNvRamInBios;
+            // TODO: save to BIOS
+            return;
+        }
+        logging::logMessage("Invalid type recieved for clear NVRAM from BIOS.");
+
+        return;
+    }
+    logging::logMessage("Invalid type recieved for clear NVRAM from VPD.");
 }
 } // namespace vpd


### PR DESCRIPTION
The commit implements API which will read the required VPD keywords and corresponding BIOS attribute once PLDM servcie is up and running to decide if the value needs to be backed up in VPD or restored to BIOS table.