### PR TITLE
Process post action tag from config JSON

### DIFF
--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 
 #include <mutex>
+#include <optional>
 #include <tuple>
 
 namespace vpd
@@ -358,6 +359,44 @@ class Worker
      */
     bool processPreAction(const std::string& i_vpdFilePath,
                           const std::string& i_flagToProcess);
+
+    /**
+     * @brief API to process postAction(base_action) defined in config JSON.
+     *
+     * @note Sequence of tags under any given flag of postAction is EXTREMELY
+     * important to ensure proper processing. The API will process all the
+     * nested items under the base action sequentially. Also if any of the tag
+     * processing fails, the code will not process remaining tags under the
+     * flag.
+     * ******** sample format **************
+     * fru EEPROM path: {
+     *     base_action: {
+     *         flag1: {
+     *           tag1: {
+     *            },
+     *           tag2: {
+     *            }
+     *         }
+     *         flag2: {
+     *           tags: {
+     *            }
+     *         }
+     *     }
+     * }
+     * *************************************
+     * Also, if post action is required to be processed only for FRUs with
+     * certain CCIN then CCIN list can be provided under flag.
+     *
+     * @param[in] i_vpdFruPath - Path to the EEPROM file.
+     * @param[in] i_flagToProcess - To identify which flag(s) needs to be
+     * processed under postAction tag of config JSON.
+     * @param[in] i_parsedVpd - Optional Parsed VPD map. If CCIN match is
+     * required.
+     * @return Execution status.
+     */
+    bool processPostAction(
+        const std::string& i_vpdFruPath, const std::string& i_flagToProcess,
+        const std::optional<types::VPDMapVariant> i_parsedVpd = std::nullopt);
 
     /**
      * @brief Function to enable and bring MUX out of idle state.

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1029,8 +1029,8 @@ bool Worker::processPreAction(const std::string& i_vpdFilePath,
         return false;
     }
 
-    if ((!jsonUtility::executePreAction(m_parsedJson, i_vpdFilePath,
-                                        i_flagToProcess)) &&
+    if ((!jsonUtility::executeBaseAction(m_parsedJson, "preAction",
+                                         i_vpdFilePath, i_flagToProcess)) &&
         (i_flagToProcess.compare("collection") == constants::STR_CMP_SUCCESS))
     {
         // TODO: Need a way to delete inventory object from Dbus and persisted
@@ -1071,6 +1071,56 @@ bool Worker::processPreAction(const std::string& i_vpdFilePath,
 
         return false;
     }
+    return true;
+}
+
+bool Worker::processPostAction(
+    const std::string& i_vpdFruPath, const std::string& i_flagToProcess,
+    const std::optional<types::VPDMapVariant> i_parsedVpd)
+{
+    if (i_vpdFruPath.empty() || i_flagToProcess.empty())
+    {
+        logging::logMessage(
+            "Invalid input parameter. Abort processing post action");
+        return false;
+    }
+
+    // Check if post action tag is to be triggered in the flow of collection
+    // based on some CCIN value?
+    if (m_parsedJson["frus"][i_vpdFruPath]
+            .at(0)["postAction"]["collection"]
+            .contains("ccin"))
+    {
+        if (!i_parsedVpd.has_value())
+        {
+            throw std::runtime_error(
+                "Parsed VPD map parameter is mandatory for CCIN match");
+        }
+
+        // CCIN match is required to process post action for this FRU as it
+        // contains the flag.
+        if (!vpdSpecificUtility::findCcinInVpd(
+                m_parsedJson["frus"][i_vpdFruPath].at(
+                    0)["postAction"]["collection"],
+                i_parsedVpd.value()))
+        {
+            // If CCIN is not found, implies post action processing is not
+            // required for this FRU. Let the flow continue.
+            return true;
+        }
+    }
+
+    if (!jsonUtility::executeBaseAction(m_parsedJson, "postAction",
+                                        i_vpdFruPath, i_flagToProcess))
+    {
+        logging::logMessage("Execution of post action failed for path: " +
+                            i_vpdFruPath);
+
+        // If post action was required and failed only in that case return
+        // false. In all other case post action is considered passed.
+        return false;
+    }
+
     return true;
 }
 
@@ -1119,6 +1169,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
 
     std::shared_ptr<Parser> vpdParser = std::make_shared<Parser>(i_vpdFilePath,
                                                                  m_parsedJson);
+    types::VPDMapVariant l_parsedVpd = vpdParser->parse();
 
     // Before returning, as collection is over, check if FRU qualifies for
     // any post action in the flow of collection.
@@ -1127,10 +1178,15 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
     if (jsonUtility::isActionRequired(m_parsedJson, i_vpdFilePath, "postAction",
                                       "collection"))
     {
-        // TODO: Trigger post action if required from here.
+        if (!processPostAction(i_vpdFilePath, "collection", l_parsedVpd))
+        {
+            throw std::runtime_error("Required post action failed for path " +
+                                     i_vpdFilePath +
+                                     " Aborting collection for this FRU");
+        }
     }
 
-    return vpdParser->parse();
+    return l_parsedVpd;
 }
 
 std::tuple<bool, std::string>


### PR DESCRIPTION
The commit defines API to process post action in case required for any FRU and defined in config JSON.

The post action can be triggered based on CCIN, hence an utility API to find CCIN in a given parsed VPD map has also been added to the code base.

Taking into consideration that multiple actions can be defined for a given FRU, API has been modified to be generic and process actions defined for the FRU.