### PR TITLE
Check if PostFailAction is present in JSON before execution.

### DIFF
--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1118,7 +1118,12 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
     if (jsonUtility::isActionRequired(m_parsedJson, i_vpdFilePath, "preAction",
                                       "collection"))
     {
-        if (processPreAction(i_vpdFilePath, "collection"))
+        // post fail action is required for a FRU if pre action is successful
+        // and some post fail action is defined for the FRU in the System Config
+        // JSON.
+        if (processPreAction(i_vpdFilePath, "collection") &&
+            jsonUtility::isActionRequired(m_parsedJson, i_vpdFilePath,
+                                          "PostFailAction", "collection"))
         {
             l_isPostFailActionRequired = true;
         }


### PR DESCRIPTION
This commit addresses github issue #441.
PostFailAction tag is not a mandatory tag in System Config JSON. The worker::parseVpdFile API tried to execute PostFailAction for FRUs, even though it is not defined in the JSON, resulting in unnecessary logs and throws.

Fix:

Added a check to see if PostFailAction tag is defined for a given FRU, before trying to execute PostFailAction.

Test:

Tested on a rainier 2S2U system with some empty DIMM slots. Check for empty DIMM slots using Present property:

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0 xyz.openbmc_project.Inventory.Item Present

1. Install an image without the fix
2. Reboot BMC
3. After BMC boots up, check vpd-manager logs to see log message: "PostFailAction flag missing in config JSON. Abort processing" "Post fail action failed for path * Aborting collection for this FRU
4. Install an image with the fix
5. Rebot BMC
6. After BMC boots up, check vpd-manager logs.
7. Above stated log messages are not seen.