### PR TITLE
Everest:Add Slot interface to all NVMe drives

### DIFF
--- a/configuration/ibm/50003000.json
+++ b/configuration/ibm/50003000.json
@@ -2344,6 +2344,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C0"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 1
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 0"
                     }
@@ -2377,6 +2380,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C1"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 2
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 1"
@@ -2412,6 +2418,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C2"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 3
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 2"
                     }
@@ -2445,6 +2454,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C3"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 4
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 3"
@@ -2480,6 +2492,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C4"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 5
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 4"
                     }
@@ -2513,6 +2528,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C5"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 6
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 5"
@@ -2548,6 +2566,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C6"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 7
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 6"
                     }
@@ -2581,6 +2602,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C7"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 8
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 7"
@@ -2616,6 +2640,9 @@
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C8"
                     },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 9
+                    },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 8"
                     }
@@ -2649,6 +2676,9 @@
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs-P1-C9"
+                    },
+                    "xyz.openbmc_project.Inventory.Decorator.Slot": {
+                        "SlotNumber": 10
                     },
                     "xyz.openbmc_project.Inventory.Item": {
                         "PrettyName": "NVMe U.2 drive 9"


### PR DESCRIPTION
Assign a slot number to all drive paths so that the entity manager config file for IBM's drives can use that to give its objects unique names.  Previously it used its own incrementing index but sometimes got confused and tried to put a duplicate interface on the same object path which would crash.

This was already being done for IBM's cable card sensors.

Because the NVMe temperature sensor names are being hardcoded in other places (fan control and HMC telemetry), the slots are being assigned to always start at 1 and sequentially increment to keep the names the same as before.

Tested:

Properties are on D-Bus:

```
 busctl get-property xyz.openbmc_project.Inventory.Manager \
 /xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0/dp0_drive0 \
 xyz.openbmc_project.Inventory.Decorator.Slot SlotNumber
u 1
```

Change-Id: I233397450dc47ccc8c02a01bba1fa42e29db857c