### PR TITLE
Backup restore JSON for Everest system

### DIFF
--- a/configuration/ibm/backup_restore_50003000.json
+++ b/configuration/ibm/backup_restore_50003000.json
@@ -1,0 +1,158 @@
+{
+    "source": {
+        "hardwarePath": "/sys/bus/i2c/drivers/at24/8-0050/eeprom"
+    },
+    "destination": {
+        "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard"
+    },
+    "type": "IPZ",
+    "backupMap": [
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "BR",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "BR",
+            "defaultValue": [32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "TM",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "TM",
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "SE",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "SE",
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "SU",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "SU",
+            "defaultValue": [32, 32, 32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "RB",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "RB",
+            "defaultValue": [32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "WN",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "WN",
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "RG",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "RG",
+            "defaultValue": [32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VSYS",
+            "sourceKeyword": "FV",
+            "destinationRecord": "VSYS",
+            "destinationKeyword": "FV",
+            "defaultValue": [
+                32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
+                32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32
+            ],
+            "isPelRequired": false,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "VCEN",
+            "sourceKeyword": "FC",
+            "destinationRecord": "VCEN",
+            "destinationKeyword": "FC",
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": false
+        },
+        {
+            "sourceRecord": "VCEN",
+            "sourceKeyword": "SE",
+            "destinationRecord": "VCEN",
+            "destinationKeyword": "SE",
+            "defaultValue": [32, 32, 32, 32, 32, 32, 32],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "LXR0",
+            "sourceKeyword": "LX",
+            "destinationRecord": "LXR0",
+            "destinationKeyword": "LX",
+            "defaultValue": [0, 0, 0, 0, 0, 0, 0, 0],
+            "isPelRequired": true,
+            "isManufactureResetRequired": false
+        },
+        {
+            "sourceRecord": "UTIL",
+            "sourceKeyword": "D0",
+            "destinationRecord": "UTIL",
+            "destinationKeyword": "D0",
+            "defaultValue": [0],
+            "isPelRequired": true,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "UTIL",
+            "sourceKeyword": "D1",
+            "destinationRecord": "UTIL",
+            "destinationKeyword": "D1",
+            "defaultValue": [0],
+            "isPelRequired": false,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "UTIL",
+            "sourceKeyword": "F0",
+            "destinationRecord": "UTIL",
+            "destinationKeyword": "F0",
+            "defaultValue": [0, 0, 0, 0, 0, 0, 0, 0],
+            "isPelRequired": false,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "UTIL",
+            "sourceKeyword": "F5",
+            "destinationRecord": "UTIL",
+            "destinationKeyword": "F5",
+            "defaultValue": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "isPelRequired": false,
+            "isManufactureResetRequired": true
+        },
+        {
+            "sourceRecord": "UTIL",
+            "sourceKeyword": "F6",
+            "destinationRecord": "UTIL",
+            "destinationKeyword": "F6",
+            "defaultValue": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "isPelRequired": false,
+            "isManufactureResetRequired": true
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds backup and restore config JSON file for Everest system.

Tested the changes by loading image on the Everest system,
* Manually set the VSYS BR record value on DBus using busctl to create mismatch value with the value present on hardware, observed that the mismatch value is retained as it is on DBus and on the hardware after restarting vpd-manager application.
*  Set the VSYS BR record value on DBus with its default value using busctl command, after vpd-manager application restart BR value from the hardware is reflected on the DBus.