### PR TITLE
Keyword VPD: Read from hardware and update the same on D-bus

### DIFF
--- a/include/keyword_vpd_parser.hpp
+++ b/include/keyword_vpd_parser.hpp
@@ -41,6 +41,19 @@ class KeywordVpdParser : public ParserInterface
      */
     types::VPDMapVariant parse();
 
+    /**
+     * @brief API to read keyword's value from hardware
+     *
+     * @param[in] i_paramsToReadData - Data required to perform read
+     *
+     * @throw
+     * sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument
+     *
+     * @return On success return the value read. On failure throw exception.
+     */
+    types::DbusVariantType
+        readKeywordFromHardware(const types::ReadVpdParams i_paramsToReadData);
+
   private:
     /**
      * @brief Parse the VPD data and emplace them as pair into the Map.
@@ -87,6 +100,19 @@ class KeywordVpdParser : public ParserInterface
      * @throw DataException - Truncated VPD data, check VPD.
      */
     void checkNextBytesValidity(uint8_t numberOfBytes);
+
+    /**
+     * @brief API to iterate through the VPD vector to find the given keyword.
+     *
+     * This API iterates through VPD vector using m_vpdIterator and finds the
+     * given keyword. m_vpdIterator points to the keyword name if find is
+     * successful.
+     *
+     * @param[in] i_keyword - Keyword name.
+     *
+     * @return 0 On successful find, -1 on failure.
+     */
+    int findKeyword(const std::string& i_keyword);
 
     /*Vector of keyword VPD data*/
     const types::BinaryVector& m_keywordVpdVector;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -116,6 +116,34 @@ int Parser::updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData)
                 return -1;
             }
         }
+        else if (const types::KwData* l_kwData =
+                     std::get_if<types::KwData>(&i_paramsToWriteData))
+        {
+            l_interfaceName = constants::kwdVpdInf;
+            l_propertyName = std::get<0>(*l_kwData);
+
+            try
+            {
+                // Read keyword's value from hardware to write the same on
+                // D-bus.
+                std::shared_ptr<ParserInterface> l_vpdParserInstance =
+                    getVpdParserInstance();
+                logging::logMessage("Performing VPD read on " + m_vpdFilePath);
+                l_keywordValue = l_vpdParserInstance->readKeywordFromHardware(
+                    types::ReadVpdParams(l_propertyName));
+            }
+            catch (const std::exception& l_exception)
+            {
+                // Unable to read keyword's value from hardware.
+                logging::logMessage(
+                    "Error while reading keyword's value from hadware path " +
+                    m_vpdFilePath +
+                    ", error: " + std::string(l_exception.what()));
+
+                // TODO: Log PEL
+                return -1;
+            }
+        }
         else
         {
             // Input parameter type provided isn't compatible to perform update.


### PR DESCRIPTION
Keyword's value gets updated on D-bus irrespective of verifying the keyword size.

For example, For a 4 byte keyword, if user gives more than 4 bytes of data to
update, hardware update will accept only 4 bytes but D-bus update will accept
every extra byte given by the user. This will create a mismatch between hardware
and D-bus.

So to avoid such mismatches we came up with the design of updating the keyword's
value in hardware first ( which takes care of size checks) and copy the same
in other sources. With this approach we maintain the reliability of keyword
updates across all other sources.

This commit implements the portion where we read the keyword's value from hardware
(assuming the hardware write is already done from Manager class) and write the same
on D-bus.

Test:
busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager  ReadKeyword sv "/tmp/keyword.dat" s "SN"
v ay 12 89 72 51 48 66 71 55 56 66 48 49 52