### PR TITLE
Everest:Missing EXP_PRSNT GPIO pin for PCIe cards

### DIFF
--- a/config/ibm/50003000.json
+++ b/config/ibm/50003000.json
@@ -2540,6 +2540,11 @@
                 "concurrentlyMaintainable": true,
                 "devAddress": "16-0052",
                 "pcaChipAddress": "16-0062",
+                "presence": {
+                    "pin": "expander-cable-card1",
+                    "value": 0,
+                    "gpioI2CAddress": "4-0065"
+                },
                 "preAction": {
                     "pin": "presence-cable-card1",
                     "value": 1,
@@ -2606,6 +2611,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card2",
+                    "value": 0,
+                    "gpioI2CAddress": "4-0065"
+                },
                 "preAction": {
                     "pin": "presence-cable-card2",
                     "value": 1,
@@ -2674,6 +2684,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card3",
+                    "value": 0,
+                    "gpioI2CAddress": "4-0065"
+                },
                 "preAction": {
                     "pin": "presence-cable-card3",
                     "value": 1,
@@ -2742,6 +2757,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card4",
+                    "value": 0,
+                    "gpioI2CAddress": "4-0065"
+                },
                 "preAction": {
                     "pin": "presence-cable-card4",
                     "value": 1,
@@ -2810,6 +2830,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card5",
+                    "value": 0,
+                    "gpioI2CAddress": "4-0065"
+                },
                 "preAction": {
                     "pin": "presence-cable-card5",
                     "value": 1,
@@ -2878,6 +2903,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card6",
+                    "value": 0,
+                    "gpioI2CAddress": "5-0066"
+                },
                 "preAction": {
                     "pin": "presence-cable-card6",
                     "value": 1,
@@ -2915,6 +2945,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card7",
+                    "value": 0,
+                    "gpioI2CAddress": "5-0066"
+                },
                 "preAction": {
                     "pin": "presence-cable-card7",
                     "value": 1,
@@ -2983,6 +3018,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card8",
+                    "value": 0,
+                    "gpioI2CAddress": "5-0066"
+                },
                 "preAction": {
                     "pin": "presence-cable-card8",
                     "value": 1,
@@ -3051,6 +3091,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card9",
+                    "value": 0,
+                    "gpioI2CAddress": "5-0066"
+                },
                 "preAction": {
                     "pin": "presence-cable-card9",
                     "value": 1,
@@ -3088,6 +3133,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card10",
+                    "value": 0,
+                    "gpioI2CAddress": "5-0066"
+                },
                 "preAction": {
                     "pin": "presence-cable-card10",
                     "value": 1,
@@ -3156,6 +3206,11 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
+                "presence": {
+                    "pin": "expander-cable-card11",
+                    "value": 0,
+                    "gpioI2CAddress": "5-0066"
+                },
                 "preAction": {
                     "pin": "presence-cable-card11",
                     "value": 1,


### PR DESCRIPTION
In everest VPD JSON, "presence" section with expander presence gpio pin information is missing for PCIe cards. Due to which during FRU VPD collection, I2C line for PCIe card VPD is enabled without checking if IBM specific PCIe card is actually present on the system.

This check is required for PCIe cards because the PCIe slot accepts both IBM specific cards and any industry standard cards. So during VPD collection before enabling the I2C line of PCIe card VPD, it's recommended to check if IBM standard PCIe card is present on IBM system.

Test:
busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager CollectFRUVPD o "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2"

Oct 16 13:10:40 ever6bmc vpd-manager[1929]: Manager called to collect vpd for fru: /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2
Oct 16 13:10:40 ever6bmc vpd-manager[1929]: Setting GPIO: presence-cable-card2 to 1
Oct 16 13:10:40 ever6bmc vpd-manager[1929]: Executing driver binding for chip address - 17-0060
Oct 16 13:10:40 ever6bmc kernel: at24 17-0050: 8192 byte 24c64 EEPROM, writable, 1 bytes/write
Oct 16 13:10:40 ever6bmc kernel: leds-pca955x 17-0060: leds-pca955x: Using pca9551 8-bit LED driver at slave address 0x60
Oct 16 13:10:40 ever6bmc kernel: leds-pca955x 17-0060: gpios 1040...1047
Oct 16 13:10:40 ever6bmc systemd[1]: Started IPZ format VPD Parser service for FRU sys/devices/platform/ahb/ahb:apb/ahb:apb:bus@1e78a000/1e78a280.i2c-bus/i2c-4/i2c-17/17-0050/17-005060.
Oct 16 13:10:40 ever6bmc systemd[1]: Started Phosphor sysfs LED controller.
Oct 16 13:10:40 ever6bmc systemd[1]: Started Phosphor sysfs LED controller.
Oct 16 13:10:41 ever6bmc systemd[1]: ibm-vpd-parser@sys-devices-platform-ahb-ahb:apb-ahb:apb:bus\x401e78a000-1e78a280.i2c\x2dbus-i2c\x2d4-i2c\x2d17-17\x2d0050-17\x2d005060.service: Deactivated successfully.
