### PR TITLE
Fix BackupAndRestore unnecessarily invoked twice

### DIFF
--- a/include/backup_restore.hpp
+++ b/include/backup_restore.hpp
@@ -10,14 +10,11 @@ namespace vpd
 {
 
 // Backup and restore operation status.
-enum BackupAndRestoreStatus
+enum class BackupAndRestoreStatus : uint8_t
 {
-    NotStarted = 0,
-    Instantiated = 1,
-    InstantiationFailed = 2,
-    Invoked = 3,
-    InvokeFailed = 4,
-    Completed = 5
+    NotStarted,
+    Invoked,
+    Completed
 };
 
 /**

--- a/src/backup_restore.cpp
+++ b/src/backup_restore.cpp
@@ -22,11 +22,9 @@ BackupAndRestore::BackupAndRestore(const nlohmann::json& i_sysCfgJsonObj) :
     {
         m_backupAndRestoreCfgJsonObj =
             jsonUtility::getParsedJson(l_backupAndRestoreCfgFilePath);
-        m_backupAndRestoreStatus = BackupAndRestoreStatus::Instantiated;
     }
     catch (const std::exception& ex)
     {
-        m_backupAndRestoreStatus = BackupAndRestoreStatus::InstantiationFailed;
         logging::logMessage(
             "Failed to intialize backup and restore object for file = " +
             l_backupAndRestoreCfgFilePath);
@@ -138,7 +136,6 @@ std::tuple<types::VPDMapVariant, types::VPDMapVariant>
     }
     catch (const std::exception& ex)
     {
-        m_backupAndRestoreStatus = BackupAndRestoreStatus::InvokeFailed;
         logging::logMessage("Back up and restore failed with exception: " +
                             std::string(ex.what()));
     }

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1432,6 +1432,9 @@ void Worker::performBackupAndRestore(types::VPDMapVariant& io_srcVpdMap)
         nlohmann::json l_backupAndRestoreCfgJsonObj =
             jsonUtility::getParsedJson(l_backupAndRestoreCfgFilePath);
 
+        // check if either of "source" or "destination" has inventory path.
+        // this indicates that this sytem has System VPD on hardware
+        // and other copy on D-Bus (BMC cache).
         if (!l_backupAndRestoreCfgJsonObj.empty() &&
             ((l_backupAndRestoreCfgJsonObj.contains("source") &&
               l_backupAndRestoreCfgJsonObj["source"].contains(


### PR DESCRIPTION
Issue:

BackupAndRestore should be triggered only once in a flow. In the following scenario, BackupAndRestore is getting invoked twice:

1. Ensure Chassis is powered off, flash a bitbaked image on BMC and reboot.
2. After genesis boot, symlink is created and correct device tree is selected, vpd-manager.service triggers a reboot.
3. After BMC boots up, vpd-manager collects System VPD and publishes it on D-Bus.
4. Now restart vpd-manager.service.
5. From logs, observe that BackupAndRestore is invoked twice:
	1. Once after System VPD collection, and before publishing System VPD 
	2. Once after all FRUs are done collected
6. This issue happened because of incorrect value assignment of m_backupAndRestoreStatus variable.

This commit fixes the above issue. This commit also refactors BackupAndRestoreStatus from plain enum to a safer enum class type, and removes unused enumerations.

Test:

1. Recreate above scenario and see that BackupAndRestore is invoked only once : before publishing System VPD. Check for log "Backup and restore invoked already".
2. rm -rf /var/lib/phosphor-inventory-manager/xyz/openbmc_project/ inventory/system/chassis/motherboard 
3. Restart xyz.openbmc_project.Inventory.Manager 
4. Now System VPD is not on D-Bus. 
5. Restart vpd-manager.service and see that BackupAndRestore is invoked only once : after collection of all FRUs is complete.

Change-Id: I255ac2e9101267d4e2ca240ac30d31a8f5c1fb5b