### PR TITLE
Fix Process Keep and Clear BIOS attribute

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -669,11 +669,9 @@ void IbmBiosHandler::processKeepAndClear()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdKeepAndClear);
 
-    // TODO: l_kwdValueVariant should be checked for binary vector rather than
-    // string
-    if (auto l_pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    if (auto l_pVal = std::get_if<types::BinaryVector>(&l_kwdValueVariant))
     {
-        saveKeepAndClearToBios(*l_pVal);
+        saveKeepAndClearToBios(std::to_string(l_pVal->at(0)));
         return;
     }
     logging::logMessage("Invalid type recieved for keep and clear from VPD.");


### PR DESCRIPTION
This commit fixes an issue in private API to process pvm_keep_and_clear BIOS attribute. The variant read from D-Bus was being checked for string instead of a binary vector.

Test:
1. Check value of BIOS attribute in PIM: busctl get-property  xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.UTIL D1 ay 1 0

2. Check BIOS attribute in BIOS Config Manager using pldmtool: pldmtool bios  GetBIOSAttributeCurrentValueByHandle -a pvm_keep_and_clear { "CurrentValue": "Disabled" }

3. Use writeKeyword API to change BIOS attribute in PIM: busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ssay\) "UTIL" "D1" 1 1

4. Restart vpd-manager app
5. After vpd-manager restart, check attribute value on BIOS Config Manager using pldmtool

4. pldmtool bios GetBIOSAttributeCurrentValueByHandle -a pvm_keep_and_clear { "CurrentValue": "Enabled" }