### PR TITLE
Add preaction In JSON for Dimms

### DIFF
--- a/configuration/ibm/50001001.json
+++ b/configuration/ibm/50001001.json
@@ -3004,6 +3004,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-111/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3062,6 +3069,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-110/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3120,6 +3134,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-214/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3178,6 +3199,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-210/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3236,6 +3264,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-202/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3294,6 +3329,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-311/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3352,6 +3394,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-310/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3410,6 +3459,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-312/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3468,6 +3524,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-402/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3526,6 +3589,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-410/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3584,6 +3654,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-112/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3642,6 +3719,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-115/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3700,6 +3784,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-100/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3758,6 +3849,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-101/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3816,6 +3914,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-114/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3874,6 +3979,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-113/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3932,6 +4044,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-216/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3990,6 +4109,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-203/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4048,6 +4174,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-217/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4106,6 +4239,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-211/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4164,6 +4304,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-215/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4222,6 +4369,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-315/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4280,6 +4434,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-300/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4338,6 +4499,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-313/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4396,6 +4564,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-314/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4454,6 +4629,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-301/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4512,6 +4694,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-417/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4570,6 +4759,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-403/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4628,6 +4824,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-416/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4686,6 +4889,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-411/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4744,6 +4954,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-415/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4802,6 +5019,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-414/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {

--- a/configuration/ibm/50001001_v2.json
+++ b/configuration/ibm/50001001_v2.json
@@ -2999,6 +2999,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-111/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3057,6 +3064,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-110/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3115,6 +3129,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-214/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3173,6 +3194,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-210/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3231,6 +3259,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-202/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3289,6 +3324,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-311/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3347,6 +3389,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-310/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3405,6 +3454,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-312/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3463,6 +3519,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-402/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3521,6 +3584,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-410/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3579,6 +3649,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-112/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3637,6 +3714,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-115/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3695,6 +3779,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-100/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3753,6 +3844,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-101/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3811,6 +3909,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-114/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3869,6 +3974,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-113/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3927,6 +4039,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-216/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3985,6 +4104,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-203/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4043,6 +4169,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-217/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4101,6 +4234,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-211/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4159,6 +4299,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-215/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4217,6 +4364,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-315/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4275,6 +4429,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-300/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4333,6 +4494,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-313/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4391,6 +4559,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-314/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4449,6 +4624,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-301/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4507,6 +4689,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-417/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4565,6 +4754,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-403/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4623,6 +4819,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-416/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4681,6 +4884,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-411/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4739,6 +4949,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-415/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {
@@ -4797,6 +5014,13 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "preAction": {
+                    "collection": {
+                        "systemCmd": {
+                            "cmd": "echo 24c32 0x50 > /sys/bus/i2c/devices/i2c-414/new_device"
+                        }
+                    }
+                },
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Dimm": null,
                     "com.ibm.ipzvpd.Location": {


### PR DESCRIPTION
As DIMMs are supposed to be bounded based on the presence of processors, hence DIMMs are not auto bounded.
In this case before collecting a DIMM pre-action is required which will detect the presence of respective CPU and based on that will bing the driver for DIMM.

The commit adds pre action in JSON to bind the DIMMs.

TODO: Presence for CPU needs to be added in the pre-action section.

Tested:
All the DIMMs are getting collected.