### PR TITLE
Handle PostFailAction tag

### DIFF
--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -206,15 +206,6 @@ inline bool executePostFailAction(const nlohmann::json& i_parsedConfigJson,
         return false;
     }
 
-    if (!(i_parsedConfigJson["frus"][i_vpdFilePath].at(0).contains(
-            "PostFailAction")))
-    {
-        logging::logMessage(
-            "PostFailAction flag missing in config JSON. Abort processing");
-
-        return false;
-    }
-
     if (!(i_parsedConfigJson["frus"][i_vpdFilePath].at(0))["PostFailAction"]
              .contains(i_flagToProcess))
     {
@@ -454,13 +445,6 @@ inline bool procesSetGpioTag(const nlohmann::json& i_parsedConfigJson,
         l_errMsg += " Reason: ";
         l_errMsg += ex.what();
         l_errMsg += " File: " + i_vpdFilePath + " Pel Logged";
-
-        // Take failure postAction
-        if (!executePostFailAction(i_parsedConfigJson, i_vpdFilePath,
-                                   i_flagToProcess))
-        {
-            logging::logMessage("executePostFailAction failed from exception.");
-        }
 
         // ToDo -- Update Internal RC code
         EventLogger::createAsyncPelWithInventoryCallout(


### PR DESCRIPTION
VPD collection for the FRU’s which doesn’t has PostFailAction tag in
the system config JSON is failing with ‘Pre-Action failed’ log even
though pre action passed for that FRU.

This commit handles the above issue, post fail action will be triggered
in case of pre action fails or the VPD parsing for the EEPROM itself
fails, in case ‘PostFailAction’ tag found in the system config JSON.