### PR TITLE
VpdTool class base framework and read keyword

### DIFF
--- a/vpd-tool/include/constants.hpp
+++ b/vpd-tool/include/constants.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vpd
+{
+namespace constants
+{
+static constexpr auto KEYWORD_SIZE = 2;
+static constexpr auto RECORD_SIZE = 4;
+
+constexpr auto vpdManagerService = "com.ibm.VPD.Manager";
+constexpr auto vpdManagerObjectPath = "/com/ibm/VPD/Manager";
+constexpr auto vpdManagerIntfName = "com.ibm.VPD.Manager";
+
+constexpr auto inventoryManagerService =
+    "xyz.openbmc_project.Inventory.Manager";
+constexpr auto baseInventoryPath = "/xyz/openbmc_project/inventory";
+constexpr auto ipzVpdIntf = "com.ibm.ipzvpd.";
+} // namespace constants
+} // namespace vpd

--- a/vpd-tool/include/types.hpp
+++ b/vpd-tool/include/types.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <sdbusplus/message/types.hpp>
+
+#include <cstdint>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+namespace vpd
+{
+namespace types
+{
+using BinaryVector = std::vector<uint8_t>;
+
+// This covers mostly all the data type supported over DBus for a property.
+// clang-format off
+using DbusVariantType = std::variant<
+    std::vector<std::tuple<std::string, std::string, std::string>>,
+    std::vector<std::string>,
+    std::vector<double>,
+    std::string,
+    int64_t,
+    uint64_t,
+    double,
+    int32_t,
+    uint32_t,
+    int16_t,
+    uint16_t,
+    uint8_t,
+    bool,
+    BinaryVector,
+    std::vector<uint32_t>,
+    std::vector<uint16_t>,
+    sdbusplus::message::object_path,
+    std::tuple<uint64_t, std::vector<std::tuple<std::string, std::string, double, uint64_t>>>,
+    std::vector<std::tuple<std::string, std::string>>,
+    std::vector<std::tuple<uint32_t, std::vector<uint32_t>>>,
+    std::vector<std::tuple<uint32_t, size_t>>,
+    std::vector<std::tuple<sdbusplus::message::object_path, std::string,
+                           std::string, std::string>>
+ >;
+} // namespace types
+} // namespace vpd

--- a/vpd-tool/include/utils.hpp
+++ b/vpd-tool/include/utils.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "types.hpp"
+
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/exception.hpp>
+
+#include <iostream>
+
+namespace vpd
+{
+namespace utils
+{
+/**
+ * @brief An API to read property from Dbus.
+ *
+ * The caller of the API needs to validate the validatity and correctness of the
+ * type and value of data returned. The API will just fetch and retun the data
+ * without any data validation.
+ *
+ * Note: It will be caller's responsibility to check for empty value returned
+ * and generate appropriate error if required.
+ *
+ * @param[in] i_serviceName - Name of the Dbus service.
+ * @param[in] i_objectPath - Object path under the service.
+ * @param[in] i_interface - Interface under which property exist.
+ * @param[in] i_property - Property whose value is to be read.
+ *
+ * @return - Value read from Dbus, if success.
+ *           If failed, empty variant.
+ */
+inline types::DbusVariantType readDbusProperty(const std::string& i_serviceName,
+                                               const std::string& i_objectPath,
+                                               const std::string& i_interface,
+                                               const std::string& i_property)
+{
+    types::DbusVariantType l_propertyValue;
+
+    // Mandatory fields to make a dbus call.
+    if (i_serviceName.empty() || i_objectPath.empty() || i_interface.empty() ||
+        i_property.empty())
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cout << "One of the parameter to make Dbus read call is empty."
+                  << std::endl;*/
+        return l_propertyValue;
+    }
+
+    try
+    {
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call(i_serviceName.c_str(), i_objectPath.c_str(),
+                                  "org.freedesktop.DBus.Properties", "Get");
+        l_method.append(i_interface, i_property);
+
+        auto result = l_bus.call(l_method);
+        result.read(l_propertyValue);
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cout << std::string(l_ex.what()) << std::endl;
+    }
+    return l_propertyValue;
+}
+
+/**
+ * @brief An API to print json data on stdout.
+ *
+ * @param[in] i_jsonData - JSON object.
+ */
+inline void printJson(const nlohmann::json& i_jsonData)
+{
+    try
+    {
+        std::cout << i_jsonData.dump(4) << std::endl;
+    }
+    catch (const nlohmann::json::type_error& l_ex)
+    {
+        throw std::runtime_error("Failed to dump JSON data, error: " +
+                                 std::string(l_ex.what()));
+    }
+}
+
+/**
+ * @brief An API to convert hex value to string.
+ *
+ * If given data contains printable characters, ASCII formated string value of
+ * the input data will be returned. Otherwise if the data has any non-printable
+ * value, returns the hex represented value of the given data in string format.
+ *
+ * @param[in] i_keywordValue - Data in hex.
+ *
+ * @throw - Throws std::bad_alloc or std::terminate in case of error.
+ *
+ * @return - Returns the converted string value.
+ */
+inline std::string getPrintableValue(const types::BinaryVector& i_keywordValue)
+{
+    bool l_allPrintable =
+        std::all_of(i_keywordValue.begin(), i_keywordValue.end(),
+                    [](const auto& l_byte) { return std::isprint(l_byte); });
+
+    std::ostringstream l_oss;
+    if (l_allPrintable)
+    {
+        l_oss << std::string(i_keywordValue.begin(), i_keywordValue.end());
+    }
+    else
+    {
+        l_oss << "0x";
+        for (const auto& l_byte : i_keywordValue)
+        {
+            l_oss << std::setfill('0') << std::setw(2) << std::hex
+                  << static_cast<int>(l_byte);
+        }
+    }
+
+    return l_oss.str();
+}
+} // namespace utils
+} // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+
+namespace vpd
+{
+/**
+ * @brief Class to support operations on VPD.
+ *
+ * The class provides API's to,
+ * Read keyword value from DBus/hardware.
+ * Update keyword value to DBus/hardware.
+ * Dump DBus object's critical information.
+ * Fix system VPD if any mismatch between DBus and hardware data.
+ * Reset specific system VPD keywords to its default value.
+ * Force VPD collection for hardware.
+ */
+class VpdTool
+{
+  public:
+    /**
+     * @brief Read keyword value.
+     *
+     * API to read VPD keyword's value from the given input path.
+     * If the provided i_onHardware option is true, read keyword's value from
+     * the hardware. Otherwise read keyword's value from DBus.
+     *
+     * Note: In case read keyword's value from DBus, the return value from DBus
+     * call expected as array of bytes.
+     *
+     * @param[in] i_fruPath - DBus object path or EEPROM path.
+     * @param[in] i_recordName - Record name.
+     * @param[in] i_keywordName - Keyword name.
+     * @param[in] i_onHardware - True if i_fruPath is EEPROM path, false
+     * otherwise.
+     * @param[in] i_fileToSave - File path to save keyword's value, if not given
+     * result will redirect to a console.
+     *
+     * @return On success return 0, otherwise return -1.
+     */
+    int readKeyword(const std::string& i_fruPath,
+                    const std::string& i_recordName,
+                    const std::string& i_keywordName, const bool i_onHardware,
+                    const std::string& i_fileToSave = {});
+};
+} // namespace vpd

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -5,11 +5,14 @@ else
     CLI11_dep = dependency('CLI11')
 endif
 
-sources = ['src/vpd_tool_main.cpp']
+sources = ['src/vpd_tool_main.cpp',
+           'src/vpd_tool.cpp']
+
+dependency_list = [CLI11_dep, sdbusplus]
 
 vpd_tool_exe = executable('vpd-tool',
                           sources,
-                          include_directories : ['../include/'],
-                          dependencies: [CLI11_dep],
+                          include_directories : ['include/'],
+                          dependencies: dependency_list,
                           install: true
                         )

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -1,0 +1,78 @@
+#include "vpd_tool.hpp"
+
+#include "constants.hpp"
+#include "types.hpp"
+#include "utils.hpp"
+
+#include <iostream>
+
+namespace vpd
+{
+int VpdTool::readKeyword(const std::string& i_fruPath,
+                         const std::string& i_recordName,
+                         const std::string& i_keywordName,
+                         const bool i_onHardware,
+                         const std::string& i_fileToSave)
+{
+    int l_rc = -1;
+    try
+    {
+        types::DbusVariantType l_keywordValue;
+        if (i_onHardware)
+        {
+            // TODO: uncomment when implementation of the API goes in
+            /*l_keywordValue = utils::readKeywordFromHardware(
+                constants::vpdManagerService,
+               constants::vpdManagerObjectPath,
+                constants::vpdManagerIntfName, i_fruPath,
+                make_tuple(i_recordName, i_keywordName));*/
+        }
+        else
+        {
+            std::string l_inventoryObjectPath(constants::baseInventoryPath +
+                                              i_fruPath);
+
+            l_keywordValue = utils::readDbusProperty(
+                constants::inventoryManagerService, l_inventoryObjectPath,
+                constants::ipzVpdIntf + i_recordName, i_keywordName);
+        }
+
+        if (const auto l_value =
+                std::get_if<types::BinaryVector>(&l_keywordValue))
+        {
+            const std::string& l_keywordStrValue =
+                utils::getPrintableValue(*l_value);
+
+            if (i_fileToSave.empty())
+            {
+                nlohmann::json l_resultInJson = nlohmann::json::object({});
+                nlohmann::json l_keywordValInJson = nlohmann::json::object({});
+
+                l_keywordValInJson.emplace(i_keywordName, l_keywordStrValue);
+                l_resultInJson.emplace(i_fruPath, l_keywordValInJson);
+
+                utils::printJson(l_resultInJson);
+            }
+            else
+            {
+                // TODO: Write result to a given file path.
+            }
+            l_rc = 0;
+        }
+        else
+        {
+            // TODO: Enable logging when verbose is enabled.
+            // std::cout << "Invalid data type received." << std::endl;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cerr << "Read keyword's value for FRU path: " << i_fruPath
+                  << ", Record: " << i_recordName
+                  << ", Keyword: " << i_keywordName
+                  << ", failed with exception: " << l_ex.what() << std::endl;*/
+    }
+    return l_rc;
+}
+} // namespace vpd

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -1,4 +1,6 @@
 #include "constants.hpp"
+#include "types.hpp"
+#include "vpd_tool.hpp"
 
 #include <CLI/CLI.hpp>
 
@@ -7,77 +9,82 @@
 
 int main(int argc, char** argv)
 {
-    int l_retValue = 0;
-    try
+    int l_rc = -1;
+    CLI::App l_app{"VPD Command Line Tool"};
+
+    std::string l_vpdPath{};
+    std::string l_recordName{};
+    std::string l_keywordName{};
+    std::string l_filePath{};
+
+    l_app.footer(
+        "Read:\n"
+        "    IPZ Format:\n"
+        "        From dbus to console: "
+        "vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
+        "        From dbus to file: "
+        "vpd-tool -r -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "        From hardware to console: "
+        "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
+        "        From hardware to file: "
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+
+    auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
+                                           "File path");
+    auto l_recordOption = l_app.add_option("--record, -R", l_recordName,
+                                           "Record name");
+    auto l_keywordOption = l_app.add_option("--keyword, -K", l_keywordName,
+                                            "Keyword name");
+
+    auto l_fileOption = l_app.add_option("--file", l_filePath,
+                                         "Absolute file path");
+
+    auto l_readFlag = l_app.add_flag("--readKeyword, -r", "Read keyword")
+                          ->needs(l_objectOption)
+                          ->needs(l_recordOption)
+                          ->needs(l_keywordOption);
+
+    auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
+                                         "CAUTION: Developer only option.");
+
+    CLI11_PARSE(l_app, argc, argv);
+
+    if (*l_objectOption && l_vpdPath.empty())
     {
-        CLI::App l_app{"VPD Command Line Tool"};
-
-        std::string l_vpdPath{};
-        std::string l_recordName{};
-        std::string l_keywordName{};
-        std::string l_filePath{};
-
-        l_app.footer(
-            "Read:\n"
-            "    IPZ Format:\n"
-            "        From dbus to console: "
-            "vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
-            "        From dbus to file: "
-            "vpd-tool -r -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
-            "        From hardware to console: "
-            "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
-            "        From hardware to file: "
-            "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
-
-        auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
-                                               "File path");
-        auto l_recordOption = l_app.add_option("--record, -R", l_recordName,
-                                               "Record name");
-        auto l_keywordOption = l_app.add_option("--keyword, -K", l_keywordName,
-                                                "Keyword name");
-
-        auto l_fileOption = l_app.add_option("--file", l_filePath,
-                                             "Absolute file path");
-
-        auto l_readFlag = l_app.add_flag("--readKeyword, -r", "Read keyword")
-                              ->needs(l_objectOption)
-                              ->needs(l_recordOption)
-                              ->needs(l_keywordOption);
-
-        auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
-                                             "CAUTION: Developer only option.");
-
-        CLI11_PARSE(l_app, argc, argv);
-
-        if (*l_keywordOption &&
-            (l_keywordName.size() != vpd::constants::TWO_BYTES))
-        {
-            throw std::runtime_error("Keyword " + l_keywordName +
-                                     " not supported.");
-        }
-
-        if (*l_hardwareFlag && !std::filesystem::exists(l_vpdPath))
-        {
-            throw std::runtime_error("Given EEPROM file path doesn't exist : " +
-                                     l_vpdPath);
-        }
-
-        (void)l_fileOption;
-
-        if (*l_readFlag)
-        {
-            // TODO: call read keyword implementation from here.
-        }
-        else
-        {
-            std::cout << l_app.help() << std::endl;
-        }
-    }
-    catch (const std::exception& l_ex)
-    {
-        std::cerr << l_ex.what() << std::endl;
-        l_retValue = -1;
+        throw std::runtime_error("Given path is empty.");
     }
 
-    return l_retValue;
+    if (*l_recordOption && (l_recordName.size() != vpd::constants::RECORD_SIZE))
+    {
+        throw std::runtime_error("Record " + l_recordName +
+                                 " is not supported.");
+    }
+
+    if (*l_keywordOption &&
+        (l_keywordName.size() != vpd::constants::KEYWORD_SIZE))
+    {
+        throw std::runtime_error("Keyword " + l_keywordName +
+                                 " is not supported.");
+    }
+
+    if (*l_recordOption && (l_recordName.size() != vpd::constants::RECORD_SIZE))
+    {
+        throw std::runtime_error("Record " + l_recordName + " not supported.");
+    }
+
+    bool l_isHardwareOperation = ((*l_hardwareFlag) ? true : false);
+
+    (void)l_fileOption;
+
+    if (*l_readFlag)
+    {
+        vpd::VpdTool l_vpdToolObj;
+        l_rc = l_vpdToolObj.readKeyword(l_vpdPath, l_recordName, l_keywordName,
+                                        l_isHardwareOperation, l_filePath);
+    }
+    else
+    {
+        std::cout << l_app.help() << std::endl;
+    }
+    return l_rc;
 }


### PR DESCRIPTION
This commit adds VpdTool class base framework, which provides the APIs to perform various VPD related operations.

Commit also adds the code for read keyword value for the given Dbus object path or hardware path.
Currently only read keyword value from DBus is implemented.