### PR TITLE
Fix vpd-parser crash when VPD path not there in JSON

### DIFF
--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -711,9 +711,16 @@ inline bool isActionRequired(const nlohmann::json& i_sysCfgJsonObj,
         return false;
     }
 
-    if (i_sysCfgJsonObj.empty() || !(i_sysCfgJsonObj.contains("frus")))
+    if (!i_sysCfgJsonObj.contains("frus"))
     {
         logging::logMessage("Invalid JSON object recieved.");
+        return false;
+    }
+
+    if (!i_sysCfgJsonObj["frus"].contains(i_vpdFruPath))
+    {
+        logging::logMessage("JSON object does not contain EEPROM path " +
+                            i_vpdFruPath);
         return false;
     }
 


### PR DESCRIPTION
This commit fixes vpd-parser app crash if the VPD file path specified is not there in the JSON file specified. Github issue #424. assert(x) inside nlohmann::json library fails if we try to use [] operator without checking if the json object contains that key. There is no exception thrown and process catches SIGABRT.

Fix:

Add contains() check to check if VPD file path is present in specified json before trying to access it with [].

Test:

1. Good case: Ensure a FRU VPD path is there in a JSON. Run vpd-parser -f <full FRU VPD file path> -c <json> Observe vpd-parser runs as expected and executes preAction, colection, etc if specified for the FRU.
2. Bad case: Ensure VPD path is not there in a JSON. Run vpd-parser -f <full VPD file path> -c <json> Observe vpd-parser logs error "Invalid JSON object received" and exits gracefully.