### PR TITLE
Fix process pvm_clear_nvram BIOS attribute.

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -568,11 +568,9 @@ void IbmBiosHandler::processClearNvram()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdClearNVRAM_CreateLPAR);
 
-    // TODO: l_kwdValueVariant should be checked for binary vector rather than
-    // string
-    if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    if (auto l_pVal = std::get_if<types::BinaryVector>(&l_kwdValueVariant))
     {
-        saveClearNvramToBios(*pVal);
+        saveClearNvramToBios(std::to_string(l_pVal->at(0)));
         return;
     }
     logging::logMessage("Invalid type recieved for clear NVRAM from VPD.");


### PR DESCRIPTION
This commit fixes an issue in private API to process pvm_clear_nvram BIOS attribute. The variant read from D-Bus was being checked for string instead of a binary vector.

Test:
1. Check value of BIOS attribute in PIM: busctl get-property  xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.UTIL D1 ay 1 0

2. Check BIOS attribute in BIOS Config Manager using pldmtool: pldmtool bios  GetBIOSAttributeCurrentValueByHandle -a pvm_clear_nvram { "CurrentValue": "Disabled" }

3. Use writeKeyword API to change BIOS attribute in PIM: Bit 4 of D1 is used to store clear NVRAM value. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ssay\) "UTIL" "D1" 1 4

4. Restart vpd-manager app
5. After vpd-manager restart, check attribute value on BIOS Config Manager using pldmtool

6. pldmtool bios GetBIOSAttributeCurrentValueByHandle -a pvm_clear_nvram { "CurrentValue": "Enabled" }
7. Repeat above steps to set pvm_clear_nvram from "Enabled" to "Disabled".