### PR TITLE
Handle collection of FRUs when chassis is on

### DIFF
--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -903,5 +903,44 @@ inline std::string getServiceName(const nlohmann::json& i_sysCfgJsonObj,
     }
     return std::string{};
 }
+
+/**
+ * @brief An API to check if a FRU is tagged as "powerOffOnly"
+ *
+ * Given the system config JSON and VPD FRU path, this API checks if the FRU
+ * VPD can be collected at Chassis Power Off state only.
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
+ * @param[in] i_vpdFruPath - EEPROM path.
+ * @return - True if FRU VPD can be collected at Chassis Power Off state only.
+ *           False otherwise
+ */
+inline bool isFruPowerOffOnly(const nlohmann::json& i_sysCfgJsonObj,
+                              const std::string& i_vpdFruPath)
+{
+    if (i_vpdFruPath.empty())
+    {
+        logging::logMessage("FRU path is empty.");
+        return false;
+    }
+
+    if (!i_sysCfgJsonObj.contains("frus"))
+    {
+        logging::logMessage("Missing frus tag in system config JSON.");
+        return false;
+    }
+
+    if (!i_sysCfgJsonObj["frus"].contains(i_vpdFruPath))
+    {
+        logging::logMessage("JSON object does not contain EEPROM path \'" +
+                            i_vpdFruPath + "\'");
+        return false;
+    }
+
+    return ((i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0))
+                .contains("powerOffOnly") &&
+            (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0)["powerOffOnly"]));
+}
+
 } // namespace jsonUtility
 } // namespace vpd

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1242,7 +1242,12 @@ void Worker::collectFrusFromJson()
         const std::string& vpdFilePath = itemFRUS.key();
 
         // skip processing of system VPD again as it has been already collected.
-        if (vpdFilePath == SYSTEM_VPD_FILE_PATH)
+        // Also, if chassis is powered on, skip collecting FRUs which are
+        // powerOffOnly.
+        // TODO: Need to revisit for P-Future to reduce code update time.
+        if (vpdFilePath == SYSTEM_VPD_FILE_PATH ||
+            (jsonUtility::isFruPowerOffOnly(m_parsedJson, vpdFilePath) &&
+             dbusUtility::isChassisPowerOn()))
         {
             continue;
         }

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,7 +54,8 @@ tests = [
   'utest_utils.cpp',
   'utest_keyword_parser.cpp',
   'utest_ddimm_parser.cpp',
-  'utest_ipz_parser.cpp'
+  'utest_ipz_parser.cpp',
+  'utest_json_utility.cpp'
 ]
 
 foreach test_file : tests

--- a/test/utest_json_utility.cpp
+++ b/test/utest_json_utility.cpp
@@ -1,0 +1,29 @@
+#include "parser.hpp"
+#include "types.hpp"
+#include "utility/json_utility.hpp"
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+using namespace vpd;
+
+TEST(IsFruPowerOffOnlyTest, PositiveTestCase)
+{
+    const std::string l_jsonPath{"/usr/local/share/vpd/50001001.json"};
+    const std::string l_vpdPath{"/sys/bus/spi/drivers/at25/spi12.0/eeprom"};
+    const nlohmann::json l_parsedJson = jsonUtility::getParsedJson(l_jsonPath);
+    const bool l_result = jsonUtility::isFruPowerOffOnly(l_parsedJson,
+                                                         l_vpdPath);
+    EXPECT_TRUE(l_result);
+}
+
+TEST(IsFruPowerOffOnlyTest, NegativeTestCase)
+{
+    const std::string l_jsonPath{"/usr/local/share/vpd/50001001.json"};
+    const std::string l_vpdPath{"/sys/bus/i2c/drivers/at24/4-0050/eeprom"};
+    const nlohmann::json l_parsedJson = jsonUtility::getParsedJson(l_jsonPath);
+    const bool l_result = jsonUtility::isFruPowerOffOnly(l_parsedJson,
+                                                         l_vpdPath);
+    EXPECT_FALSE(l_result);
+}


### PR DESCRIPTION
This commit implements changes to handle FRU when chassis is on. VPD Manager service can restart or BMC can reboot while the chassis is on. In this scenario, some FRUs should not be collected as Host has exclusive access to them. These FRUs are tagged as "powerOffOnly".

Test:

Tested on a Rainier 2S2U system.
On Rainier 2S2U system, as per 50001001_v2.json, following FRUs are "powerOffOnly":
1. /sys/bus/spi/drivers/at25/spi12.0/eeprom
2. /sys/bus/spi/drivers/at25/spi22.0/eeprom
3. /sys/bus/spi/drivers/at25/spi32.0/eeprom
4. /sys/bus/spi/drivers/at25/spi42.0/eeprom

Test steps:
1. Ensure BMC is in Ready state and Chassis is in Off state. Use obmcutil to verify. Also ensure VPD symlink path is already setup.
2. Run vpd-manager executable. Observe logs to see FRU collection is triggered for the "powerOffOnly" FRUs, as well as for other FRUs.
3. Execute 'obmcutil chassson' to power on the chassis. Wait for state to change from Transition On to Power On.
4. Now restart vpd-manager executable. Observe logs to see FRU collection is skipped for the "powerOffOnly" FRUs, and collection is triggered for the other FRUs.