### PR TITLE
Moving updateKeyword & dependent API’s to utility

### DIFF
--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -230,20 +230,6 @@ class Manager
      */
     bool isValidUnexpandedLocationCode(const std::string& i_locationCode);
 
-    /**
-     * @brief API to update keyword's value on hardware
-     *
-     * @param[in] i_fruPath - FRU path.
-     * @param[in] i_sysCfgJsonObj - JSON object.
-     * @param[in] i_paramsToWriteData - Data required to perform write.
-     *
-     * @return On success returns number of bytes written. On failure returns
-     * -1.
-     */
-    int updateKeywordOnHardware(
-        const types::Path& i_fruPath, const nlohmann::json& i_sysCfgJsonObj,
-        const types::WriteVpdParams i_paramsToWriteData);
-
     // Shared pointer to asio context object.
     const std::shared_ptr<boost::asio::io_context>& m_ioContext;
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -215,171 +215,18 @@ void Manager::SetTimerToDetectVpdCollectionStatus()
 int Manager::updateKeyword(const types::Path i_vpdPath,
                            const types::WriteVpdParams i_paramsToWriteData)
 {
-    if (i_vpdPath.empty())
-    {
-        logging::logMessage("Given VPD path is empty.");
-        return -1;
-    }
-
-    nlohmann::json l_sysCfgJsonObj{};
-
-    if (m_worker.get() != nullptr)
-    {
-        l_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
-    }
-
-    types::Path l_fruPath = i_vpdPath;
-    types::Path l_inventoryObjPath;
-    types::Path l_redundantFruPath;
-
-    if (!l_sysCfgJsonObj.empty())
-    {
-        try
-        {
-            // Get hardware path from system config JSON.
-            const types::Path& l_tempPath =
-                jsonUtility::getFruPathFromJson(l_sysCfgJsonObj, i_vpdPath);
-
-            if (!l_tempPath.empty())
-            {
-                // Save the FRU path to update on hardware
-                l_fruPath = l_tempPath;
-
-                // Get inventory object path from system config JSON
-                l_inventoryObjPath = jsonUtility::getInventoryObjPathFromJson(
-                    l_sysCfgJsonObj, i_vpdPath);
-
-                // Get redundant hardware path if present in system config JSON
-                l_redundantFruPath =
-                    jsonUtility::getRedundantEepromPathFromJson(l_sysCfgJsonObj,
-                                                                i_vpdPath);
-            }
-        }
-        catch (const std::exception& e)
-        {
-            return -1;
-        }
-    }
-
-    // Update keyword's value on hardware
-    int l_bytesUpdatedOnHardware = updateKeywordOnHardware(
-        l_fruPath, l_sysCfgJsonObj, i_paramsToWriteData);
-
-    if (l_bytesUpdatedOnHardware == -1)
-    {
-        return l_bytesUpdatedOnHardware;
-    }
-
-    // If inventory D-bus object path is present, perform update
-    if (!l_inventoryObjPath.empty())
-    {
-        types::Record l_recordName;
-        std::string l_interfaceName;
-        std::string l_propertyName;
-        types::DbusVariantType l_keywordValue;
-
-        if (const types::IpzData* l_ipzData =
-                std::get_if<types::IpzData>(&i_paramsToWriteData))
-        {
-            l_recordName = std::get<0>(*l_ipzData);
-            l_interfaceName = constants::ipzVpdInf + l_recordName;
-            l_propertyName = std::get<1>(*l_ipzData);
-
-            try
-            {
-                // Read keyword's value from hardware to write the same on
-                // D-bus.
-                l_keywordValue =
-                    readKeyword(l_fruPath, types::ReadVpdParams(std::make_tuple(
-                                               l_recordName, l_propertyName)));
-            }
-            catch (const std::exception& l_exception)
-            {
-                // TODO: Log PEL
-                // Unable to read keyword's value from hardware.
-                return -1;
-            }
-        }
-        else
-        {
-            // Input parameter type provided isn't compatible to perform update.
-            return -1;
-        }
-
-        // Create D-bus object map
-        types::ObjectMap l_dbusObjMap = {std::make_pair(
-            l_inventoryObjPath,
-            types::InterfaceMap{std::make_pair(
-                l_interfaceName, types::PropertyMap{std::make_pair(
-                                     l_propertyName, l_keywordValue)})})};
-
-        // Call PIM's Notify method to perform update
-        if (!dbusUtility::callPIM(std::move(l_dbusObjMap)))
-        {
-            // Call to PIM's Notify method failed.
-            return -1;
-        }
-    }
-
-    // Update keyword's value on redundant hardware if present
-    if (!l_redundantFruPath.empty())
-    {
-        int l_bytesUpdatedOnRedundantHw = updateKeywordOnHardware(
-            l_redundantFruPath, l_sysCfgJsonObj, i_paramsToWriteData);
-
-        if (l_bytesUpdatedOnRedundantHw == -1)
-        {
-            return l_bytesUpdatedOnRedundantHw;
-        }
-    }
-
-    // TODO: Check if revert is required when any of the writes fails.
-    // TODO: Handle error logging
-
-    // All updates are successful.
-    return l_bytesUpdatedOnHardware;
+    const nlohmann::json i_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
+    return vpdSpecificUtility::updateKeyword(i_sysCfgJsonObj, i_vpdPath,
+                                             i_paramsToWriteData);
 }
 
 types::DbusVariantType
     Manager::readKeyword(const types::Path i_fruPath,
                          const types::ReadVpdParams i_paramsToReadData)
 {
-    try
-    {
-        nlohmann::json l_jsonObj{};
-
-        if (m_worker.get() != nullptr)
-        {
-            l_jsonObj = m_worker->getSysCfgJsonObj();
-        }
-
-        std::error_code ec;
-
-        // Check if given path is filesystem path
-        if (!std::filesystem::exists(i_fruPath, ec) && (ec))
-        {
-            throw std::runtime_error("Given file path " + i_fruPath +
-                                     " not found.");
-        }
-
-        logging::logMessage("Performing VPD read on " + i_fruPath);
-
-        std::shared_ptr<vpd::Parser> l_parserObj =
-            std::make_shared<vpd::Parser>(i_fruPath, l_jsonObj);
-
-        std::shared_ptr<vpd::ParserInterface> l_vpdParserInstance =
-            l_parserObj->getVpdParserInstance();
-
-        return (
-            l_vpdParserInstance->readKeywordFromHardware(i_paramsToReadData));
-    }
-    catch (const std::exception& e)
-    {
-        logging::logMessage(
-            e.what() + std::string(". VPD manager read operation failed for ") +
-            i_fruPath);
-        throw types::DeviceError::ReadFailure();
-    }
+    const nlohmann::json i_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
+    return vpdSpecificUtility::readKeyword(i_sysCfgJsonObj, i_fruPath,
+                                           i_paramsToReadData);
 }
 
 void Manager::collectSingleFruVpd(
@@ -726,26 +573,4 @@ types::ListOfPaths Manager::getFrusByExpandedLocationCode(
 }
 
 void Manager::performVPDRecollection() {}
-
-int Manager::updateKeywordOnHardware(
-    const types::Path& i_fruPath, const nlohmann::json& i_sysCfgJsonObj,
-    const types::WriteVpdParams i_paramsToWriteData)
-{
-    try
-    {
-        std::shared_ptr<Parser> l_parserObj =
-            std::make_shared<Parser>(i_fruPath, i_sysCfgJsonObj);
-
-        std::shared_ptr<ParserInterface> l_vpdParserInstance =
-            l_parserObj->getVpdParserInstance();
-
-        return (
-            l_vpdParserInstance->writeKeywordOnHardware(i_paramsToWriteData));
-    }
-    catch (const std::exception& l_error)
-    {
-        // TODO : Log PEL
-        return -1;
-    }
-}
 } // namespace vpd


### PR DESCRIPTION
Moving the updateKeyword and its dependent API’s from manager class to vpdSpecificUtility file.
As the same updateKeyword API ‘s implementation logic is required in the backup&restore functionality as well for updating the keyword’s value.
So, in future if any other components require this API, can call API from vpdSpecificUtility.