### PR TITLE
P11 JSON:Refactored rainier 4U system JSON.

### DIFF
--- a/configuration/ibm/50001000.json
+++ b/configuration/ibm/50001000.json
@@ -1,0 +1,5517 @@
+{
+    "devTree": "conf-aspeed-bmc-ibm-rainier-4u-p1.dtb",
+    "backupRestoreConfigPath": "/usr/share/vpd/backup_restore_50001000.json",
+    "commonInterfaces": {
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "PartNumber": {
+                "recordName": "VINI",
+                "keywordName": "PN"
+            },
+            "SerialNumber": {
+                "recordName": "VINI",
+                "keywordName": "SN"
+            },
+            "SparePartNumber": {
+                "recordName": "VINI",
+                "keywordName": "FN"
+            },
+            "Model": {
+                "recordName": "VINI",
+                "keywordName": "CC"
+            },
+            "BuildDate": {
+                "recordName": "VR10",
+                "keywordName": "DC",
+                "encoding": "DATE"
+            }
+        }
+    },
+    "frus": {
+        "/sys/bus/i2c/drivers/at24/8-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "isSystemVpd": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Board.Motherboard": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System backplane"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Oscillator Reference Clock"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "isSystemVpd": true,
+                "copyRecords": ["VSYS"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.System": null,
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "SerialNumber": {
+                            "recordName": "VSYS",
+                            "keywordName": "SE"
+                        },
+                        "Model": {
+                            "recordName": "VSYS",
+                            "keywordName": "TM"
+                        },
+                        "SubModel": {
+                            "recordName": "VSYS",
+                            "keywordName": "BR"
+                        }
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Umts"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "isSystemVpd": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Global": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Chassis"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T18"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port (front)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot12/pcie_card12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T18"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 12
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port (front)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-E0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-E1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-E2"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-E3"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A0"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 51, 50, 51],
+                        "CC": [55, 66, 53, 70],
+                        "PN": [48, 50, 89, 75, 51, 50, 51],
+                        "DR": [66, 108, 111, 119, 101, 114],
+                        "SN": [89, 76, 49, 50, 74, 80, 49, 67, 49, 50, 51, 52],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 0],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5F",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK323",
+                        "SparePartNumber": "02YK323",
+                        "SerialNumber": "YL12JP1C1234"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A1"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 51, 50, 51],
+                        "CC": [55, 66, 53, 70],
+                        "PN": [48, 50, 89, 75, 51, 50, 51],
+                        "DR": [66, 108, 111, 119, 101, 114],
+                        "SN": [89, 76, 49, 50, 74, 80, 49, 67, 49, 50, 51, 52],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 1],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5F",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK323",
+                        "SparePartNumber": "02YK323",
+                        "SerialNumber": "YL12JP1C1234"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A2"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 51, 50, 51],
+                        "CC": [55, 66, 53, 70],
+                        "PN": [48, 50, 89, 75, 51, 50, 51],
+                        "DR": [66, 108, 111, 119, 101, 114],
+                        "SN": [89, 76, 49, 50, 74, 80, 49, 67, 49, 50, 51, 52],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 2],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5F",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK323",
+                        "SparePartNumber": "02YK323",
+                        "SerialNumber": "YL12JP1C1234"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A3"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 51, 50, 51],
+                        "CC": [55, 66, 53, 70],
+                        "PN": [48, 50, 89, 75, 51, 50, 51],
+                        "DR": [66, 108, 111, 119, 101, 114],
+                        "SN": [89, 76, 49, 50, 74, 80, 49, 67, 49, 50, 51, 52],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 3],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5F",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK323",
+                        "SparePartNumber": "02YK323",
+                        "SerialNumber": "YL12JP1C1234"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A4"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 51, 50, 51],
+                        "CC": [55, 66, 53, 70],
+                        "PN": [48, 50, 89, 75, 51, 50, 51],
+                        "DR": [66, 108, 111, 119, 101, 114],
+                        "SN": [89, 76, 49, 50, 74, 80, 49, 67, 49, 50, 51, 52],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 4],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5F",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK323",
+                        "SparePartNumber": "02YK323",
+                        "SerialNumber": "YL12JP1C1234"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "synthesized": true,
+                "extraInterfaces": {
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-A5"
+                    },
+                    "com.ibm.ipzvpd.VINI": {
+                        "FN": [48, 50, 89, 75, 51, 50, 51],
+                        "CC": [55, 66, 53, 70],
+                        "PN": [48, 50, 89, 75, 51, 50, 51],
+                        "DR": [66, 108, 111, 119, 101, 114],
+                        "SN": [89, 76, 49, 50, 74, 80, 49, 67, 49, 50, 51, 52],
+                        "RT": [86, 73, 78, 73]
+                    },
+                    "com.ibm.ipzvpd.DINF": {
+                        "RI": [0, 5, 33, 5],
+                        "RT": [68, 73, 78, 70]
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+                        "Model": "7B5F",
+                        "Manufacturer": "Delta",
+                        "PartNumber": "02YK323",
+                        "SparePartNumber": "02YK323",
+                        "SerialNumber": "YL12JP1C1234"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tod_battery",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Battery": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-E0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Time-of-day battery"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P0 OP3B"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P0 OP3A"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P1 OP0B"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-0 P1 OP0A"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Power signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-1 P0 OP3A"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Connector for OpenCAPI Port DCM-1 P1 OP0B"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T7"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T8"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T9"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T10"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Fan signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector13",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel display cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector14",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T14"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector15",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector16",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T16"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector17",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T17"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Fan signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector18",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T18"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port (front)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector19",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T19"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Fan cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector20",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T20"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Fan cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector21",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-T21"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Internal RDX power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/rdx0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Board": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "RDX Docking Station"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/rdx0/media0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Drive": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P4-D0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "RDX removable disk drive"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/rdx0/rdx_power_connector",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P4-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Power connector for RDX"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/rdx0/rdx_usb_connector",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P4-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB connector for RDX"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/8-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Bmc": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "eBMC card"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/ethernet0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Ethernet": null,
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item.NetworkInterface": {
+                        "MACAddress": {
+                            "recordName": "VCFG",
+                            "keywordName": "Z0",
+                            "encoding": "MAC"
+                        }
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "HMC port 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/ethernet1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Ethernet": null,
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item.NetworkInterface": {
+                        "MACAddress": {
+                            "recordName": "VCFG",
+                            "keywordName": "Z1",
+                            "encoding": "MAC"
+                        }
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "HMC port 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/usb0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 3.0 port (rear)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/displayport0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Display Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc/usb1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C5-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "USB 2.0 port (rear)"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/0-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/tpm_wilson",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "CPU_TPM_CARD_PRESENT_N",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Tpm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C22"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Trusted platform module card"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/7-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "essentialFru": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "BLYTH_OPPANEL_PRESENCE_N",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Panel": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-D0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/7-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "pollingRequired": {
+                    "hotPlugging": {
+                        "gpioPresence": {
+                            "pin": "RUSSEL_OPPANEL_PRESENCE_N",
+                            "value": 0
+                        }
+                    }
+                },
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "RUSSEL_OPPANEL_PRESENCE_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "RUSSEL_FW_I2C_ENABLE_N",
+                            "value": 0
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 7-0051 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "RUSSEL_FW_I2C_ENABLE_N",
+                            "value": 1
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Panel": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-D1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Control panel display"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/9-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Vrm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C14"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Voltage regulator module for system processor module 0"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/10-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Vrm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C23"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Voltage regulator module for system processor module 1"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi12.0/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi13.0/eeprom",
+                "cpuType": "primary",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit13",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/unit14",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi22.0/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi23.0/eeprom",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit13",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1/unit14",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi32.0/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi33.0/eeprom",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C24"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit13",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0/unit14",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/spi/drivers/at25/spi42.0/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "redundantEeprom": "/sys/bus/spi/drivers/at25/spi43.0/eeprom",
+                "powerOffOnly": true,
+                "offset": 196608,
+                "size": 65504,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cpu": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C24"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "System processor module 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Quad"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "High speed SMP/OpenCAPI Link"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory Controller Channel"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Processor To Memory Buffer Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Nest Memory Management Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Accelerator"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Interface Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "POWER Accelerator Unit Controller"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCI Express controllers"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe host bridge (PHB)"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit13",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OBUS End Point"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1/unit14",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Cache-Only Core"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/4-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT0_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT0_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 4-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 4-0060 > /sys/bus/i2c/drivers/leds-pca955x/bind"
+                        }
+                    }
+                },
+                "postFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT0_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 4,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 0
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C0-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/5-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT3_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT3_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 5-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 5-0060 > /sys/bus/i2c/drivers/leds-pca955x/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT3_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 5,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_top",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3/cxp_bot",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C3-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/5-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT4_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT4_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 5-0051 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 5-0061 > /sys/bus/i2c/drivers/leds-pca955x/bind"
+                        }
+                    }
+                },
+                "postFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT4_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 5,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_top",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4/cxp_bot",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C4-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/11-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT10_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT10_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 11-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 11-0060 > /sys/bus/i2c/drivers/leds-pca955x/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT10_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 11,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x16 or PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "CXP Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C10-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/4-0052/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT2_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT2_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 4-0052 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT2_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 4,
+                        "Address": 82
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/6-0053/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT6_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT6_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 6-0053 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT6_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/6-0052/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT7_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT7_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 6-0052 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT7_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 6,
+                        "Address": 82
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/6-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT9_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT9_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 6-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT9_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 6,
+                        "Address": 80
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/11-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT11_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT11_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 11-0051 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT11_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 11,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 11
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe5 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/c11_connector3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C11-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/4-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT1_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT1_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 4-0051 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT1_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 4,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/6-0051/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtStandby": true,
+                "concurrentlyMaintainable": true,
+                "preAction": {
+                    "collection": {
+                        "gpioPresence": {
+                            "pin": "SLOT8_EXPANDER_PRSNT_N",
+                            "value": 0
+                        },
+                        "setGpio": {
+                            "pin": "SLOT8_PRSNT_EN_RSVD",
+                            "value": 1
+                        },
+                        "systemCmd": {
+                            "cmd": "echo 6-0051 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "PostFailAction": {
+                    "collection": {
+                        "setGpio": {
+                            "pin": "SLOT8_PRSNT_EN_RSVD",
+                            "value": 0
+                        }
+                    }
+                },
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.I2CDevice": {
+                        "Bus": 6,
+                        "Address": 81
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "PCIe4 x8 adapter"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/c8_connector3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "ccin": ["6B87"],
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C8-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Internal Connector"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/13-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0/dp0_drive0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C0"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 0"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1/dp0_drive1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 2"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2/dp0_drive2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C2"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 2"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 3"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme3/dp0_drive3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 3"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 4"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme4/dp0_drive4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C4"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 4"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 5"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme5/dp0_drive5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 5"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C6"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 6"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6/dp0_drive6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C6"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 6"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "com.ibm.Control.Host.PCIeLink": null,
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 7"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7/dp0_drive7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 7"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/dp0_connector5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P1-T5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp0_cable0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp0_cable1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp0_cable2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp0_cable3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/14-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.DiskBackplane": null,
+                    "xyz.openbmc_project.Inventory.Item.FabricAdapter": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane 1"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C8"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 8"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0/dp1_drive0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C8"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 8"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 9"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1/dp1_drive1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 9"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 10"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2/dp1_drive2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C10"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 11
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 10"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 11"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme3/dp1_drive3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 12
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 11"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 12"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme4/dp1_drive4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C12"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 13
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 12"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 13"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme5/dp1_drive5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 14
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 13"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C14"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 14"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6/dp1_drive6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C14"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 15
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 14"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.State.Decorator.PowerState": "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot": {
+                        "SlotType": "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2"
+                    },
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 15"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7/dp1_drive7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "embedded": false,
+                "concurrentlyMaintainable": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 16
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe U.2 drive 15"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T0"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T1"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T2"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T3"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T4"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane signal cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/dp1_connector5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Connector": null,
+                    "xyz.openbmc_project.Inventory.Connector.Port": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P2-T5"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Drive backplane power cable port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp1_cable0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp1_cable1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp1_cable2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/cables/dp1_cable3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "noprime": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Cable": null,
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "NVMe Backplane Cable"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/111-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C12"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 0"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/110-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 1"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/214-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C16"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 2"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/210-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C17"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 3"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/202-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C18"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 4"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/311-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C19"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 5"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/310-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C20"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 6"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/312-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C21"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 7"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/402-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C25"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 8"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/410-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C26"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 9"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/112-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C27"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 10"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/115-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C28"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 11"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/100-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C29"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 12"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/101-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C30"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 13"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/114-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C31"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 14"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/113-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C32"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 15"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/216-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C33"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 16"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/203-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C34"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 17"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/217-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C35"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 18"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/211-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C36"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 19"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/215-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C37"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 20"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/315-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C38"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 21"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/300-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C39"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 22"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/313-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C40"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 23"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/314-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C41"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 24"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/301-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C42"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 25"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/417-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C43"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 26"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/403-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C44"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 27"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/416-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C45"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 28"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/411-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C46"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 29"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/415-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C47"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 30"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ],
+        "/sys/bus/i2c/drivers/at24/414-0050/eeprom": [
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "powerOffOnly": true,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item.Dimm": null,
+                    "com.ibm.ipzvpd.Location": {
+                        "LocationCode": "Ufcs-P0-C48"
+                    },
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Memory module 31"
+                    },
+                    "xyz.openbmc_project.State.Decorator.Availability": {
+                        "Available": false
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit0",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "OpenCAPI Memory Buffer"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit1",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "DDR Memory Port"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit2",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Control Device"
+                    }
+                }
+            },
+            {
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26/unit3",
+                "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "inherit": false,
+                "extraInterfaces": {
+                    "xyz.openbmc_project.Inventory.Item": {
+                        "PrettyName": "Onboard Memory Power Management IC"
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
P11 JSON:Refactored rainier 4U system JSON.

This commit has rainier 4U system JSON refactored with the following
modifications.

1. Added devTree tag.
2. Added backupRestoreConfigPath tag.
3. Added serviceName in every parent FRU and sub FRU section.
4. Modified pollingRequired section.
5. Modified preAction and PostFailAction sections.
6. Removed busType, driverType and devAddress as we have systemCmd tag
which has command to bind.
7. Added postAction section
8. Modified inventoryPath value
9. Added presence gpio pin for Base panel, TPM & PCIe cards
10. Added powerOffOnly tag for DDIMMs.
11. Added NVMe slot number
