### PR TITLE
Fix: Using constants namespace in DdimmVpdParser

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -131,5 +131,3 @@ SpacesInSquareBrackets: false
 Standard:        Latest
 TabWidth:        4
 UseTab:          Never
-...
-

--- a/src/ddimm_parser.cpp
+++ b/src/ddimm_parser.cpp
@@ -179,14 +179,14 @@ size_t DdimmVpdParser::getDdr5BasedDdimmSize(
 
         if (((i_iterator[constants::SPD_BYTE_234] &
               constants::MASK_BYTE_BIT_7) >>
-             VALUE_7))
+             constants::VALUE_7))
         {
             l_ranksPerChannel = ((i_iterator[constants::SPD_BYTE_234] &
                                   constants::MASK_BYTE_BITS_345) >>
                                  constants::VALUE_3) +
                                 constants::VALUE_1;
         }
-        else if (((i_iterator[SVPD_JEDEC_BYTE_235] &
+        else if (((i_iterator[constants::SPD_BYTE_235] &
                    constants::MASK_BYTE_BIT_6) >>
                   constants::VALUE_6))
         {

--- a/test/utest_ddimm_parser.cpp
+++ b/test/utest_ddimm_parser.cpp
@@ -16,7 +16,7 @@ using namespace vpd;
 TEST(DdimmVpdParserTest, GoodTestCase)
 {
     types::DdimmVpdMap l_ddimmMap{
-        std::pair<std::string, size_t>{"MemorySizeInKB", 0x4000000},
+        std::pair<std::string, size_t>{"MemorySizeInKB", 0x2000000},
         std::pair<std::string, types::BinaryVector>{
             "FN", {0x30, 0x33, 0x48, 0x44, 0x37, 0x30, 0x30}},
         std::pair<std::string, types::BinaryVector>{


### PR DESCRIPTION
This commits the code to fix compilation error by using constants namespace wherever its members being used in the DdimmVpdParser class.