### PR TITLE
Manager:Single FRU VPD collection

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -106,5 +106,12 @@ static constexpr auto CMD_BUFFER_LENGTH = 256;
 
 // To be explicitly used for string comparision.
 static constexpr auto STR_CMP_SUCCESS = 0;
+
+constexpr auto bmcStateService = "xyz.openbmc_project.State.BMC";
+constexpr auto bmcZeroStateObject = "/xyz/openbmc_project/state/bmc0";
+constexpr auto bmcStateInterface = "xyz.openbmc_project.State.BMC";
+constexpr auto currentBMCStateProperty = "CurrentBMCState";
+constexpr auto bmcReadyState = "xyz.openbmc_project.State.BMC.BMCState.Ready";
+
 } // namespace constants
 } // namespace vpd

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -347,8 +347,88 @@ types::DbusVariantType
 void Manager::collectSingleFruVpd(
     const sdbusplus::message::object_path& i_dbusObjPath)
 {
-    // Dummy code to supress unused variable warning. To be removed.
-    logging::logMessage(std::string(i_dbusObjPath));
+    try
+    {
+        // TODO: Check if CM flag enabled for the given D-bus object path in
+        // system config JSON.
+
+        // Check if BMC reaches Ready state
+        const auto l_dbusValue = dbusUtility::readDbusProperty(
+            constants::bmcStateService, constants::bmcZeroStateObject,
+            constants::bmcStateInterface, constants::currentBMCStateProperty);
+
+        if (const auto l_currentBMCSate =
+                std::get_if<std::string>(&l_dbusValue))
+        {
+            if (*l_currentBMCSate != constants::bmcReadyState)
+            {
+                throw std::runtime_error(
+                    "BMC not ready. Single FRU VPD collection failed for " +
+                    std::string(i_dbusObjPath));
+            }
+        }
+
+        // Get system config JSON object from worker class
+        nlohmann::json l_sysCfgJsonObj{};
+
+        if (m_worker.get() != nullptr)
+        {
+            l_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
+        }
+
+        // Check if system config JSON is present
+        if (l_sysCfgJsonObj.empty())
+        {
+            throw std::runtime_error(
+                "System config JSON object not present. Single FRU VPD collection failed for " +
+                std::string(i_dbusObjPath));
+        }
+
+        // Get FRU path for the given D-bus object path from JSON
+        const std::string& l_fruPath =
+            jsonUtility::getFruPathFromJson(l_sysCfgJsonObj, i_dbusObjPath);
+
+        if (l_fruPath.empty())
+        {
+            throw std::runtime_error(
+                "D-bus object path not present in JSON. Single FRU VPD collection failed for " +
+                std::string(i_dbusObjPath));
+        }
+
+        // Parse VPD
+        types::VPDMapVariant l_parsedVpd = m_worker->parseVpdFile(l_fruPath);
+
+        // If l_parsedVpd is pointing to std::monostate
+        if (l_parsedVpd.index() == 0)
+        {
+            throw std::runtime_error("VPD parsing failed for " +
+                                     std::string(i_dbusObjPath));
+        }
+
+        // Get D-bus object map from worker class
+        types::ObjectMap l_dbusObjectMap;
+        m_worker->populateDbus(l_parsedVpd, l_dbusObjectMap, l_fruPath);
+
+        if (l_dbusObjectMap.empty())
+        {
+            throw std::runtime_error(
+                "Failed to create D-bus object map. Single FRU VPD collection failed for " +
+                std::string(i_dbusObjPath));
+        }
+
+        // Call PIM's Notify method
+        if (!dbusUtility::callPIM(move(l_dbusObjectMap)))
+        {
+            throw std::runtime_error(
+                "Notify PIM failed. Single FRU VPD collection failed for " +
+                std::string(i_dbusObjPath));
+        }
+    }
+    catch (const std::exception& l_error)
+    {
+        // TODO: Log PEL
+        logging::logMessage(std::string(l_error.what()));
+    }
 }
 
 void Manager::deleteSingleFruVpd(


### PR DESCRIPTION
This commit implements an API to perform VPD collection for the given FRU. One of the usecases is during concurrent maintenance, the FRU will be removed and replaced physically, during which PHYP sends the request to BMC via PLDM to perform VPD collection after FRU replacement.

Test:
Tested that FRU VPD collection is successful.

echo 11-0050 > /sys/bus/i2c/drivers/at24/unbind

busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager CollectFRUVPD o "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10"

vpd-manager[7444]: FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/include/utility/json_utility.hpp, Line: 356, Func: bool vpd::jsonUtility::procesSetGpioTag(const nlohmann::json_abi_v3_11_2::json&, const std::string&, const std::string&, const std::string&), Setting GPIO: SLOT10_PRSNT_EN_RSVD to 1
vpd-manager[7444]: FileName: /usr/src/debug/openpower-fru-vpd/1.0+git-r1/include/utility/json_utility.hpp, Line: 219, Func: bool vpd::jsonUtility::processSystemCmdTag(const nlohmann::json_abi_v3_11_2::json&, const std::string&, const std::string&, const std::string&), Bind command = echo 11-0050 > /sys/bus/i2c/drivers/at24/bind
p10b kernel: at24 11-0050: 8192 byte 24c64 EEPROM, writable, 1 bytes/write
p10b systemd[1]: Started IPZ format VPD Parser service for FRU sys/devices/platform/ahb/ahb:apb/ahb:apb:bus@1e78a000/1e78a600.i2c-bus/i2c-11/11-0050/11-00508.
vpd-manager[7444]: IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/11-0050/eeprom