### PR TITLE
Enable PEL in json_utility file

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -46,6 +46,7 @@ test_sources = [
   '../src/isdimm_parser.cpp',
   '../src/ipz_parser.cpp',
   '../src/keyword_vpd_parser.cpp',
+  '../src/event_logger.cpp',
   '../vpdecc/vpdecc.c'
 ]
 


### PR DESCRIPTION
This commit adds code to log a PEL in json_utility file, in case of error where PEL is required.

getInventoryObjPathFromJson API is moved above, as this API is being used in processGpioPresenceTag and procesSetGpioTag API's to get inventory path to create PEL.

output:
'''
root@p10bmc:peltool -l
{
    "0x50000001": {
        "SRC":                  "BD554007",
        "Message":              "GPIO line couldn't be found or read.",
        "PLID":                 "0x50000001",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - VPD Interface",
        "Commit Time":          "09/20/2024 04:32:28",
        "Sev":                  "Predictive Error",
        "CompID":               "bmc vpd"
    }
}

root@p10bmc:~# peltool -i 0x50000001
[
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "09/20/2024 07:19:24",
    "Committed at":             "09/20/2024 07:19:24",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50000001",
    "Entry Id":                 "0x50000001",
    "BMC Event Log Id":         "1"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "GPIO line couldn't be found or read."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554007",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "2",
        "Callouts": [{
            "FRU Type":         "Normal Hardware FRU",
            "Priority":         "Mandatory, replace all with this type as a unit",
            "Location Code":    "U78DA.ND0.1234567-D1",
            "Part Number":      "F191014",
            "CCIN":             "6B86",
            "Serial Number":    "YL6B86010000"
        }, {
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a unit",
            "Procedure":        "BMC0001"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-22A",
    "Reporting Serial Number":  "SIMP10R",
    "FW Released Ver":          "NL1060_069",
    "FW SubSys Version":        "fw1060.20-14",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554007_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-22A",
    "Serial Number":            "SIMP10R"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.16 0.23 0.14",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 0h 8m 43s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1060.20-14-1060.2436.20240905a (NL1060_069)",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "CALLOUT_INVENTORY_PATH": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
    "CALLOUT_PRIORITY": "H",
    "DESCRIPTION": "Exception on GPIO line: RUSSEL_OPPANEL_PRESENCE_N Reason: std::exception File: /sys/bus/i2c/drivers/at24/7-0051/eeprom Pel Logged",
    "FileName": "/usr/src/debug/openpower-fru-vpd/1.0+git-r1/include/utility/json_utility.hpp",
    "FunctionName": "bool vpd::jsonUtility::processGpioPresenceTag(const nlohmann::json_abi_v3_11_2::json&, const std::string&, const std::string&, const std::string&)",
    "InternalRc": "",
    "UserData1": "",
    "UserData2": ""
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "PEL Internal Debug Data": {
        "DIMMs Info Fetch Error": [
            "Failed to determine the HW Type, LocationCode:[U78DA.ND0.1234567-D1] PHALErrorMsg:[The location code is not found in device tree]"
        ]
    }
}
}'''