### PR TITLE
Save FCO value to BIOS

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -90,6 +90,13 @@ class IbmBiosHandler : public BiosHandlerInterface
     void saveFcoToVpd(int64_t i_fcoInBios);
 
     /**
+     * @brief API to save given value to "hb_field_core_override" attribute.
+     *
+     * @param[in] i_fcoVal - FCO value.
+     */
+    void saveFcoToBios(const types::BinaryVector& i_fcoVal);
+
+    /**
      * @brief API to save AMM data into VPD.
      *
      * @param[in] i_memoryMirrorMode - Memory mirror mode value.

--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -194,7 +194,7 @@ void IbmBiosHandler::processFieldCoreOverride()
         }))
         {
             // Restore the data to BIOS.
-            // TODO: saveFcoToBios(*l_fcoInVpd);
+            saveFcoToBios(*l_fcoInVpd);
         }
         else
         {
@@ -228,6 +228,37 @@ void IbmBiosHandler::saveFcoToVpd(int64_t i_fcoInBios)
         0, 0, 0, static_cast<uint8_t>(i_fcoInBios)};
 
     // TODO:  Call Manager API to write keyword data using inventory path.
+}
+
+void IbmBiosHandler::saveFcoToBios(const types::BinaryVector& i_fcoVal)
+{
+    if (i_fcoVal.size() != constants::VALUE_4)
+    {
+        logging::logMessage("Bad size for FCO received. Skip writing to BIOS");
+        return;
+    }
+
+    types::PendingBIOSAttrs l_pendingBiosAttribute;
+    l_pendingBiosAttribute.push_back(std::make_pair(
+        "hb_field_core_override",
+        std::make_tuple(
+            "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Integer",
+            std::to_string(i_fcoVal.at(constants::VALUE_3)))));
+
+    try
+    {
+        dbusUtility::writeDbusProperty(
+            constants::biosConfigMgrService, constants::biosConfigMgrObjPath,
+            constants::biosConfigMgrInterface, "PendingAttributes",
+            l_pendingBiosAttribute);
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Should we log informational PEL here as well?
+        logging::logMessage(
+            "DBus call to update FCO value in pending attribute failed. " +
+            std::string(l_ex.what()));
+    }
 }
 
 void IbmBiosHandler::saveAmmToVpd(const std::string& i_memoryMirrorMode)


### PR DESCRIPTION
The commit implements API to save recieved value to BIOS pending attribute table.
The API will be required to restore data from VPD back to the BIOS table for the corresponding attribute.