### PR TITLE
Move isChassisPowerOn API out of conditional compilation.

### DIFF
--- a/include/utility/dbus_utility.hpp
+++ b/include/utility/dbus_utility.hpp
@@ -286,5 +286,40 @@ inline types::BiosAttributeCurrentValue
 
     return std::get<1>(l_attributeVal);
 }
+
+/**
+ * @brief API to check if Chassis is powered on.
+ *
+ * This API queries Phosphor Chassis State Manager to know whether
+ * Chassis is powered on.
+ *
+ * @return true if chassis is powered on, false otherwise
+ */
+inline bool isChassisPowerOn()
+{
+    auto powerState = dbusUtility::readDbusProperty(
+        "xyz.openbmc_project.State.Chassis",
+        "/xyz/openbmc_project/state/chassis0",
+        "xyz.openbmc_project.State.Chassis", "CurrentPowerState");
+
+    if (auto curPowerState = std::get_if<std::string>(&powerState))
+    {
+        if ("xyz.openbmc_project.State.Chassis.PowerState.On" == *curPowerState)
+        {
+            logging::logMessage("Chassis is in on state");
+            return true;
+        }
+        return false;
+    }
+
+    /*
+        TODO: Add PEL.
+        Callout: Firmware callout
+        Type: Informational
+        Description: Chassis state can't be determined, defaulting to chassis
+        off. : e.what()
+    */
+    return false;
+}
 } // namespace dbusUtility
 } // namespace vpd

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -95,31 +95,11 @@ void Worker::enableMuxChips()
 }
 
 #ifdef IBM_SYSTEM
-static bool isChassisPowerOn()
-{
-    auto powerState = dbusUtility::readDbusProperty(
-        "xyz.openbmc_project.State.Chassis",
-        "/xyz/openbmc_project/state/chassis0",
-        "xyz.openbmc_project.State.Chassis", "CurrentPowerState");
-
-    if (auto curPowerState = std::get_if<std::string>(&powerState))
-    {
-        if ("xyz.openbmc_project.State.Chassis.PowerState.On" == *curPowerState)
-        {
-            logging::logMessage("VPD cannot be read in power on state.");
-            return true;
-        }
-        return false;
-    }
-
-    throw std::runtime_error("Dbus call to get chassis power state failed");
-}
-
 void Worker::performInitialSetup()
 {
     try
     {
-        if (!isChassisPowerOn())
+        if (!dbusUtility::isChassisPowerOn())
         {
             setDeviceTreeAndJson();
         }


### PR DESCRIPTION
This commit moves isChassisPowerOn out of IBM conditional compilation. Also moves the definition from worker.cpp and into dbus_utility.hpp. Addresses issue #436.

Test:
Run the CI job steps on local unit test docker container and see that compilation and unit test cases pass.