### PR TITLE
Fix save FCO to BIOS.

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -260,7 +260,7 @@ void IbmBiosHandler::saveFcoToBios(const types::BinaryVector& i_fcoVal)
         "hb_field_core_override",
         std::make_tuple(
             "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Integer",
-            std::to_string(i_fcoVal.at(constants::VALUE_3)))));
+            i_fcoVal.at(constants::VALUE_3))));
 
     try
     {


### PR DESCRIPTION
This commit fixes D-bus call failure in private API to save FCO BIOS attribute to BIOS Config Manager. D-Bus call to set the attribute in PendingAttributes table was failing with error "invalid argument".

Test:
Tested on a rainier 2S2U system with Host in Off state and BMC in Ready state.

1. Check value of FCO on PIM: busctl get-property xyz.openbmc_project.Inventory.Manager xyz/openbmc_project/inventory/system/chassis/motherboard com.ibm.ipzvpd.VSYS RG ay 4 0 0 0 0 Byte 3 stores FCO value.
2. Check value of FCO on BIOS Config Manager: pldmtool bios  GetBIOSAttributeCurrentValueByHandle -a hb_field_core_override { "CurrentValue": 0 }
3. Use VPD Manager Write Keyword API to update FCO value on PIM: busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword sv "/sys/bus/i2c/drivers/at24/8-0050/eeprom" "VSYS" "RG" 4 0 0 0 1
4. Restart vpd-manager application.
5. After vpd-manager app restart, check value of FCO on BIOS Config Manager using pldmtool: pldmtool bios  GetBIOSAttributeCurrentValueByHandle -a hb_field_core_override { "CurrentValue": 1 }
6. Also observe following journal log: BIOS attribute 'hb_field_core_override' updated to value '1' by BMC 'true'