### PR TITLE
Update one time properties

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -116,6 +116,7 @@ constexpr auto xyzLocationCodeInf =
     "xyz.openbmc_project.Inventory.Decorator.LocationCode";
 constexpr auto operationalStatusInf =
     "xyz.openbmc_project.State.Decorator.OperationalStatus";
+constexpr auto enableInf = "xyz.openbmc_project.Object.Enable";
 constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
 constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
 constexpr auto pldmServiceName = "xyz.openbmc_project.PLDM";

--- a/include/worker.hpp
+++ b/include/worker.hpp
@@ -415,6 +415,36 @@ class Worker
      */
     void performBackupAndRestore(types::VPDMapVariant& io_srcVpdMap);
 
+    /**
+     * @brief API to update "Functional" property.
+     *
+     * The API sets the default value for "Functional" property once if the
+     * property is not yet populated over DBus. As the property value is not
+     * controlled by the VPD-Collection process, if it is found already
+     * populated, the functions skips re-populating the property so that already
+     * existing value can be retained.
+     *
+     * @param[in] i_inventoryObjPath - Inventory path as read from config JSON.
+     * @param[in] io_interfaces - Map to hold all the interfaces for the FRU.
+     */
+    void processFunctionalPorperty(const std::string& i_inventoryObjPath,
+                                   types::InterfaceMap& io_interfaces);
+
+    /**
+     * @brief API to update "enabled" property.
+     *
+     * The API sets the default value for "enabled" property once if the
+     * property is not yet populated over DBus. As the property value is not
+     * controlled by the VPD-Collection process, if it is found already
+     * populated, the functions skips re-populating the property so that already
+     * existing value can be retained.
+     *
+     * @param[in] i_inventoryObjPath - Inventory path as read from config JSON.
+     * @param[in] io_interfaces - Map to hold all the interfaces for the FRU.
+     */
+    void processEnabledProperty(const std::string& i_inventoryObjPath,
+                                types::InterfaceMap& io_interfaces);
+
     // Parsed JSON file.
     nlohmann::json m_parsedJson{};
 


### PR DESCRIPTION
The commit populates and initializes "Functional" and "Enabled" property for a given FRU.

The properties are only populated and initilized during first collection of the FRU. As the value of these properties are not controlled by VPD-Collection process, they are not re-populated in case they are found already existing over DBus. This is done to retain the property set for these properties across BMC reboots or any re-collection.