### PR TITLE
Handle empty vector in ddimm

### DIFF
--- a/include/ddimm_parser.hpp
+++ b/include/ddimm_parser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "constants.hpp"
+#include "exceptions.hpp"
 #include "logger.hpp"
 #include "parser_interface.hpp"
 #include "types.hpp"
@@ -34,7 +36,13 @@ class DdimmVpdParser : public ParserInterface
      */
     DdimmVpdParser(const types::BinaryVector& i_vpdVector) :
         m_vpdVector(i_vpdVector)
-    {}
+    {
+        if ((constants::DDIMM_11S_BARCODE_START +
+             constants::DDIMM_11S_BARCODE_LEN) > m_vpdVector.size())
+        {
+            throw(DataException("Malformed DDIMM VPD"));
+        }
+    }
 
     /**
      * @brief API to parse DDIMM VPD file.

--- a/test/utest_ddimm_parser.cpp
+++ b/test/utest_ddimm_parser.cpp
@@ -78,6 +78,14 @@ TEST(DdimmVpdParserTest, InvalidVpdType)
     EXPECT_THROW(l_vpdParser.parse(), std::exception);
 }
 
+TEST(DdimmVpdParserTest, EmptyInputVector)
+{
+    // Blank VPD
+    types::BinaryVector emptyVector{};
+
+    EXPECT_THROW(DdimmVpdParser(std::move(emptyVector)), DataException);
+}
+
 int main(int i_argc, char** io_argv)
 {
     ::testing::InitGoogleTest(&i_argc, io_argv);


### PR DESCRIPTION
If the DdimmVpdParser object is created with empty vector and called
its parse API, application will crash as there is no check on the
input vpd vector size.

This commit adds changes to handle empty vector and vpd vector
having invalid size passed to DdimmVpdParser.

Signed-off-by: Anupama B R <anupama.b.r1@ibm.com>