### PR TITLE
DDIMM:VINI interface is not populated wholly

### DIFF
--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -616,7 +616,8 @@ void Worker::populateKwdVPDpropertyMap(const types::KeywordVpdMap& keyordVPDMap,
 
         if (!propertyValueMap.empty())
         {
-            interfaceMap.emplace(constants::kwdVpdInf, move(propertyValueMap));
+            vpdSpecificUtility::insertOrMerge(
+                interfaceMap, constants::kwdVpdInf, move(propertyValueMap));
         }
     }
 }


### PR DESCRIPTION
This commit addresses the issue where properties of VINI interface of keyword VPD types are not completely populated on D-bus.
This is because of calling map.emplace() multiple
times with the same key, which contradicts the map.emplace 's property where it inserts the element only if the key is unique.

Test:
Tested that the properties are not wrapped and completely populated on D-bus.

Change-Id: Id2b7046b230c2966338ac7bd835d09789ef20d86