### PR TITLE
Fix: vpd-tool input validation checks

### DIFF
--- a/vpd_tool.cpp
+++ b/vpd_tool.cpp
@@ -107,9 +107,14 @@ int main(int argc, char** argv)
 
     try
     {
-        if (objectPath.empty())
+        if (*object && objectPath.empty())
         {
             throw runtime_error("Given path is empty.");
+        }
+
+        if (*record && (recordName.size() != 4))
+        {
+            throw runtime_error("Record " + recordName + " not supported.");
         }
 
         if ((*kw) && (keyword.size() != 2))


### PR DESCRIPTION
vpd-tool with option’s which does not require an object path is failing with an error ‘Given path is empty’.

As CLI library checks whether value is passed or not for the selected options by default. As explicit check is not required, removed the object path check in the code.