### PR TITLE
API to process field core overrride

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include "types.hpp"
+
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/bus.hpp>
 
@@ -60,6 +62,25 @@ class IbmBiosHandler : public BiosHandlerInterface
      * @param[in] i_msg - The callback message.
      */
     virtual void biosAttributesCallback(sdbusplus::message_t& i_msg);
+
+  private:
+    /**
+     * @brief API to read given attribute from BIOS table.
+     *
+     * @param[in] attributeName - Attribute to be read.
+     * @return - Bios attribute current value.
+     */
+    types::BiosAttributeCurrentValue
+        readBiosAttribute(const std::string& attributeName);
+
+    /**
+     * @brief API to process "hb_field_core_override" attribute.
+     *
+     * The API checks value stored in VPD. If found default then the BIOS value
+     * is saved to VPD else VPD value is restored in BIOS pending attribute
+     * table.
+     */
+    void processFieldCoreOverride();
 };
 
 /**

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -80,17 +80,25 @@ static constexpr auto SHIFT_BITS_0 = 0;
 static constexpr auto SHIFT_BITS_3 = 3;
 static constexpr auto SHIFT_BITS_5 = 5;
 
+static constexpr auto ASCII_OF_SPACE = 32;
+
 constexpr auto pimPath = "/xyz/openbmc_project/inventory";
 constexpr auto pimIntf = "xyz.openbmc_project.Inventory.Manager";
 constexpr auto ipzVpdInf = "com.ibm.ipzvpd.";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
+constexpr auto vsysInf = "com.ibm.ipzvpd.VSYS";
 constexpr auto kwdCCIN = "CC";
+constexpr auto kwdRG = "RG";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto pldmServiceName = "xyz.openbmc_project.PLDM";
 constexpr auto pimServiceName = "xyz.openbmc_project.Inventory.Manager";
 constexpr auto biosConfigMgrObjPath =
     "/xyz/openbmc_project/bios_config/manager";
 constexpr auto biosConfigMgrService = "xyz.openbmc_project.BIOSConfig.Manager";
+constexpr auto biosConfigMgrInterface =
+    "xyz.openbmc_project.BIOSConfig.Manager";
+constexpr auto systemVpdInvPath =
+    "/xyz/openbmc_project/inventory/system/chassis/motherboard";
 
 static constexpr auto BD_YEAR_END = 4;
 static constexpr auto BD_MONTH_END = 7;

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -21,6 +21,11 @@ using BiosProperty = std::tuple<
     std::vector<std::tuple<std::string, std::variant<int64_t, std::string>>>>;
 using BiosBaseTable = std::variant<std::map<std::string, BiosProperty>>;
 using BiosBaseTableType = std::map<std::string, BiosBaseTable>;
+using BiosAttributeCurrentValue = std::variant<int64_t, std::string>;
+using BiosAttributePendingValue = std::variant<int64_t, std::string>;
+using BiosGetAttrRetType = std::tuple<std::string, BiosAttributeCurrentValue,
+                                      BiosAttributePendingValue>;
+
 using BinaryVector = std::vector<uint8_t>;
 
 // This covers mostly all the data type supported over Dbus for a property.

--- a/include/utility/dbus_utility.hpp
+++ b/include/utility/dbus_utility.hpp
@@ -231,5 +231,46 @@ inline bool isServiceRunning(const std::string& i_serviceName)
 
     return l_retVal;
 }
+
+/**
+ * @brief API to call "GetAttribute" method uner BIOS manager.
+ *
+ * The API reads the given attribuute from BIOS and returns a tuple of both
+ * current as well as pending value for that attribute.
+ * The API return only the current attribute value if found.
+ * API returns an empty variant of type BiosAttributeCurrentValue in case of any
+ * error.
+ *
+ * @param[in] i_attributeName - Attribute to be read.
+ * @return Tuple of PLDM attribute Type, current attribute value and pending
+ * attribute value.
+ */
+inline types::BiosAttributeCurrentValue
+    biosGetAttributeMethodCall(const std::string& i_attributeName)
+{
+    auto l_bus = sdbusplus::bus::new_default();
+    auto l_method = l_bus.new_method_call(
+        constants::biosConfigMgrService, constants::biosConfigMgrObjPath,
+        constants::biosConfigMgrInterface, "GetAttribute");
+    l_method.append(i_attributeName);
+
+    types::BiosGetAttrRetType l_attributeVal;
+    try
+    {
+        auto l_result = l_bus.call(l_method);
+        l_result.read(std::get<0>(l_attributeVal), std::get<1>(l_attributeVal),
+                      std::get<2>(l_attributeVal));
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        logging::logMessage(
+            "Failed to read BIOS Attribute: " + i_attributeName +
+            " due to error " + std::string(l_ex.what()));
+
+        // TODO: Log an informational PEL here.
+    }
+
+    return std::get<1>(l_attributeVal);
+}
 } // namespace dbusUtility
 } // namespace vpd


### PR DESCRIPTION
The commit implements API to read VPD keyword RG under system record and "hb_field_core_override" attribute from BIOS table to decide if the attribute value needs to be backed up in VPD or restored in BIOS.