### PR TITLE
Save pvm_keep_and_clear to VPD

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -569,7 +569,7 @@ void IbmBiosHandler::saveKeepAndClearToVpd(const std::string& i_KeepAndClearVal)
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdKeepAndClear);
 
-    if (auto l_pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    if (auto l_pVal = std::get_if<types::BinaryVector>(&l_kwdValueVariant))
     {
         commonUtility::toLower(const_cast<std::string&>(i_KeepAndClearVal));
 
@@ -586,7 +586,17 @@ void IbmBiosHandler::saveKeepAndClearToVpd(const std::string& i_KeepAndClearVal)
             l_valToUpdateInVpd.emplace_back((*l_pVal).at(0) &
                                             ~(constants::VALUE_1));
         }
-        // TODO: Write API to be called to update in VPD.
+
+        if (-1 == m_manager->updateKeyword(
+                      SYSTEM_VPD_FILE_PATH,
+                      types::IpzData("UTIL", constants::kwdKeepAndClear,
+                                     l_valToUpdateInVpd)))
+        {
+            logging::logMessage("Failed to update " +
+                                std::string(constants::kwdKeepAndClear) +
+                                " keyword to VPD");
+        }
+
         return;
     }
     logging::logMessage("Invalid type recieved for keep and clear from VPD.");


### PR DESCRIPTION
This commit implements the private API to save pvm_keep_and_clear BIOS attribute to VPD.

This API will be required to save BIOS Attribute pvm_keep_and_clear received from BIOS Config Manager to VPD.

Test:
Tested the below on a rainier 2S2U system.
1. Once BMC is in Ready State, ran vpd-manager executable
2. Used pldmtool to get current value of "pvm_keep_and_clear" in BIOSConfig Manager. pldmtool bios GetBIOSAttributeCurrentValueByHandle -a \ pvm_keep_and_clear { "CurrentValue": "Disabled" }
3. Used pldmtool to set current value of "pvm_keep_and_clear" to "Enabled". pldmtool bios SetBIOSAttributeCurrentValue -a \ pvm_keep_and_clear -d Enabled { "Response": "SUCCESS" }
4. Checked vpd-manager log to see biosAttributesCallback is triggered
5. Checked the value of "UTIL" record "D1" keyword is updated on hardware. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager \ com.ibm.VPD.Manager ReadKeyword sv \ "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ss\) "UTIL" "D1" v ay 1 3 "Disabled" = Bit 1 is 0. "Enabled"  = Bit 1 is 1.
6. Checked the value of "UTIL" record "D1" keyword is updated in PIM. busctl get-property xyz.openbmc_project.Inventory.Manager \ /xyz/openbmc_project/inventory/system/chassis/motherboard \ com.ibm.ipzvpd.UTIL D1 ay 1 3
7. Repeated above steps to Disable pvm_keep_and_clear and observed UTIL:D1 1st bit is cleared on Hardware and PIM.