### PR TITLE
Get D-bus representation of given keyword

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -46,6 +46,7 @@ static constexpr auto SPD_DRAM_TYPE_DDR4 = 0x0C;
 
 static constexpr auto LAST_KW = "PF";
 static constexpr auto POUND_KW = '#';
+static constexpr auto POUND_KW_PREFIX = "PD_";
 static constexpr auto MB_YEAR_END = 4;
 static constexpr auto MB_MONTH_END = 7;
 static constexpr auto MB_DAY_END = 10;

--- a/include/utility/vpd_specific_utility.hpp
+++ b/include/utility/vpd_specific_utility.hpp
@@ -377,5 +377,29 @@ inline void getVpdDataInVector(const std::string& vpdFilePath,
         throw;
     }
 }
+
+/**
+ * @brief An API to get D-bus representation of given VPD keyword.
+ *
+ * @param[in] i_keywordName - VPD keyword name.
+ *
+ * @return D-bus representation of given keyword.
+ */
+inline std::string getDbusPropNameForGivenKw(const std::string& i_keywordName)
+{
+    // Check for "#" prefixed VPD keyword.
+    if ((i_keywordName.size() == vpd::constants::TWO_BYTES) &&
+        (i_keywordName.at(0) == constants::POUND_KW))
+    {
+        // D-bus doesn't support "#". Replace "#" with "PD_" for those "#"
+        // prefixed keywords.
+        return (std::string(constants::POUND_KW_PREFIX) +
+                i_keywordName.substr(1));
+    }
+
+    // Return the keyword name back, if D-bus representation is same as the VPD
+    // keyword name.
+    return i_keywordName;
+}
 } // namespace vpdSpecificUtility
 } // namespace vpd

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -108,6 +108,10 @@ int Parser::updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData)
             return -1;
         }
 
+        // Get D-bus name for the given keyword
+        l_propertyName =
+            vpdSpecificUtility::getDbusPropNameForGivenKw(l_propertyName);
+
         // Create D-bus object map
         types::ObjectMap l_dbusObjMap = {std::make_pair(
             l_inventoryObjPath,


### PR DESCRIPTION
D-bus doesn't allow the property names with "#" in it. The keywords in VPD which starts with "#< keyword name >" should be represented "PD_< keyword name >.

Test:
-> Before updating D-bus:

vpd-tool -r -O /xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0 -R "VPRI" -K "#D" {
    "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0": {
        "#D": ""
    }
}

->Updating 2 bytes to "#D" keyword on D-bus:

busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0" "(ssay)" "VPRI" "#D" 2 0x31 0x32 i 2

->After updating D-bus:
vpd-tool -r -O /xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0 -R "VPRI" -K "#D" {
    "/sys/bus/i2c/drivers/at24/9-0050/eeprom": {
        "#D": "0x3132000000000000000000000000....
    }
}