### PR TITLE
Process create default Lpar attribute

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -104,6 +104,29 @@ class IbmBiosHandler : public BiosHandlerInterface
      * table.
      */
     void processActiveMemoryMirror();
+
+    /**
+     * @brief API to process "pvm_create_default_lpar" attribute.
+     *
+     * The API reads the value from VPD and restore it to the BIOS attribute
+     * in BIOS pending attribute table.
+     */
+    void processCreateDefaultLpar();
+
+    /**
+     * @brief API to save given value to "pvm_create_default_lpar" attribute.
+     *
+     * @param[in] i_createDefaultLparVal - Value to be saved;
+     */
+    void saveCreateDefaultLparToBios(const std::string& i_createDefaultLparVal);
+
+    /**
+     * @brief API to save given value to VPD.
+     *
+     * @param[in] i_createDefaultLparVal - Value to be saved.
+     *
+     */
+    void saveCreateDefaultLparToVpd(const std::string& i_createDefaultLparVal);
 };
 
 /**

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -93,6 +93,7 @@ constexpr auto utilInf = "com.ibm.ipzvpd.UTIL";
 constexpr auto kwdCCIN = "CC";
 constexpr auto kwdRG = "RG";
 constexpr auto kwdAMM = "D0";
+constexpr auto kwdClearNVRAM_CreateLPAR = "D1";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto pldmServiceName = "xyz.openbmc_project.PLDM";
 constexpr auto pimServiceName = "xyz.openbmc_project.Inventory.Manager";

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -25,6 +25,9 @@ using BiosAttributeCurrentValue = std::variant<int64_t, std::string>;
 using BiosAttributePendingValue = std::variant<int64_t, std::string>;
 using BiosGetAttrRetType = std::tuple<std::string, BiosAttributeCurrentValue,
                                       BiosAttributePendingValue>;
+using PendingBIOSAttrItem =
+    std::pair<std::string, std::tuple<std::string, BiosAttributePendingValue>>;
+using PendingBIOSAttrs = std::vector<PendingBIOSAttrItem>;
 
 using BinaryVector = std::vector<uint8_t>;
 
@@ -53,7 +56,8 @@ using DbusVariantType = std::variant<
     std::vector<std::tuple<uint32_t, std::vector<uint32_t>>>,
     std::vector<std::tuple<uint32_t, size_t>>,
     std::vector<std::tuple<sdbusplus::message::object_path, std::string,
-                           std::string, std::string>>
+                           std::string, std::string>>,
+    PendingBIOSAttrs
  >;
 
 using MapperGetObject =


### PR DESCRIPTION
The commit implements API to update default data stored into VPD to BIOS table at the start of PLDM service.
It also implements API to update VPD if callback is recieved as a result of change in "pvm_create_default_lpar" attribute.

It is required to back up the value in VPD and to restore the value back to BIOS on start up.