### PR TITLE
Post action tag in JSON

### DIFF
--- a/configuration/ibm/50001001.json
+++ b/configuration/ibm/50001001.json
@@ -1696,6 +1696,14 @@
                         }
                     }
                 },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 4-0060 > /sys/bus/i2c/drivers/leds-pca955x/bind"
+                        }
+                    }
+                },
                 "PostFailAction": {
                     "collection": {
                         "setGpio": {
@@ -1770,6 +1778,14 @@
                         },
                         "systemCmd": {
                             "cmd": "echo 5-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 5-0060 > /sys/bus/i2c/drivers/leds-pca955x/bind"
                         }
                     }
                 },
@@ -1850,6 +1866,14 @@
                         }
                     }
                 },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 5-0061 > /sys/bus/i2c/drivers/leds-pca955x/bind"
+                        }
+                    }
+                },
                 "PostFailAction": {
                     "collection": {
                         "setGpio": {
@@ -1924,6 +1948,14 @@
                         },
                         "systemCmd": {
                             "cmd": "echo 11-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    }
+                },
+                "postAction": {
+                    "collection": {
+                        "ccin": ["2CE2", "58FF", "6B92", "6B99"],
+                        "systemCmd": {
+                            "cmd": "echo 11-0060 > /sys/bus/i2c/drivers/leds-pca955x/bind"
                         }
                     }
                 },


### PR DESCRIPTION
The commit introduces an action tag "postAction".

This can be used in case a set of job is required to be executed after the collection has been done.

Post action can also be tagged to be performed for some specifc FRUs. For this CCIN list can be added under it and based on that it will be executed.
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>