### PR TITLE
Fix process AMM BIOS attribute

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -340,9 +340,7 @@ void IbmBiosHandler::processActiveMemoryMirror()
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::utilInf, constants::kwdAMM);
 
-    // TODO: l_kwdValueVariant should be checked for binary vector rather than a
-    // string
-    if (auto pVal = std::get_if<std::string>(&l_kwdValueVariant))
+    if (auto pVal = std::get_if<types::BinaryVector>(&l_kwdValueVariant))
     {
         auto l_ammValInVpd = *pVal;
 
@@ -363,7 +361,7 @@ void IbmBiosHandler::processActiveMemoryMirror()
         }
         else
         {
-            saveAmmToBios(l_ammValInVpd);
+            saveAmmToBios(std::to_string(l_ammValInVpd.at(0)));
         }
         return;
     }


### PR DESCRIPTION
This commit fixes an issue in private API to process hb_memory_mirror_mode BIOS attribute. The variant read from D-Bus was being checked for string instead of a binary vector.

Test:
1. Check value of BIOS attribute in PIM: busctl get-property  xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.UTIL D0 ay 1 1

2. Check BIOS attribute in BIOS Config Manager using pldmtool: pldmtool bios  GetBIOSAttributeCurrentValueByHandle -a hb_memory_mirror_mode { "CurrentValue": "Disabled" }

3. Use writeKeyword API to change BIOS attribute in PIM: UTIL:D0 is used to store AMM in PIM. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ssay\) "UTIL" "D0" 1 2

4. Restart vpd-manager app
5. After vpd-manager restart, check attribute value on BIOS Config Manager using pldmtool

6. pldmtool bios GetBIOSAttributeCurrentValueByHandle -a hb_memory_mirror_mode { "CurrentValue": "Enabled" }
7. Repeat above steps to set hb_memory_mirror_mode from "Enabled" to "Disabled".
8. Use writeKeyword API to change BIOS attribute in PIM to default value is 0. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ssay\) "UTIL" "D0" 1 0
9. Restart vpd-manager app
10. After vpd-manager restart, attribute value is copied from BIOS Config Manager to VPD(PIM and hardware).
11. Check value on PIM: busctl get-property  xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.UTIL D0 ay 1 2