### PR TITLE
Save AMM to VPD

### DIFF
--- a/include/bios_handler.hpp
+++ b/include/bios_handler.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "manager.hpp"
 #include "types.hpp"
 
 #include <sdbusplus/asio/connection.hpp>
@@ -45,6 +46,16 @@ class BiosHandlerInterface
 class IbmBiosHandler : public BiosHandlerInterface
 {
   public:
+    /**
+     * @brief Construct a new IBM BIOS Handler object
+     *
+     * This constructor constructs a new IBM BIOS Handler object
+     * @param[in] i_manager - Manager object.
+     */
+    explicit IbmBiosHandler(const std::shared_ptr<Manager>& i_manager) :
+        m_manager(i_manager)
+    {}
+
     /**
      * @brief API to back up or restore BIOS attributes.
      *
@@ -185,6 +196,9 @@ class IbmBiosHandler : public BiosHandlerInterface
      * @param[in] i_KeepAndClearVal - Value to be saved.
      */
     void saveKeepAndClearToVpd(const std::string& i_KeepAndClearVal);
+
+    // const reference to shared pointer to Manager object.
+    const std::shared_ptr<Manager>& m_manager;
 };
 
 /**
@@ -219,13 +233,14 @@ class BiosHandler
     /**
      * @brief Constructor.
      *
-     * @param[in] connection - Asio connection object.
+     * @param[in] i_connection - Asio connection object.
+     * @param[in] i_manager - Manager object.
      */
     BiosHandler(
-        const std::shared_ptr<sdbusplus::asio::connection>& i_connection) :
-        m_asioConn(i_connection)
+        const std::shared_ptr<sdbusplus::asio::connection>& i_connection,
+        const std::shared_ptr<Manager>& i_manager) : m_asioConn(i_connection)
     {
-        m_specificBiosHandler = std::make_shared<T>();
+        m_specificBiosHandler = std::make_shared<T>(i_manager);
         checkAndListenPldmService();
     }
 

--- a/meson.build
+++ b/meson.build
@@ -77,11 +77,11 @@ common_SOURCES = ['src/logger.cpp',
                   'src/worker.cpp',
                   'src/backup_restore.cpp',
                   'src/gpio_monitor.cpp',
-                  'src/bios_handler.cpp',
                   'src/event_logger.cpp']
 
 vpd_manager_SOURCES = ['src/manager_main.cpp',
                     'src/manager.cpp',
+                    'src/bios_handler.cpp',
                     ] + common_SOURCES
 
 parser_dependencies = [sdbusplus, libgpiodcxx, phosphor_logging, phosphor_dbus_interfaces]

--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include "bios_handler.hpp"
 
 #include "constants.hpp"
@@ -283,7 +285,13 @@ void IbmBiosHandler::saveAmmToVpd(const std::string& i_memoryMirrorMode)
         (i_memoryMirrorMode == "Enabled" ? constants::AMM_ENABLED_IN_VPD
                                          : constants::AMM_DISABLED_IN_VPD)};
 
-    // TODO: Call write keyword API to update the value in VPD.
+    if (-1 == m_manager->updateKeyword(SYSTEM_VPD_FILE_PATH,
+                                       types::IpzData("UTIL", constants::kwdAMM,
+                                                      l_valToUpdateInVpd)))
+    {
+        logging::logMessage("Failed to update " +
+                            std::string(constants::kwdAMM) + " keyword to VPD");
+    }
 }
 
 void IbmBiosHandler::saveAmmToBios(const std::string& i_ammVal)

--- a/src/ipz_parser.cpp
+++ b/src/ipz_parser.cpp
@@ -829,7 +829,7 @@ int IpzVpdParser::writeKeywordOnHardware(
                         std::get<2>(l_inputRecordDetails),
                         std::get<3>(l_inputRecordDetails), l_vpdVector);
 
-        logging::logMessage(l_sizeWritten +
+        logging::logMessage(std::to_string(l_sizeWritten) +
                             " bytes updated successfully on hardware for " +
                             l_recordName + ":" + l_keywordName);
     }

--- a/src/manager_main.cpp
+++ b/src/manager_main.cpp
@@ -29,8 +29,10 @@ int main(int, char**)
         auto vpdManager = std::make_shared<vpd::Manager>(io_con, interface,
                                                          connection);
 
+        // TODO: Take this under conditional compilation for IBM
         auto biosHandler =
-            std::make_shared<vpd::BiosHandler<vpd::IbmBiosHandler>>(connection);
+            std::make_shared<vpd::BiosHandler<vpd::IbmBiosHandler>>(connection,
+                                                                    vpdManager);
 
         interface->initialize();
 


### PR DESCRIPTION
This commit implements API to save received BIOS Attribute AMM(hb_memory_mirror_mode) to VPD.
This implementation uses Manager updateKeyword API to do the above.

This API will be required to save BIOS Attribute AMM received from BIOS Config Manager to VPD.

Test:
Tested the below on a rainier 2S2U system.
1. Once BMC is in Ready State, ran vpd-manager executable
2. Used pldmtool to get current value of "hb_memory_mirror_mode" in BIOSConfig. pldmtool bios GetBIOSAttributeCurrentValueByHandle -a \ hb_memory_mirror_mode { "CurrentValue": "Disabled" }
3. Used pldmtool to set current value of "hb_memory_mirror_mode" to "Enabled". pldmtool bios SetBIOSAttributeCurrentValue -a \ hb_memory_mirror_mode -d Enabled { "Response": "SUCCESS" }
4. Checked vpd-manager log to see biosAttributesCallback is triggered and saveAmmToVpd() is called.
5. Checked the value of "UTIL" record "D0" keyword is updated on hardware. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager \ com.ibm.VPD.Manager ReadKeyword sv \ "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ss\) "UTIL" "D0" v ay 1 2 "Disabled" = 1 "Enabled"  = 2
6. Checked the value of "UTIL" record "D0" keyword is updated in PIM. busctl get-property xyz.openbmc_project.Inventory.Manager \ /xyz/openbmc_project/inventory/xyz/openbmc_project/inventory/system/chassis/motherboard \ com.ibm.ipzvpd.UTIL D0 ay 1 2
7. Repeated above steps with "hb_memory_mirror_mode" as "Disabled"