### PR TITLE
Update decorator locationcode interface

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -97,6 +97,8 @@ constexpr auto kwdAMM = "D0";
 constexpr auto kwdClearNVRAM_CreateLPAR = "D1";
 constexpr auto kwdKeepAndClear = "D1";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
+constexpr auto xyzLocationCodeInf =
+    "xyz.openbmc_project.Inventory.Decorator.LocationCode";
 constexpr auto operationalStatusInf =
     "xyz.openbmc_project.State.Decorator.OperationalStatus";
 constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -649,6 +649,12 @@ void Worker::populateInterfaces(const nlohmann::json& interfaceJson,
                             propValuePair.value().get<std::string>(),
                             parsedVpdMap);
                     propertyMap.emplace(property, value);
+
+                    auto l_locCodeProperty = propertyMap;
+                    vpdSpecificUtility::insertOrMerge(
+                        interfaceMap,
+                        std::string(constants::xyzLocationCodeInf),
+                        move(l_locCodeProperty));
                 }
                 else
                 {


### PR DESCRIPTION
This commit adds ‘LocationCode’ property and its value under “xyz.openbmc_project.Inventory.Decorator.LocationCode” interface to publish this data on DBus for the inventories having ‘LocationCode’ tag in the system config JSON.

Tested the changes on the system, observed decorator locationcode Interface and its LocationCode property and value appeared on the DBus.