### PR TITLE
Replace cout with logger

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -123,8 +123,8 @@ void Manager::SetTimerToDetectSVPDOnDbus()
     // timer for 2 seconds
     auto asyncCancelled = timer.expires_after(std::chrono::seconds(2));
 
-    (asyncCancelled == 0) ? std::cout << "Timer started" << std::endl
-                          : std::cout << "Timer re-started" << std::endl;
+    (asyncCancelled == 0) ? logging::logMessage("Timer started")
+                          : logging::logMessage("Timer re-started");
 
     timer.async_wait([this](const boost::system::error_code& ec) {
         if (ec == boost::asio::error::operation_aborted)
@@ -162,8 +162,8 @@ void Manager::SetTimerToDetectVpdCollectionStatus()
     auto l_asyncCancelled = l_timer.expires_after(std::chrono::seconds(3));
 
     (l_asyncCancelled == 0)
-        ? std::cout << "Collection Timer started" << std::endl
-        : std::cout << "Collection Timer re-started" << std::endl;
+        ? logging::logMessage("Collection Timer started")
+        : logging::logMessage("Collection Timer re-started");
 
     l_timer.async_wait([this](const boost::system::error_code& ec) {
         if (ec == boost::asio::error::operation_aborted)

--- a/src/parser_factory.cpp
+++ b/src/parser_factory.cpp
@@ -110,16 +110,16 @@ std::shared_ptr<ParserInterface>
     {
         case vpdType::IPZ_VPD:
         {
-            std::cout << "IPZ parser selected for VPD file path "
-                      << i_vpdFilePath << std::endl;
+            logging::logMessage("IPZ parser selected for VPD file path " +
+                                i_vpdFilePath);
             return std::make_shared<IpzVpdParser>(i_vpdVector, i_vpdFilePath,
                                                   i_vpdStartOffset);
         }
 
         case vpdType::KEYWORD_VPD:
         {
-            std::cout << "KWD vpd parser selected for VPD file path "
-                      << i_vpdFilePath << std::endl;
+            logging::logMessage("KWD vpd parser selected for VPD file path " +
+                                i_vpdFilePath);
             return std::make_shared<KeywordVpdParser>(i_vpdVector);
         }
 


### PR DESCRIPTION
This commit adds changes to replace std::cout with logging API. Which adds the further information like function name, line number & file name to the log to debug the logs in case of error.