### PR TITLE
Process clear NVRAM attribute

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -127,6 +127,28 @@ class IbmBiosHandler : public BiosHandlerInterface
      *
      */
     void saveCreateDefaultLparToVpd(const std::string& i_createDefaultLparVal);
+
+    /**
+     * @brief API to process "pvm_clear_nvram" attribute.
+     *
+     * The API reads the value from VPD and restores it to the BIOS pending
+     * attribute table.
+     */
+    void processClearNvram();
+
+    /**
+     * @brief API to save given value to "pvm_clear_nvram" attribute.
+     *
+     * @param[in] i_clearNvramVal - Value to be saved.
+     */
+    void saveClearNvramToBios(const std::string& i_clearNvramVal);
+
+    /**
+     * @brief API to save given value to VPD.
+     *
+     * @param[in] i_clearNvramVal - Value to be saved.
+     */
+    void saveClearNvramToVpd(const std::string& i_clearNvramVal);
 };
 
 /**

--- a/include/utility/common_utility.hpp
+++ b/include/utility/common_utility.hpp
@@ -1,7 +1,9 @@
 #pragma once
+
 #include "constants.hpp"
 #include "logger.hpp"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <vector>
@@ -102,5 +104,14 @@ inline std::vector<std::string> executeCmd(T&& i_path, Types... i_args)
     return l_cmdOutput;
 }
 
+/** @brief Converts string to lower case.
+ *
+ * @param [in] i_string - Input string.
+ */
+inline void toLower(std::string& i_string)
+{
+    std::transform(i_string.begin(), i_string.end(), i_string.begin(),
+                   [](unsigned char l_char) { return std::tolower(l_char); });
+}
 } // namespace commonUtility
 } // namespace vpd


### PR DESCRIPTION
The commit implements API to update default data stored into VPD to BIOS table at the start of PLDM service.
It also implements API to update VPD if callback is recieved as a result of change in "pvm_clear_nvram" attribute.

It is required to back up the value in VPD and to restore the value back to BIOS on start up.