### PR TITLE
Add Slot interface to all NVMe drives

### DIFF
--- a/config/ibm/50001000.json
+++ b/config/ibm/50001000.json
@@ -2455,6 +2455,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C0"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2489,6 +2492,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2525,6 +2531,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2559,6 +2568,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2595,6 +2607,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2629,6 +2644,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2665,6 +2683,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C6"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2699,6 +2720,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"
@@ -2877,6 +2901,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C8"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 8"
                     }
@@ -2910,6 +2937,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 9"
@@ -2945,6 +2975,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C10"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 11
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 10"
                     }
@@ -2978,6 +3011,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 12
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 11"
@@ -3013,6 +3049,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C12"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 13
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 12"
                     }
@@ -3046,6 +3085,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 14
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 13"
@@ -3081,6 +3123,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C14"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 15
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 14"
                     }
@@ -3114,6 +3159,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 16
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 15"

--- a/config/ibm/50001000_v2.json
+++ b/config/ibm/50001000_v2.json
@@ -2535,6 +2535,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C0"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2569,6 +2572,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2605,6 +2611,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2639,6 +2648,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2675,6 +2687,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2709,6 +2724,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2745,6 +2763,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C6"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2779,6 +2800,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"
@@ -2958,6 +2982,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C8"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 8"
                     }
@@ -2992,6 +3019,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 9"
@@ -3028,6 +3058,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C10"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 11
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 10"
                     }
@@ -3062,6 +3095,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 12
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 11"
@@ -3098,6 +3134,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C12"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 13
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 12"
                     }
@@ -3132,6 +3171,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 14
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 13"
@@ -3168,6 +3210,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C14"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 15
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 14"
                     }
@@ -3202,6 +3247,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 16
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 15"

--- a/config/ibm/50001001.json
+++ b/config/ibm/50001001.json
@@ -2315,6 +2315,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2349,6 +2352,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2385,6 +2391,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2419,6 +2428,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2548,6 +2560,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C10"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2582,6 +2597,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2618,6 +2636,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C12"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2652,6 +2673,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"

--- a/config/ibm/50001001_v2.json
+++ b/config/ibm/50001001_v2.json
@@ -2392,6 +2392,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2426,6 +2429,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2462,6 +2468,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2496,6 +2505,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2625,6 +2637,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C10"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2659,6 +2674,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2695,6 +2713,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C12"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2729,6 +2750,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"

--- a/config/ibm/50001002.json
+++ b/config/ibm/50001002.json
@@ -1654,6 +1654,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C0"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -1688,6 +1691,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -1724,6 +1730,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -1758,6 +1767,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -1794,6 +1806,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -1828,6 +1843,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -1864,6 +1882,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C6"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -1898,6 +1919,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"
@@ -2077,6 +2101,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C8"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 8"
                     }
@@ -2111,6 +2138,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 9"
@@ -2147,6 +2177,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C10"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 11
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 10"
                     }
@@ -2181,6 +2214,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C11"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 12
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 11"
@@ -2217,6 +2253,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C12"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 13
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 12"
                     }
@@ -2251,6 +2290,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C13"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 14
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 13"
@@ -2287,6 +2329,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C14"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 15
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 14"
                     }
@@ -2321,6 +2366,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P2-C15"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 16
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 15"

--- a/config/ibm/50003000.json
+++ b/config/ibm/50003000.json
@@ -2082,6 +2082,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C0"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2116,6 +2119,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2152,6 +2158,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2186,6 +2195,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2222,6 +2234,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2256,6 +2271,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2292,6 +2310,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C6"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2326,6 +2347,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"
@@ -2362,6 +2386,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C8"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 8"
                     }
@@ -2396,6 +2423,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 9"

--- a/config/ibm/50003000_v2.json
+++ b/config/ibm/50003000_v2.json
@@ -2066,6 +2066,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C0"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2100,6 +2103,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2136,6 +2142,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2170,6 +2179,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2206,6 +2218,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2240,6 +2255,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2276,6 +2294,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C6"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2310,6 +2331,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"
@@ -2346,6 +2370,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C8"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 8"
                     }
@@ -2380,6 +2407,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 9"


### PR DESCRIPTION
Assign a slot number to all drive paths so that the entity manager config file for IBM's drives can use that to give its objects unique names.  Previously it used its own incrementing index but sometimes got confused and tried to put a duplicate interface on the same object path which would crash.

This was already being done for IBM's cable card sensors.

Because the NVMe temperature sensor names are being hardcoded in other places (fan control and HMC telemetry), the slots are being assigned to always start at 1 and sequentially increment to keep the names the same as before.

Tested:

Properties are on D-Bus:

```
 busctl get-property xyz.openbmc_project.Inventory.Manager \
 /xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0/dp0_drive0 \
 xyz.openbmc_project.Inventory.Decorator.Slot SlotNumber
u 1
```