### PR TITLE
Remove try&catch block from vpd-tool

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -6,6 +6,9 @@ namespace vpd
 {
 namespace constants
 {
+static constexpr auto KEYWORD_SIZE = 2;
+static constexpr auto RECORD_SIZE = 4;
+
 static constexpr uint8_t IPZ_DATA_START = 11;
 static constexpr uint8_t IPZ_DATA_START_TAG = 0x84;
 static constexpr uint8_t IPZ_RECORD_END_TAG = 0x78;

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -5,11 +5,13 @@ else
     CLI11_dep = dependency('CLI11')
 endif
 
+dependency_list = [CLI11_dep, sdbusplus]
+
 sources = ['src/vpd_tool_main.cpp']
 
 vpd_tool_exe = executable('vpd-tool',
                           sources,
                           include_directories : ['../include/'],
-                          dependencies: [CLI11_dep],
+                          dependencies: dependency_list,
                           install: true
                         )

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -7,77 +7,82 @@
 
 int main(int argc, char** argv)
 {
-    int l_retValue = 0;
-    try
+    int l_rc = -1;
+    CLI::App l_app{"VPD Command Line Tool"};
+
+    std::string l_vpdPath{};
+    std::string l_recordName{};
+    std::string l_keywordName{};
+    std::string l_filePath{};
+
+    l_app.footer(
+        "Read:\n"
+        "    IPZ Format:\n"
+        "        From dbus to console: "
+        "vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
+        "        From dbus to file: "
+        "vpd-tool -r -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "        From hardware to console: "
+        "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
+        "        From hardware to file: "
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+
+    auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
+                                           "File path");
+    auto l_recordOption = l_app.add_option("--record, -R", l_recordName,
+                                           "Record name");
+    auto l_keywordOption = l_app.add_option("--keyword, -K", l_keywordName,
+                                            "Keyword name");
+
+    auto l_fileOption = l_app.add_option("--file", l_filePath,
+                                         "Absolute file path");
+
+    auto l_readFlag = l_app.add_flag("--readKeyword, -r", "Read keyword")
+                          ->needs(l_objectOption)
+                          ->needs(l_recordOption)
+                          ->needs(l_keywordOption);
+
+    auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
+                                         "CAUTION: Developer only option.");
+
+    CLI11_PARSE(l_app, argc, argv);
+
+    if (*l_objectOption && l_vpdPath.empty())
     {
-        CLI::App l_app{"VPD Command Line Tool"};
-
-        std::string l_vpdPath{};
-        std::string l_recordName{};
-        std::string l_keywordName{};
-        std::string l_filePath{};
-
-        l_app.footer(
-            "Read:\n"
-            "    IPZ Format:\n"
-            "        From dbus to console: "
-            "vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
-            "        From dbus to file: "
-            "vpd-tool -r -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
-            "        From hardware to console: "
-            "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
-            "        From hardware to file: "
-            "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
-
-        auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
-                                               "File path");
-        auto l_recordOption = l_app.add_option("--record, -R", l_recordName,
-                                               "Record name");
-        auto l_keywordOption = l_app.add_option("--keyword, -K", l_keywordName,
-                                                "Keyword name");
-
-        auto l_fileOption = l_app.add_option("--file", l_filePath,
-                                             "Absolute file path");
-
-        auto l_readFlag = l_app.add_flag("--readKeyword, -r", "Read keyword")
-                              ->needs(l_objectOption)
-                              ->needs(l_recordOption)
-                              ->needs(l_keywordOption);
-
-        auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
-                                             "CAUTION: Developer only option.");
-
-        CLI11_PARSE(l_app, argc, argv);
-
-        if (*l_keywordOption &&
-            (l_keywordName.size() != vpd::constants::TWO_BYTES))
-        {
-            throw std::runtime_error("Keyword " + l_keywordName +
-                                     " not supported.");
-        }
-
-        if (*l_hardwareFlag && !std::filesystem::exists(l_vpdPath))
-        {
-            throw std::runtime_error("Given EEPROM file path doesn't exist : " +
-                                     l_vpdPath);
-        }
-
-        (void)l_fileOption;
-
-        if (*l_readFlag)
-        {
-            // TODO: call read keyword implementation from here.
-        }
-        else
-        {
-            std::cout << l_app.help() << std::endl;
-        }
-    }
-    catch (const std::exception& l_ex)
-    {
-        std::cerr << l_ex.what() << std::endl;
-        l_retValue = -1;
+        std::cout << "Given path is empty." << std::endl;
+        return -1;
     }
 
-    return l_retValue;
+    if (*l_recordOption && (l_recordName.size() != vpd::constants::RECORD_SIZE))
+    {
+        std::cerr << "Record " << l_recordName << " is not supported."
+                  << std::endl;
+    }
+
+    if (*l_keywordOption &&
+        (l_keywordName.size() != vpd::constants::KEYWORD_SIZE))
+    {
+        std::cerr << "Keyword " << l_keywordName << " is not supported."
+                  << std::endl;
+        return l_rc;
+    }
+
+    if (*l_hardwareFlag && !std::filesystem::exists(l_vpdPath))
+    {
+        std::cerr << "Given EEPROM file path doesn't exist : " + l_vpdPath
+                  << std::endl;
+        return l_rc;
+    }
+
+    (void)l_fileOption;
+
+    if (*l_readFlag)
+    {
+        // TODO: call read keyword implementation from here.
+    }
+    else
+    {
+        std::cout << l_app.help() << std::endl;
+    }
+    return l_rc;
 }


### PR DESCRIPTION
This commit removes try & catch block from the main file as CLI library API’s doesn’t throw an exception. Instead, each feature API’s should handle the exception and return success or failure status back to the main API.

And also added the code to check input record size in this commit.