### PR TITLE
Adding  "pollingRequired" tag in config JSON

### DIFF
--- a/configuration/ibm/50001001.json
+++ b/configuration/ibm/50001001.json
@@ -929,6 +929,12 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "pollingRequired": {
+                    "gpioPresence": {
+                        "pin": "RUSSEL_OPPANEL_PRESENCE_N",
+                        "value": 0
+                    }
+                },
                 "preAction": {
                     "collection": {
                         "gpioPresence": {


### PR DESCRIPTION
This commit adds a tag "pollingRequired" and GPIO related information under this tag in the system config JSON.