### PR TITLE
Keyword VPD:Write keyword's value on hardware

### DIFF
--- a/include/keyword_vpd_parser.hpp
+++ b/include/keyword_vpd_parser.hpp
@@ -25,9 +25,10 @@ class KeywordVpdParser : public ParserInterface
      *
      * @param kwVpdVector - move it to object's m_keywordVpdVector
      */
-    KeywordVpdParser(const types::BinaryVector& kwVpdVector) :
+    KeywordVpdParser(const types::BinaryVector& kwVpdVector,
+                     const std::string& vpdFilePath) :
         m_keywordVpdVector(kwVpdVector),
-        m_vpdIterator(m_keywordVpdVector.begin())
+        m_vpdIterator(m_keywordVpdVector.begin()), m_vpdFilePath(vpdFilePath)
     {}
 
     /**
@@ -40,6 +41,18 @@ class KeywordVpdParser : public ParserInterface
      * @return map of keyword:value
      */
     types::VPDMapVariant parse();
+
+    /**
+     * @brief API to write keyword's value on hardware.
+     *
+     * @param[in] i_paramsToWriteData - Data required to perform write.
+     *
+     * @throw sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument.
+     *
+     * @return On success returns number of bytes written on hardware, On
+     * failure throws exception.
+     */
+    int writeKeywordOnHardware(const types::WriteVpdParams i_paramsToWriteData);
 
   private:
     /**
@@ -88,10 +101,26 @@ class KeywordVpdParser : public ParserInterface
      */
     void checkNextBytesValidity(uint8_t numberOfBytes);
 
+    /**
+     * @brief API to iterate through the VPD vector to find the given keyword.
+     *
+     * This API iterates through VPD vector using m_vpdIterator and finds the
+     * given keyword. m_vpdIterator points to the keyword name if find is
+     * successful.
+     *
+     * @param[in] i_keyword - Keyword name.
+     *
+     * @return 0 On successful find, -1 on failure.
+     */
+    int findKeyword(const std::string& i_keyword);
+
     /*Vector of keyword VPD data*/
     const types::BinaryVector& m_keywordVpdVector;
 
     /*Iterator to VPD data*/
     types::BinaryVector::const_iterator m_vpdIterator;
+
+    // Holds the VPD file path
+    const std::string& m_vpdFilePath;
 };
 } // namespace vpd

--- a/src/parser_factory.cpp
+++ b/src/parser_factory.cpp
@@ -120,7 +120,8 @@ std::shared_ptr<ParserInterface>
         {
             logging::logMessage("KWD vpd parser selected for VPD file path " +
                                 i_vpdFilePath);
-            return std::make_shared<KeywordVpdParser>(i_vpdVector);
+            return std::make_shared<KeywordVpdParser>(i_vpdVector,
+                                                      i_vpdFilePath);
         }
 
         case vpdType::DDR5_DDIMM_MEMORY_VPD:

--- a/test/utest_keyword_parser.cpp
+++ b/test/utest_keyword_parser.cpp
@@ -139,7 +139,7 @@ TEST(KeywordVpdParserTest, EmptyInput)
 {
     // Blank keyword VPD
     types::BinaryVector emptyVector{};
-    KeywordVpdParser l_keywordParser(std::move(emptyVector));
+    KeywordVpdParser l_keywordParser(std::move(emptyVector), std::string());
 
     EXPECT_THROW(l_keywordParser.parse(), std::exception);
 }


### PR DESCRIPTION
This commit implements API to write keyword's value on hardware for keyword VPD types.

Test:
busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeyword  sv "/tmp/keyword.dat" "(say)" "FN" 2 0x65 0x66

hexdump -C keyword.dat
00000010 53 41 53 84 9b 00 46 4e  08 65 66 31 4b 55 37 32 |SAS...FN.ef1KU72|

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard /keyword_vpd_type com.ibm.ipzvpd.VINI FN

ay 8 101 102 49 75 85 55 50 52

Change-Id: I203c7d6def40830459f90adf9c0e3c88560956e5