### PR TITLE
Moving out updateKeyword core logic from manager

### DIFF
--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -230,20 +230,6 @@ class Manager
      */
     bool isValidUnexpandedLocationCode(const std::string& i_locationCode);
 
-    /**
-     * @brief API to update keyword's value on hardware
-     *
-     * @param[in] i_fruPath - FRU path.
-     * @param[in] i_sysCfgJsonObj - JSON object.
-     * @param[in] i_paramsToWriteData - Data required to perform write.
-     *
-     * @return On success returns number of bytes written. On failure returns
-     * -1.
-     */
-    int updateKeywordOnHardware(
-        const types::Path& i_fruPath, const nlohmann::json& i_sysCfgJsonObj,
-        const types::WriteVpdParams i_paramsToWriteData);
-
     // Shared pointer to asio context object.
     const std::shared_ptr<boost::asio::io_context>& m_ioContext;
 

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -49,7 +49,48 @@ class Parser
      */
     std::shared_ptr<vpd::ParserInterface> getVpdParserInstance();
 
+    /**
+     * @brief Update keyword value.
+     *
+     * This API is used to update keyword value on the EEPROM path and its
+     * redundant path(s) if any taken from system config JSON. And also updates
+     * keyword value on DBus.
+     *
+     * To update IPZ type VPD, input parameter for writing should be in the form
+     * of (Record, Keyword, Value). Eg: ("VINI", "SN", {0x01, 0x02, 0x03}).
+     *
+     * To update Keyword type VPD, input parameter for writing should be in the
+     * form of (Keyword, Value). Eg: ("PE", {0x01, 0x02, 0x03}).
+     *
+     * @param[in] i_paramsToWriteData - Input details.
+     *
+     * @return On success returns number of bytes written, on failure returns
+     * -1.
+     */
+    int updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData);
+
   private:
+    /**
+     * @brief Update keyword value on redundant path.
+     *
+     * This API is used to update keyword value on the given redundant path(s).
+     *
+     * To update IPZ type VPD, input parameter for writing should be in the form
+     * of (Record, Keyword, Value). Eg: ("VINI", "SN", {0x01, 0x02, 0x03}).
+     *
+     * To update Keyword type VPD, input parameter for writing should be in the
+     * form of (Keyword, Value). Eg: ("PE", {0x01, 0x02, 0x03}).
+     *
+     * @param[in] i_fruPath - Redundant EEPROM path.
+     * @param[in] i_paramsToWriteData - Input details.
+     *
+     * @return On success returns number of bytes written, on failure returns
+     * -1.
+     */
+    int updateVpdKeywordOnRedundantPath(
+        const std::string& i_fruPath,
+        const types::WriteVpdParams& i_paramsToWriteData);
+
     // holds offfset to VPD if applicable.
     size_t m_vpdStartOffset = 0;
 

--- a/include/utility/dbus_utility.hpp
+++ b/include/utility/dbus_utility.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "constants.hpp"
 #include "logger.hpp"
 #include "types.hpp"
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -221,123 +221,39 @@ int Manager::updateKeyword(const types::Path i_vpdPath,
         return -1;
     }
 
+    types::Path l_fruPath;
     nlohmann::json l_sysCfgJsonObj{};
 
     if (m_worker.get() != nullptr)
     {
         l_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
-    }
 
-    types::Path l_fruPath = i_vpdPath;
-    types::Path l_inventoryObjPath;
-    types::Path l_redundantFruPath;
-
-    if (!l_sysCfgJsonObj.empty())
-    {
-        try
+        // Get the EEPROM path
+        if (!l_sysCfgJsonObj.empty())
         {
-            // Get hardware path from system config JSON.
-            const types::Path& l_tempPath =
-                jsonUtility::getFruPathFromJson(l_sysCfgJsonObj, i_vpdPath);
-
-            if (!l_tempPath.empty())
-            {
-                // Save the FRU path to update on hardware
-                l_fruPath = l_tempPath;
-
-                // Get inventory object path from system config JSON
-                l_inventoryObjPath = jsonUtility::getInventoryObjPathFromJson(
-                    l_sysCfgJsonObj, i_vpdPath);
-
-                // Get redundant hardware path if present in system config JSON
-                l_redundantFruPath =
-                    jsonUtility::getRedundantEepromPathFromJson(l_sysCfgJsonObj,
-                                                                i_vpdPath);
-            }
-        }
-        catch (const std::exception& e)
-        {
-            return -1;
-        }
-    }
-
-    // Update keyword's value on hardware
-    int l_bytesUpdatedOnHardware = updateKeywordOnHardware(
-        l_fruPath, l_sysCfgJsonObj, i_paramsToWriteData);
-
-    if (l_bytesUpdatedOnHardware == -1)
-    {
-        return l_bytesUpdatedOnHardware;
-    }
-
-    // If inventory D-bus object path is present, perform update
-    if (!l_inventoryObjPath.empty())
-    {
-        types::Record l_recordName;
-        std::string l_interfaceName;
-        std::string l_propertyName;
-        types::DbusVariantType l_keywordValue;
-
-        if (const types::IpzData* l_ipzData =
-                std::get_if<types::IpzData>(&i_paramsToWriteData))
-        {
-            l_recordName = std::get<0>(*l_ipzData);
-            l_interfaceName = constants::ipzVpdInf + l_recordName;
-            l_propertyName = std::get<1>(*l_ipzData);
-
             try
             {
-                // Read keyword's value from hardware to write the same on
-                // D-bus.
-                l_keywordValue =
-                    readKeyword(l_fruPath, types::ReadVpdParams(std::make_tuple(
-                                               l_recordName, l_propertyName)));
+                l_fruPath = jsonUtility::getFruPathFromJson(l_sysCfgJsonObj,
+                                                            i_vpdPath);
             }
             catch (const std::exception& l_exception)
             {
-                // TODO: Log PEL
-                // Unable to read keyword's value from hardware.
+                logging::logMessage(
+                    "Error while getting FRU path, Path: " + i_vpdPath +
+                    ", error: " + std::string(l_exception.what()));
                 return -1;
             }
         }
-        else
-        {
-            // Input parameter type provided isn't compatible to perform update.
-            return -1;
-        }
-
-        // Create D-bus object map
-        types::ObjectMap l_dbusObjMap = {std::make_pair(
-            l_inventoryObjPath,
-            types::InterfaceMap{std::make_pair(
-                l_interfaceName, types::PropertyMap{std::make_pair(
-                                     l_propertyName, l_keywordValue)})})};
-
-        // Call PIM's Notify method to perform update
-        if (!dbusUtility::callPIM(std::move(l_dbusObjMap)))
-        {
-            // Call to PIM's Notify method failed.
-            return -1;
-        }
     }
 
-    // Update keyword's value on redundant hardware if present
-    if (!l_redundantFruPath.empty())
+    if (l_fruPath.empty())
     {
-        int l_bytesUpdatedOnRedundantHw = updateKeywordOnHardware(
-            l_redundantFruPath, l_sysCfgJsonObj, i_paramsToWriteData);
-
-        if (l_bytesUpdatedOnRedundantHw == -1)
-        {
-            return l_bytesUpdatedOnRedundantHw;
-        }
+        l_fruPath = i_vpdPath;
     }
 
-    // TODO: Check if revert is required when any of the writes fails.
-    // TODO: Handle error logging
-
-    // All updates are successful.
-    return l_bytesUpdatedOnHardware;
+    std::shared_ptr<Parser> l_parserObj =
+        std::make_shared<Parser>(l_fruPath, l_sysCfgJsonObj);
+    return l_parserObj->updateVpdKeyword(i_paramsToWriteData);
 }
 
 types::DbusVariantType
@@ -726,26 +642,4 @@ types::ListOfPaths Manager::getFrusByExpandedLocationCode(
 }
 
 void Manager::performVPDRecollection() {}
-
-int Manager::updateKeywordOnHardware(
-    const types::Path& i_fruPath, const nlohmann::json& i_sysCfgJsonObj,
-    const types::WriteVpdParams i_paramsToWriteData)
-{
-    try
-    {
-        std::shared_ptr<Parser> l_parserObj =
-            std::make_shared<Parser>(i_fruPath, i_sysCfgJsonObj);
-
-        std::shared_ptr<ParserInterface> l_vpdParserInstance =
-            l_parserObj->getVpdParserInstance();
-
-        return (
-            l_vpdParserInstance->writeKeywordOnHardware(i_paramsToWriteData));
-    }
-    catch (const std::exception& l_error)
-    {
-        // TODO : Log PEL
-        return -1;
-    }
-}
 } // namespace vpd

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,5 +1,6 @@
 #include "parser.hpp"
 
+#include <utility/dbus_utility.hpp>
 #include <utility/json_utility.hpp>
 #include <utility/vpd_specific_utility.hpp>
 
@@ -34,6 +35,138 @@ types::VPDMapVariant Parser::parse()
 {
     std::shared_ptr<vpd::ParserInterface> l_parser = getVpdParserInstance();
     return l_parser->parse();
+}
+
+int Parser::updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData)
+{
+    // Update keyword's value on hardware
+    int l_bytesUpdatedOnHardware = -1;
+    try
+    {
+        std::shared_ptr<ParserInterface> l_vpdParserInstance =
+            getVpdParserInstance();
+        l_bytesUpdatedOnHardware =
+            l_vpdParserInstance->writeKeywordOnHardware(i_paramsToWriteData);
+    }
+    catch (const std::exception& l_exception)
+    {
+        logging::logMessage(
+            "Error while updating keyword's value on hardware path " +
+            m_vpdFilePath + ", error: " + std::string(l_exception.what()));
+        // TODO : Log PEL
+        return -1;
+    }
+
+    auto [l_fruPath, l_inventoryObjPath, l_redundantFruPath] =
+        jsonUtility::getAllPathsToUpdateKeyword(m_parsedJson, m_vpdFilePath);
+
+    // If inventory D-bus object path is present, update keyword's value on DBus
+    if (!l_inventoryObjPath.empty())
+    {
+        types::Record l_recordName;
+        std::string l_interfaceName;
+        std::string l_propertyName;
+        types::DbusVariantType l_keywordValue;
+
+        if (const types::IpzData* l_ipzData =
+                std::get_if<types::IpzData>(&i_paramsToWriteData))
+        {
+            l_recordName = std::get<0>(*l_ipzData);
+            l_interfaceName = constants::ipzVpdInf + l_recordName;
+            l_propertyName = std::get<1>(*l_ipzData);
+
+            try
+            {
+                // Read keyword's value from hardware to write the same on
+                // D-bus.
+                std::shared_ptr<ParserInterface> l_vpdParserInstance =
+                    getVpdParserInstance();
+
+                logging::logMessage("Performing VPD read on " + m_vpdFilePath);
+
+                l_keywordValue = l_vpdParserInstance->readKeywordFromHardware(
+                    types::ReadVpdParams(
+                        std::make_tuple(l_recordName, l_propertyName)));
+            }
+            catch (const std::exception& l_exception)
+            {
+                // Unable to read keyword's value from hardware.
+                logging::logMessage(
+                    "Error while reading keyword's value from hadware path " +
+                    m_vpdFilePath +
+                    ", error: " + std::string(l_exception.what()));
+                // TODO: Log PEL
+                return -1;
+            }
+        }
+        else
+        {
+            // Input parameter type provided isn't compatible to perform update.
+            logging::logMessage(
+                "Input parameter type isn't compatible to update keyword's value on DBus for object path: " +
+                l_inventoryObjPath);
+            return -1;
+        }
+
+        // Create D-bus object map
+        types::ObjectMap l_dbusObjMap = {std::make_pair(
+            l_inventoryObjPath,
+            types::InterfaceMap{std::make_pair(
+                l_interfaceName, types::PropertyMap{std::make_pair(
+                                     l_propertyName, l_keywordValue)})})};
+
+        // Call PIM's Notify method to perform update
+        if (!dbusUtility::callPIM(std::move(l_dbusObjMap)))
+        {
+            // Call to PIM's Notify method failed.
+            logging::logMessage("Notify PIM is failed for object path: " +
+                                l_inventoryObjPath);
+            return -1;
+        }
+    }
+
+    // Update keyword's value on redundant hardware if present
+    if (!l_redundantFruPath.empty())
+    {
+        if (updateVpdKeywordOnRedundantPath(l_redundantFruPath,
+                                            i_paramsToWriteData) < 0)
+        {
+            logging::logMessage(
+                "Error while updating keyword's value on redundant path " +
+                l_redundantFruPath);
+            return -1;
+        }
+    }
+
+    // TODO: Check if revert is required when any of the writes fails.
+    // TODO: Handle error logging
+
+    // All updates are successful.
+    return l_bytesUpdatedOnHardware;
+}
+
+int Parser::updateVpdKeywordOnRedundantPath(
+    const std::string& i_fruPath,
+    const types::WriteVpdParams& i_paramsToWriteData)
+{
+    try
+    {
+        std::shared_ptr<Parser> l_parserObj =
+            std::make_shared<Parser>(i_fruPath, m_parsedJson);
+
+        std::shared_ptr<ParserInterface> l_vpdParserInstance =
+            l_parserObj->getVpdParserInstance();
+
+        return l_vpdParserInstance->writeKeywordOnHardware(i_paramsToWriteData);
+    }
+    catch (const std::exception& l_exception)
+    {
+        logging::logMessage(
+            "Error while updating keyword's value on redundant path " +
+            i_fruPath + ", error: " + std::string(l_exception.what()));
+        // TODO : Log PEL
+        return -1;
+    }
 }
 
 } // namespace vpd


### PR DESCRIPTION
This commit adds the code to move updateKeyword API from Manager class to Parser class. And removed the dependent API from the Manager class.

As updateKeyword API implementation core logic
is required in the backup&restore functionality to update the keyword’s value. So, Parser class will host this functionality.

In the Parser class updateVpdKeyword API is introduced, which updates keyword’s value on the given EEPROM path and updates on DBus, redundant EEPROM path(s) also if those path’s information is available in the system config JSON.