### PR TITLE
4U JSON:Remove GPIO presence check for PCIe cards

### DIFF
--- a/configuration/ibm/50001000.json
+++ b/configuration/ibm/50001000.json
@@ -1856,10 +1856,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT0_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT0_PRSNT_EN_RSVD",
                             "value": 1
@@ -1946,10 +1942,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT3_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT3_PRSNT_EN_RSVD",
                             "value": 1
@@ -2036,10 +2028,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT4_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT4_PRSNT_EN_RSVD",
                             "value": 1
@@ -2123,10 +2111,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT10_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT10_PRSNT_EN_RSVD",
                             "value": 1
@@ -2281,10 +2265,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT2_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT2_PRSNT_EN_RSVD",
                             "value": 1
@@ -2328,10 +2308,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT6_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT6_PRSNT_EN_RSVD",
                             "value": 1
@@ -2368,10 +2344,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT7_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT7_PRSNT_EN_RSVD",
                             "value": 1
@@ -2415,10 +2387,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT9_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT9_PRSNT_EN_RSVD",
                             "value": 1
@@ -2462,10 +2430,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT11_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT11_PRSNT_EN_RSVD",
                             "value": 1
@@ -2578,10 +2542,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT1_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT1_PRSNT_EN_RSVD",
                             "value": 1
@@ -2625,10 +2585,6 @@
                 "concurrentlyMaintainable": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "SLOT8_EXPANDER_PRSNT_N",
-                            "value": 0
-                        },
                         "setGpio": {
                             "pin": "SLOT8_PRSNT_EN_RSVD",
                             "value": 1


### PR DESCRIPTION
This commit removes GPIO presence check for PCIe cards in rainier 4U pass1 JSON.

Change-Id: Ic774800b84d9a1167185e5d52fa5744e647ab513