### PR TITLE
Save pvm_clear_nvram to VPD

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -478,7 +478,7 @@ void IbmBiosHandler::saveClearNvramToVpd(const std::string& i_clearNvramVal)
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdClearNVRAM_CreateLPAR);
 
-    if (auto l_pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    if (auto l_pVal = std::get_if<types::BinaryVector>(&l_kwdValueVariant))
     {
         commonUtility::toLower(const_cast<std::string&>(i_clearNvramVal));
 
@@ -495,7 +495,19 @@ void IbmBiosHandler::saveClearNvramToVpd(const std::string& i_clearNvramVal)
             l_valToUpdateInVpd.emplace_back((*l_pVal).at(0) &
                                             ~(constants::VALUE_4));
         }
-        // TODO: Write API to be called to update in VPD.
+
+        if (-1 ==
+            m_manager->updateKeyword(
+                SYSTEM_VPD_FILE_PATH,
+                types::IpzData("UTIL", constants::kwdClearNVRAM_CreateLPAR,
+                               l_valToUpdateInVpd)))
+        {
+            logging::logMessage(
+                "Failed to update " +
+                std::string(constants::kwdClearNVRAM_CreateLPAR) +
+                " keyword to VPD");
+        }
+
         return;
     }
     logging::logMessage("Invalid type recieved for clear NVRAM from VPD.");


### PR DESCRIPTION
This commit implements the private API to save pvm_clear_nvram BIOS attribute to VPD.

This API will be required to save BIOS Attribute pvm_clear_nvram received from BIOS Config Manager to VPD.

Test:
Tested the below on a rainier 2S2U system.
1. Once BMC is in Ready State, ran vpd-manager executable
2. Used pldmtool to get current value of "pvm_clear_nvram" in BIOSConfig Manager. pldmtool bios GetBIOSAttributeCurrentValueByHandle -a \ pvm_clear_nvram { "CurrentValue": "Disabled" }
3. Used pldmtool to set current value of "pvm_clear_nvram" to "Enabled". pldmtool bios SetBIOSAttributeCurrentValue -a \ pvm_clear_nvram -d Enabled { "Response": "SUCCESS" }
4. Checked vpd-manager log to see biosAttributesCallback is triggered
5. Checked the value of "UTIL" record "D1" keyword is updated on hardware. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager \ com.ibm.VPD.Manager ReadKeyword sv \ "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ss\) "UTIL" "D1" v ay 1 5 "Disabled" = Bit 4 is 0. "Enabled"  = Bit 4 is 1.
6. Checked the value of "UTIL" record "D1" keyword is updated in PIM. busctl get-property xyz.openbmc_project.Inventory.Manager \ /xyz/openbmc_project/inventory/system/chassis/motherboard \ com.ibm.ipzvpd.UTIL D1 ay 1 5
7. Repeated above steps to Disable pvm_clear_nvram and observed UTIL:D1 Bit 4 is cleared on Hardware and PIM.