### PR TITLE
Utility to check for multiple actions

### DIFF
--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -871,5 +871,50 @@ inline std::string getServiceName(const nlohmann::json& i_sysCfgJsonObj,
     }
     return std::string{};
 }
+
+/** @brief API to check if an action is required for given EEPROM path.
+ *
+ * System config JSON can contain pre-action, post-action etc. like actions
+ * defined for an EEPROM path. The API will check if any such action is defined
+ * for the EEPROM.
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
+ * @param[in] i_vpdFruPath - EEPROM path.
+ * @param[in] i_action - Action to be checked.
+ * @param[in] i_flowFlag - Denotes the flow w.r.t which the action should be
+ * triggered.
+ * @return - True if action is defined for the flow, false otherwise.
+ */
+inline bool isActionRequired(const nlohmann::json& i_sysCfgJsonObj,
+                             const std::string& i_vpdFruPath,
+                             const std::string& i_action,
+                             const std::string& i_flowFlag)
+{
+    if (i_vpdFruPath.empty() || i_action.empty() || i_flowFlag.empty())
+    {
+        logging::logMessage("Invalid parameters recieved.");
+        return false;
+    }
+
+    if (i_sysCfgJsonObj.empty() || i_sysCfgJsonObj.contains("frus"))
+    {
+        logging::logMessage("Invalid JSON object recieved.");
+        return false;
+    }
+
+    if ((i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0)).contains(i_action))
+    {
+        if ((i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0))[i_action].contains(
+                i_flowFlag))
+        {
+            return true;
+        }
+
+        logging::logMessage("Flow flag: [" + i_flowFlag +
+                            "], not found in JSON for path: " + i_vpdFruPath);
+        return false;
+    }
+    return false;
+}
 } // namespace jsonUtility
 } // namespace vpd

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1084,8 +1084,9 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
 
     bool l_isPostFailActionRequired = false;
 
-    // check if the FRU qualifies for pre/post handling.
-    if ((m_parsedJson["frus"][i_vpdFilePath].at(0)).contains("preAction"))
+    // check if the FRU qualifies for pre action.
+    if (jsonUtility::isActionRequired(m_parsedJson, i_vpdFilePath, "preAction",
+                                      "collection"))
     {
         if (processPreAction(i_vpdFilePath, "collection"))
         {
@@ -1118,6 +1119,17 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
 
     std::shared_ptr<Parser> vpdParser = std::make_shared<Parser>(i_vpdFilePath,
                                                                  m_parsedJson);
+
+    // Before returning, as collection is over, check if FRU qualifies for
+    // any post action in the flow of collection.
+    // Note: Don't change the order, post action needs to be processed only
+    // after collection for FRU is successfully done.
+    if (jsonUtility::isActionRequired(m_parsedJson, i_vpdFilePath, "postAction",
+                                      "collection"))
+    {
+        // TODO: Trigger post action if required from here.
+    }
+
     return vpdParser->parse();
 }
 


### PR DESCRIPTION
Processing of some FRUs needs some special handling which can be defined as actions. These actions needs to be taken at different stages of the flow.

The commit defines an utility method which checks if any particular action is required or not from a particular flow for any given FRU.

The caller needs to pass the action string needs to be checked and the flow for which it may be needed along with the parsed system config json and VPD file path.