### PR TITLE
Fix Expanded LocationCode for DDIMMs

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -106,11 +106,17 @@ constexpr auto ipzVpdInf = "com.ibm.ipzvpd.";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto vsysInf = "com.ibm.ipzvpd.VSYS";
 constexpr auto utilInf = "com.ibm.ipzvpd.UTIL";
+constexpr auto vcenInf = "com.ibm.ipzvpd.VCEN";
 constexpr auto kwdCCIN = "CC";
 constexpr auto kwdRG = "RG";
 constexpr auto kwdAMM = "D0";
 constexpr auto kwdClearNVRAM_CreateLPAR = "D1";
 constexpr auto kwdKeepAndClear = "D1";
+constexpr auto kwdFC = "FC";
+constexpr auto kwdTM = "TM";
+constexpr auto kwdSE = "SE";
+constexpr auto recVSYS = "VSYS";
+constexpr auto recVCEN = "VCEN";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto xyzLocationCodeInf =
     "xyz.openbmc_project.Inventory.Decorator.LocationCode";


### PR DESCRIPTION
Expanded location code was not showing for DDIMMs, even though VPD parsing is successful for those DDIMMs.

Expanded location code was only calculated for IPZ type VPD, so it was skipping for non IPZ type VPD and publishing unexpanded location on the DBus as present in the system config JSON for that FRU.

This commit adds the code to fix the above issue.

Tested the changes on the Rainier system observed that expanded LocationCode was showing for DDIMMs correctly on the DBus.