### PR TITLE
delete-vpd:Do not throw exception if FRU is absent - 1030

### DIFF
--- a/vpd-manager/manager.cpp
+++ b/vpd-manager/manager.cpp
@@ -720,14 +720,9 @@ void Manager::deleteFRUVPD(const sdbusplus::message::object_path path)
     string chipAddress =
         jsonFile["frus"][vpdFilePath].at(0).value("pcaChipAddress", "");
 
-    // if the FRU is not present then log error
+    // if the FRU is present, then unbind the LED driver if any
     if (readBusProperty(objPath, "xyz.openbmc_project.Inventory.Item",
-                        "Present") == "false")
-    {
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("FRU not preset"),
-                              Argument::ARGUMENT_VALUE(objPath.c_str()));
-    }
-    else
+                        "Present") == "true")
     {
         // check if we have cxp-port populated for the given object path.
         std::vector<std::string> interfaceList{


### PR DESCRIPTION
While deleting FRU VPD for the FRU which is not present, do not throw exception and crash the application.

Test:
Tested that the application continues to work fine in case of attempting VPD deletion for the FRU which is not present.

Change-Id: I6a9a03bfd3378c8c018d8f26b5647b393ed879d4