### PR TITLE
Update FRU status on recollection

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -489,45 +489,6 @@ void Manager::performVPDRecollection()
             singleFru["inventoryPath"]
                 .get_ref<const nlohmann::json::string_t&>();
 
-        // Before re-collecting clear the CC and Present value. It should be
-        // auto set after re-collection, if re-collection is successful.
-        inventory::ObjectMap objectMap{
-            {inventoryPath,
-             {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
-               {{"Functional", true}}},
-              {"com.ibm.ipzvpd.VINI", {{"CC", Binary{}}}},
-              {"xyz.openbmc_project.Inventory.Item", {{"Present", false}}}}}};
-
-        common::utility::callPIM(move(objectMap));
-
-        // check if any subtree exist under the parent path.
-        std::vector<std::string> interfaceList{
-            "xyz.openbmc_project.Inventory.Item"};
-        MapperResponse subTree = getObjectSubtreeForInterfaces(
-            INVENTORY_PATH + inventoryPath, 0, interfaceList);
-
-        for (auto [objectPath, serviceInterfaceMap] : subTree)
-        {
-            std::string subTreeObjPath{objectPath};
-            // Strip any inventory prefix in path
-            if (subTreeObjPath.find(INVENTORY_PATH) == 0)
-            {
-                subTreeObjPath =
-                    subTreeObjPath.substr(sizeof(INVENTORY_PATH) - 1);
-            }
-
-            // If subtree present, set its presence to false and functional to
-            // true.
-            inventory::ObjectMap objectMap{
-                {subTreeObjPath,
-                 {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
-                   {{"Functional", true}}},
-                  {"xyz.openbmc_project.Inventory.Item",
-                   {{"Present", false}}}}}};
-
-            common::utility::callPIM(move(objectMap));
-        }
-
         bool prePostActionRequired = false;
 
         if ((jsonFile["frus"][item].at(0)).find("preAction") !=
@@ -545,6 +506,9 @@ void Manager::performVPDRecollection()
                         "Pre-Action execution failed for the FRU",
                         entry("ERROR=%s",
                               ("Inventory path: " + inventoryPath).c_str()));
+
+                    // As recollection failed delete FRU data.
+                    deleteFRUVPD(inventoryPath);
                     continue;
                 }
             }
@@ -555,6 +519,9 @@ void Manager::performVPDRecollection()
                 additionalData.emplace("DESCRIPTION", e.what());
                 createPEL(additionalData, PelSeverity::WARNING,
                           errIntfForGpioError, sdBus);
+
+                // As recollection failed delete FRU data.
+                deleteFRUVPD(inventoryPath);
                 continue;
             }
             prePostActionRequired = true;
@@ -574,6 +541,9 @@ void Manager::performVPDRecollection()
                 {
                     // If not, then take failure postAction
                     executePostFailAction(jsonFile, item);
+
+                    // As recollection failed delete FRU data.
+                    deleteFRUVPD(inventoryPath);
                 }
                 catch (const GpioException& e)
                 {
@@ -581,6 +551,9 @@ void Manager::performVPDRecollection()
                     additionalData.emplace("DESCRIPTION", e.what());
                     createPEL(additionalData, PelSeverity::WARNING,
                               errIntfForGpioError, sdBus);
+
+                    // As recollection failed delete FRU data.
+                    deleteFRUVPD(inventoryPath);
                 }
             }
             else
@@ -807,32 +780,32 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path& path)
         // check if we have cxp-port populated for the given object path.
         std::vector<std::string> interfaceList{
             "xyz.openbmc_project.State.Decorator.OperationalStatus"};
-        MapperResponse subTree = getObjectSubtreeForInterfaces(path, 0,
-                                                               interfaceList);
+
+        MapperResponse subTree = getObjectSubtreeForInterfaces(
+            INVENTORY_PATH + objPath, 0, interfaceList);
 
         if (subTree.size() != 0)
         {
             for (auto [objectPath, serviceInterfaceMap] : subTree)
             {
                 std::string subTreeObjPath{objectPath};
-                if (subTreeObjPath.find("cxp_top") != std::string::npos ||
-                    subTreeObjPath.find("cxp_bot") != std::string::npos)
+
+                // Strip any inventory prefix in path
+                if (subTreeObjPath.find(INVENTORY_PATH) == 0)
                 {
-                    // Strip any inventory prefix in path
-                    if (subTreeObjPath.find(INVENTORY_PATH) == 0)
-                    {
-                        subTreeObjPath =
-                            subTreeObjPath.substr(sizeof(INVENTORY_PATH) - 1);
-                    }
-
-                    inventory::ObjectMap objectMap{
-                        {subTreeObjPath,
-                         {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
-                           {{"Functional", true}}}}}};
-
-                    // objectMap.emplace(objectPath, move(interfaceMap));
-                    common::utility::callPIM(move(objectMap));
+                    subTreeObjPath =
+                        subTreeObjPath.substr(sizeof(INVENTORY_PATH) - 1);
                 }
+
+                inventory::ObjectMap objectMap{
+                    {subTreeObjPath,
+                     {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                       {{"Functional", true}}},
+                      {"xyz.openbmc_project.Inventory.Item",
+                       {{"Present", false}}}}}};
+
+                // objectMap.emplace(objectPath, move(interfaceMap));
+                common::utility::callPIM(move(objectMap));
             }
         }
 


### PR DESCRIPTION
Some FRUs qualifies for recollection at standby. Based on their recollection status, clear VPD and reset their functional and present property if required.