### PR TITLE
Update BIOS table type

### DIFF
--- a/include/types.hpp
+++ b/include/types.hpp
@@ -18,10 +18,13 @@ namespace types
 using BiosProperty = std::tuple<
     std::string, bool, std::string, std::string, std::string,
     std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
-    std::vector<std::tuple<std::string, std::variant<int64_t, std::string>>>>;
-using BiosBaseTable = std::variant<std::map<std::string, BiosProperty>>;
+    std::vector<std::tuple<std::string, std::variant<int64_t, std::string>,
+                           std::string>>>;
+using BiosBaseTable =
+    std::variant<std::monostate, std::map<std::string, BiosProperty>>;
 using BiosBaseTableType = std::map<std::string, BiosBaseTable>;
-using BiosAttributeCurrentValue = std::variant<int64_t, std::string>;
+using BiosAttributeCurrentValue =
+    std::variant<std::monostate, int64_t, std::string>;
 using BiosAttributePendingValue = std::variant<int64_t, std::string>;
 using BiosGetAttrRetType = std::tuple<std::string, BiosAttributeCurrentValue,
                                       BiosAttributePendingValue>;


### PR DESCRIPTION
The typedef used for BIOS table needs to be modified to match the changes done in the structure of new BIOS table.
Also, monostate has been added to the variant to detect any type change in future.