### PR TITLE
Fix vpd-manager crash when it starts before pldmd

### DIFF
--- a/src/bios_handler.cpp
+++ b/src/bios_handler.cpp
@@ -43,13 +43,13 @@ void BiosHandler<T>::checkAndListenPldmService()
             (l_name.compare(constants::pldmServiceName) ==
              constants::STR_CMP_SUCCESS))
         {
-            // TODO: Restore BIOS attribute from here.
-            //  We don't need the match anymore
-            l_nameOwnerMatch.reset();
             m_specificBiosHandler->backUpOrRestoreBiosAttributes();
 
             // Start listener now that we have done the restore.
             listenBiosAttributes();
+
+            //  We don't need the match anymore
+            l_nameOwnerMatch.reset();
         }
     });
 


### PR DESCRIPTION
This commit fixes the vpd-manager catching a SIGSEGV observed when we
first load a bitbaked image. This crash is also reproduced when
vpd-manager service starts before pldmd service.

RCA:

Inside the lambda callback which gets triggered when pldmd starts,
the nameOwnerMatch object was being reset before the captured this
pointer was used. The reset call caused the this pointer to point
to an invalid BiosHandler object, resulting in a SIGSEGV whenever the
this pointer got used.

Fix:

nameOwnerMatch reset call is now moved after all the calls in which the
captured this pointer is used.

Test:

1. Install bitbaked image with fix.
2. Reboot BMC.
3. After BMC boot up, check for any vpd-manager service restarts
   systemctl show vpd-manager -p NRestarts
   This is 0.
4. Stop vpd-manager service and pldmd service.
5. Start vpd-manager service.
6. Now start pldmd service, observe journal log
7. vpd-manager should not restart.