### PR TITLE
Update object path before publishing to PIM

### DIFF
--- a/include/utility/dbus_utility.hpp
+++ b/include/utility/dbus_utility.hpp
@@ -172,6 +172,19 @@ inline bool callPIM(types::ObjectMap&& objectMap)
 {
     try
     {
+        for (const auto& l_objectKeyValue : objectMap)
+        {
+            auto l_nodeHandle = objectMap.extract(l_objectKeyValue.first);
+
+            if (l_nodeHandle.key().str.find(constants::pimPath, 0) !=
+                std::string::npos)
+            {
+                l_nodeHandle.key() = l_nodeHandle.key().str.replace(
+                    0, std::strlen(constants::pimPath), "");
+                objectMap.insert(std::move(l_nodeHandle));
+            }
+        }
+
         std::array<const char*, 1> pimInterface = {constants::pimIntf};
 
         auto mapperObjectMap = getObjectMap(constants::pimPath, pimInterface);

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -194,8 +194,8 @@ bool Worker::isSystemVPDOnDBus() const
     std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Board.Motherboard"};
 
-    types::MapperGetObject objectMap =
-        dbusUtility::getObjectMap(PIM_PATH_PREFIX + mboardPath, interfaces);
+    const types::MapperGetObject& objectMap =
+        dbusUtility::getObjectMap(mboardPath, interfaces);
 
     if (objectMap.empty())
     {


### PR DESCRIPTION
“Phosphor Inventory Manager” service is publishing object paths with duplicate prefix of /xyz/openbmc_project/inventory in the object path. Instead of just single /xyz/openbmc_project/inventory prefix in the object path.

This issue is happening because “Vpd Manager” service passing whole object path to PIM service “notify” interface method instead passing the object path without /xyz/openbmc_project/inventory prefix. And again, PIM was adding /xyz/openbmc_project/inventory prefix to passed object path.

This commit adds the changes to remove /xyz/openbmc_project/inventory path prefix if present in the object path before constructing ObjectMap data which is passed to PIM service “notify’”interface method.

This commit also removes the above duplicate prefix path to get the system VPD information using DBus query.