### PR TITLE
Enable ibm_system meson option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,4 +10,4 @@ option('JSON_ABSOLUTE_PATH_PREFIX', type: 'string', value: '/usr/share/vpd/',  d
 option('SYSTEM_VPD_FILE_PATH', type: 'string', value: '/sys/bus/i2c/drivers/at24/8-0050/eeprom',  description: 'EEPROM path of system VPD.')
 option('VPD_SYMLIMK_PATH', type: 'string', value: '/var/lib/vpd',  description: 'Symlink folder for VPD invnetory JSONs')
 option('PIM_PATH_PREFIX', type: 'string', value: '/xyz/openbmc_project/inventory', description: 'Prefix for PIM inventory paths.')
-option('ibm_system', type: 'feature', value : 'disabled', description: 'Enable code specific to IBM systems.')
+option('ibm_system', type: 'feature', value : 'enabled', description: 'Enable code specific to IBM systems.')


### PR DESCRIPTION
This commit enables 'ibm_system' option in meson_options.txt. This option was disabled earlier due to which the ibm-openbmc Jenkins PR CI job was not compiling code placed under IBM conditional compilation.

Test:

1. Put a #error under any piece of code under IBM conditional compilation.
2. Create a test PR on ibm-openbmc/openpower-vpd-parser repo.
3. Test PR Jenkins CI job should fail.
4. Remove the #error and update the PR.
5. Test PR Jenkins CI job should pass.