### PR TITLE
Handle file exists in Parser class

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -251,9 +251,19 @@ int Manager::updateKeyword(const types::Path i_vpdPath,
         l_fruPath = i_vpdPath;
     }
 
-    std::shared_ptr<Parser> l_parserObj =
-        std::make_shared<Parser>(l_fruPath, l_sysCfgJsonObj);
-    return l_parserObj->updateVpdKeyword(i_paramsToWriteData);
+    try
+    {
+        std::shared_ptr<Parser> l_parserObj =
+            std::make_shared<Parser>(l_fruPath, l_sysCfgJsonObj);
+        return l_parserObj->updateVpdKeyword(i_paramsToWriteData);
+    }
+    catch (const std::exception& l_exception)
+    {
+        // TODO:: error log needed
+        logging::logMessage("Update keyword failed for file[" + i_vpdPath +
+                            "], reason: " + std::string(l_exception.what()));
+        return -1;
+    }
 }
 
 types::DbusVariantType

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,6 +11,23 @@ namespace vpd
 Parser::Parser(const std::string& vpdFilePath, nlohmann::json parsedJson) :
     m_vpdFilePath(vpdFilePath), m_parsedJson(parsedJson)
 {
+    std::error_code l_errCode;
+
+    // ToDo: Add minimum file size check in all the concert praser classes,
+    // depends on their VPD type.
+    if (!std::filesystem::exists(m_vpdFilePath, l_errCode))
+    {
+        std::string l_message{"Parser object creation failed, file [" +
+                              m_vpdFilePath + "] doesn't exists."};
+
+        if (l_errCode)
+        {
+            l_message += " Error message: " + l_errCode.message();
+        }
+
+        throw std::runtime_error(l_message);
+    }
+
     // Read VPD offset if applicable.
     if (!m_parsedJson.empty())
     {

--- a/test/utest_ipz_parser.cpp
+++ b/test/utest_ipz_parser.cpp
@@ -66,9 +66,8 @@ TEST(IpzVpdParserTest, VpdFileDoesNotExist)
     // Vpd file does not exist
     nlohmann::json l_json;
     std::string l_vpdFile("vpd_files/xyz.dat");
-    vpd::Parser l_vpdParser(l_vpdFile, l_json);
 
-    EXPECT_THROW(l_vpdParser.parse(), std::exception);
+    EXPECT_THROW(vpd::Parser(l_vpdFile, l_json), std::runtime_error);
 }
 
 TEST(IpzVpdParserTest, MissingHeader)


### PR DESCRIPTION
This commit adds the changes to handle the file doesn’t exist while
 creating the Parser object. Exception is thrown from the Parser
 constructor if given file path doesn’t exist in the system.
    
 Also updated IpzVpdParserTest unit test case for file doesn’t exist,
 which got affected with the above changes in the Parser class, observed
 that test case got passed.