### PR TITLE
Add service files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -115,5 +115,13 @@ vpd_parser_exe = executable(
                 install : true,
                 )
 
+services = ['service_files/vpd-manager.service',
+            'service_files/system-vpd.service',
+            'service_files/wait-vpd-parsers.service']
+            
+systemd_system_unit_dir = dependency('systemd').get_variable(
+        'systemdsystemunitdir')
+install_data(services, install_dir: systemd_system_unit_dir)
+
 package_datadir = join_paths('share', 'vpd')
 install_subdir('configuration/ibm/', install_mode: 'rwxr-xr-x', install_dir: package_datadir, strip_directory: true)

--- a/service_files/system-vpd.service
+++ b/service_files/system-vpd.service
@@ -1,0 +1,7 @@
+#currently these services are added just for backward compatibility.
+#It will perform no task in the system and will be eventually removed.
+
+[Unit]
+Description=System VPD Collection
+After=vpd-manager.service
+Before=phosphor-discover-system-state@0.service

--- a/service_files/vpd-manager.service
+++ b/service_files/vpd-manager.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=VPD Manager
+StopWhenUnneeded=false
+Wants=mapper-wait@-xyz-openbmc_project-inventory.service
+After=mapper-wait@-xyz-openbmc_project-inventory.service
+Wants=obmc-power-reset-on@0.target
+After=obmc-power-reset-on@0.target
+Wants=mapper-wait@-xyz-openbmc_project-state-chassis0.service
+After=mapper-wait@-xyz-openbmc_project-state-chassis0.service
+After=set-spi-mux.service
+Before=phosphor-discover-system-state@0.service
+
+[Service]
+BusName=com.ibm.VPD.Manager
+SyslogIdentifier=vpd-manager
+Type=dbus
+Restart=always
+RestartSec=5
+ExecStart=/usr/bin/vpd-manager
+
+[Install]
+WantedBy=multi-user.target

--- a/service_files/wait-vpd-parsers.service
+++ b/service_files/wait-vpd-parsers.service
@@ -1,0 +1,7 @@
+#currently these services are added just for backward compatibility.
+#It will perform no task in the system and will be eventually removed.
+
+[Unit]
+Description=Wait for VPD Collection Services to complete
+After=system-vpd.service
+After=set-spi-mux.service


### PR DESCRIPTION
Service files has been added to trigger daemon from system-d. Corresponding changes has been done in meson file to install the same.

system-vpd.service and wait-vpd-parser.service has been kept for backward compatibility as other applications will be dependent on them.
Eventually dependency needs to be moved and these two service files should be removed from the repository.