### PR TITLE
Fix JSON validation check in isActionRequired API

### DIFF
--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -896,7 +896,7 @@ inline bool isActionRequired(const nlohmann::json& i_sysCfgJsonObj,
         return false;
     }
 
-    if (i_sysCfgJsonObj.empty() || i_sysCfgJsonObj.contains("frus"))
+    if (i_sysCfgJsonObj.empty() || !(i_sysCfgJsonObj.contains("frus")))
     {
         logging::logMessage("Invalid JSON object recieved.");
         return false;


### PR DESCRIPTION
isActionRequired API is returning false even though "frus" tag is present in the system config JSON.

This commit updates the above check to return false if "frus" tag is missing in the system config JSON.