### PR TITLE
vpd-tool: Enable write keyword option

### DIFF
--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -8,25 +8,36 @@
 
 int main(int argc, char** argv)
 {
-    int l_rc = -1;
+    int l_rc = vpd::constants::FAILURE;
     CLI::App l_app{"VPD Command Line Tool"};
 
     std::string l_vpdPath{};
     std::string l_recordName{};
     std::string l_keywordName{};
     std::string l_filePath{};
+    std::string l_keywordValue{};
 
     l_app.footer(
         "Read:\n"
         "    IPZ Format:\n"
-        "        From dbus to console: "
+        "        From DBus to console: "
         "vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
-        "        From dbus to file: "
-        "vpd-tool -r -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "        From DBus to file: "
+        "vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
         "        From hardware to console: "
-        "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name>\n"
         "        From hardware to file: "
-        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "Write:\n"
+        "    IPZ Format:\n"
+        "        On DBus: "
+        "vpd-tool -w -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
+        "        On DBus, take keyword value from file:\n"
+        "              vpd-tool -w -O <DBus Object Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "        On hardware: "
+        "vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
+        "        On hardware, take keyword value from file:\n"
+        "              vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
 
     auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
                                            "File path");
@@ -38,13 +49,27 @@ int main(int argc, char** argv)
     auto l_fileOption = l_app.add_option("--file", l_filePath,
                                          "Absolute file path");
 
+    auto l_keywordValueOption =
+        l_app.add_option("--value, -V", l_keywordValue,
+                         "Keyword value in ascii/hex format."
+                         " ascii ex: 01234; hex ex: 0x30313233");
+
+    auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
+                                         "CAUTION: Developer only option.");
+
     auto l_readFlag = l_app.add_flag("--readKeyword, -r", "Read keyword")
                           ->needs(l_objectOption)
                           ->needs(l_recordOption)
                           ->needs(l_keywordOption);
 
-    auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
-                                         "CAUTION: Developer only option.");
+    auto l_writeFlag =
+        l_app
+            .add_flag(
+                "--writeKeyword, -w",
+                "Write keyword, Note: Irrespective of DBus or hardware path provided, primary and backup, redundant EEPROM(if any) paths will get updated with given key value")
+            ->needs(l_objectOption)
+            ->needs(l_recordOption)
+            ->needs(l_keywordOption);
 
     // ToDo: Take offset value from user for hardware path.
 
@@ -72,8 +97,6 @@ int main(int argc, char** argv)
         return l_rc;
     }
 
-    (void)l_fileOption;
-
     if (!l_readFlag->empty())
     {
         std::error_code l_ec;
@@ -99,6 +122,61 @@ int main(int argc, char** argv)
 
         l_rc = l_vpdToolObj.readKeyword(l_vpdPath, l_recordName, l_keywordName,
                                         l_isHardwareOperation, l_filePath);
+    }
+    else if (!l_writeFlag->empty())
+    {
+        std::error_code l_ec;
+
+        if (!l_hardwareFlag->empty() &&
+            !std::filesystem::exists(l_vpdPath, l_ec))
+        {
+            std::cerr << "Given EEPROM file path doesn't exist : " + l_vpdPath
+                      << std::endl;
+            return l_rc;
+        }
+        if (l_ec)
+        {
+            std::cerr << "filesystem call exists failed for file: " << l_vpdPath
+                      << ", reason: " + l_ec.message() << std::endl;
+            return l_rc;
+        }
+
+        if (!l_fileOption->empty() &&
+            !std::filesystem::exists(l_filePath, l_ec))
+        {
+            std::cerr
+                << "File doesn't exists: " << l_filePath
+                << "\nPlease provide a valid absolute file path which has keyword value.\nUse --value/--file to give "
+                   "keyword value. Refer --help."
+                << std::endl;
+            return l_rc;
+        }
+        if (l_ec)
+        {
+            std::cerr << "filesystem call exists failed for file: "
+                      << l_filePath << ", reason: " + l_ec.message()
+                      << std::endl;
+            return l_rc;
+        }
+
+        if (!l_keywordValueOption->empty() && l_keywordValue.empty())
+        {
+            std::cerr
+                << "Please provide keyword value.\nUse --value/--file to give "
+                   "keyword value. Refer --help."
+                << std::endl;
+            return l_rc;
+        }
+        else if (l_fileOption->empty() && l_keywordValueOption->empty())
+        {
+            std::cerr
+                << "Please provide keyword value.\nUse --value/--file to give "
+                   "keyword value. Refer --help."
+                << std::endl;
+            return l_rc;
+        }
+
+        // ToDo: implementation of write keyword
     }
     else
     {


### PR DESCRIPTION
This commit adds code to enable write keyword value option for vpd-tool application.

Result:
‘’’
root@rain104bmctest:/tmp# ./vpd-tool
VPD Command Line Tool
Usage: ./vpd-tool [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -O,--object TEXT            File path
  -R,--record TEXT            Record name
  -K,--keyword TEXT           Keyword name
  --file TEXT                 Absolute file path
  -r,--readKeyword Needs: --object --record --keyword
                              Read keyword
  -w,--writeKeyword Needs: --object --record --keyword
                              Write keyword
  -V,--value TEXT             Keyword value in ascii/hex format. ascii ex: 01234; hex ex: 0x30313233
  -H,--Hardware               CAUTION: Developer only option.

Read:
    IPZ Format:
        From dbus to console: vpd-tool -r -O <DBus Object Path> -R <Record Name> -K <Keyword Name>
        From dbus to file: vpd-tool -r -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>
        From hardware to console: vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>
        From hardware to file: vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>
Write:
    IPZ Format:
        On dbus: vpd-tool -w -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>
        On dbus, Take keyword value from file:
              vpd-tool -w -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>
        On hardware: vpd-tool -w -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>
        On hardware, Take keyword value from file:
              vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>
'''