### PR TITLE
Save BIOS attributes to VPD

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -238,7 +238,13 @@ void IbmBiosHandler::saveFcoToVpd(int64_t i_fcoInBios)
     types::BinaryVector l_biosValInVpdFormat = {
         0, 0, 0, static_cast<uint8_t>(i_fcoInBios)};
 
-    // TODO:  Call Manager API to write keyword data using inventory path.
+    if (-1 == m_manager->updateKeyword(SYSTEM_VPD_FILE_PATH,
+                                       types::IpzData("VSYS", constants::kwdRG,
+                                                      l_biosValInVpdFormat)))
+    {
+        logging::logMessage("Failed to update " +
+                            std::string(constants::kwdRG) + " keyword to VPD.");
+    }
 }
 
 void IbmBiosHandler::saveFcoToBios(const types::BinaryVector& i_fcoVal)
@@ -334,6 +340,8 @@ void IbmBiosHandler::processActiveMemoryMirror()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdAMM);
 
+    // TODO: l_kwdValueVariant should be checked for binary vector rather than a
+    // string
     if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
     {
         auto l_ammValInVpd = *pVal;
@@ -445,6 +453,8 @@ void IbmBiosHandler::processCreateDefaultLpar()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdClearNVRAM_CreateLPAR);
 
+    // TODO: l_kwdValueVariant should be checked for binary vector rather than
+    // string
     if (auto l_pVal = std::get_if<std::string>(&l_kwdValueVariant))
     {
         saveCreateDefaultLparToBios(*l_pVal);
@@ -535,6 +545,8 @@ void IbmBiosHandler::processClearNvram()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdClearNVRAM_CreateLPAR);
 
+    // TODO: l_kwdValueVariant should be checked for binary vector rather than
+    // string
     if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
     {
         saveClearNvramToBios(*pVal);
@@ -624,6 +636,8 @@ void IbmBiosHandler::processKeepAndClear()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdKeepAndClear);
 
+    // TODO: l_kwdValueVariant should be checked for binary vector rather than
+    // string
     if (auto l_pVal = std::get_if<std::string>(&l_kwdValueVariant))
     {
         saveKeepAndClearToBios(*l_pVal);


### PR DESCRIPTION
This commit implements the private API to save BIOS
attribute hb_field_core_override to VPD.

This API will be required to save the above BIOS attributes received
from BIOS Config Manager to VPD.

Test:
Tested on rainier_2s2u system.
1. Once BMC is in Ready state, run vpd-manager executable.
2. Check the BIOS attribute value on BIOS Config Manager using pldmtool pldmtool bios GetBIOSAttributeCurrentValueByHandle -a \ hb_field_core_override { "CurrentValue": 0 }
3. Update the value on BIOS Config Maanger: pldmtool bios SetBIOSAttributeCurrentValue -a \ hb_field_core_override -d Enabled
4. Check vpd-manager logs to see bios attribute callback is triggered.
5. Check BIOS attribute on hardware: busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager \ com.ibm.VPD.Manager ReadKeyword sv \ "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ss\) "VSYS" "RG" ay 4 0 0 0 1
6. Check BIOS attribute on PIM: busctl get-property xyz.openbmc_project.Inventory.Manager \ /xyz/openbmc_project/inventory/xyz/openbmc_project /inventory/system/chassis/motherboard \ com.ibm.ipzvpd.VSYS RG ay 4 0 0 0 1