### PR TITLE
Implement vpd-tool dump inventory

### DIFF
--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -14,5 +14,10 @@ constexpr auto inventoryManagerService =
     "xyz.openbmc_project.Inventory.Manager";
 constexpr auto baseInventoryPath = "/xyz/openbmc_project/inventory";
 constexpr auto ipzVpdInfPrefix = "com.ibm.ipzvpd.";
+constexpr auto ipzVpdInf = "com.ibm.ipzvpd.";
+constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
+constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
+constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
+constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -8,6 +8,11 @@ namespace constants
 {
 static constexpr auto KEYWORD_SIZE = 2;
 static constexpr auto RECORD_SIZE = 4;
+static constexpr auto INDENTATION = 4;
 
+constexpr auto inventoryManagerService =
+    "xyz.openbmc_project.Inventory.Manager";
+constexpr auto baseInventoryPath = "/xyz/openbmc_project/inventory";
+constexpr auto ipzVpdInfPrefix = "com.ibm.ipzvpd.";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_json_utility.hpp
+++ b/vpd-tool/include/tool_json_utility.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+
+namespace vpd
+{
+namespace jsonUtility
+{
+
+/**
+ * @brief API to parse respective JSON.
+ *
+ * Exception is thrown in case of JSON parse error.
+ *
+ * @param[in] pathToJson - Path to JSON.
+ * @return Parsed JSON.
+ * @throw std::runtime_error
+ */
+inline nlohmann::json getParsedJson(const std::string& pathToJson)
+{
+    if (pathToJson.empty())
+    {
+        throw std::runtime_error("Path to JSON is missing");
+    }
+
+    if (!std::filesystem::exists(pathToJson) ||
+        std::filesystem::is_empty(pathToJson))
+    {
+        throw std::runtime_error("Incorrect File Path or empty file");
+    }
+
+    std::ifstream jsonFile(pathToJson);
+    if (!jsonFile)
+    {
+        throw std::runtime_error("Failed to access Json path = " + pathToJson);
+    }
+
+    try
+    {
+        return nlohmann::json::parse(jsonFile);
+    }
+    catch (const nlohmann::json::parse_error& e)
+    {
+        throw std::runtime_error("Failed to parse JSON file");
+    }
+}
+
+} // namespace jsonUtility
+} // namespace vpd

--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <sdbusplus/message/types.hpp>
+
+#include <cstdint>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+namespace vpd
+{
+namespace types
+{
+using BinaryVector = std::vector<uint8_t>;
+
+// This covers mostly all the data type supported over DBus for a property.
+// clang-format off
+using DbusVariantType = std::variant<
+    std::vector<std::tuple<std::string, std::string, std::string>>,
+    std::vector<std::string>,
+    std::vector<double>,
+    std::string,
+    int64_t,
+    uint64_t,
+    double,
+    int32_t,
+    uint32_t,
+    int16_t,
+    uint16_t,
+    uint8_t,
+    bool,
+    BinaryVector,
+    std::vector<uint32_t>,
+    std::vector<uint16_t>,
+    sdbusplus::message::object_path,
+    std::tuple<uint64_t, std::vector<std::tuple<std::string, std::string, double, uint64_t>>>,
+    std::vector<std::tuple<std::string, std::string>>,
+    std::vector<std::tuple<uint32_t, std::vector<uint32_t>>>,
+    std::vector<std::tuple<uint32_t, size_t>>,
+    std::vector<std::tuple<sdbusplus::message::object_path, std::string,
+                           std::string, std::string>>
+ >;
+} // namespace types
+} // namespace vpd

--- a/vpd-tool/include/utils.hpp
+++ b/vpd-tool/include/utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tool_constants.hpp"
 #include "tool_types.hpp"
 
 #include <nlohmann/json.hpp>

--- a/vpd-tool/include/utils.hpp
+++ b/vpd-tool/include/utils.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "tool_types.hpp"
+
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/exception.hpp>
+
+#include <iostream>
+
+namespace vpd
+{
+namespace utils
+{
+/**
+ * @brief An API to read property from Dbus.
+ *
+ * API reads the property value for the specified interface and object path from
+ * the given Dbus service.
+ *
+ * The caller of the API needs to validate the validity and correctness of the
+ * type and value of data returned. The API will just fetch and return the data
+ * without any data validation.
+ *
+ * Note: It will be caller's responsibility to check for empty value returned
+ * and generate appropriate error if required.
+ *
+ * @param[in] i_serviceName - Name of the Dbus service.
+ * @param[in] i_objectPath - Object path under the service.
+ * @param[in] i_interface - Interface under which property exist.
+ * @param[in] i_property - Property whose value is to be read.
+ *
+ * @return - Value read from Dbus, if success.
+ *           If failed, empty variant.
+ */
+inline types::DbusVariantType readDbusProperty(const std::string& i_serviceName,
+                                               const std::string& i_objectPath,
+                                               const std::string& i_interface,
+                                               const std::string& i_property)
+{
+    types::DbusVariantType l_propertyValue;
+
+    // Mandatory fields to make a dbus call.
+    if (i_serviceName.empty() || i_objectPath.empty() || i_interface.empty() ||
+        i_property.empty())
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cout << "One of the parameter to make Dbus read call is empty."
+                  << std::endl;*/
+        return l_propertyValue;
+    }
+
+    try
+    {
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call(i_serviceName.c_str(), i_objectPath.c_str(),
+                                  "org.freedesktop.DBus.Properties", "Get");
+        l_method.append(i_interface, i_property);
+
+        auto result = l_bus.call(l_method);
+        result.read(l_propertyValue);
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cout << std::string(l_ex.what()) << std::endl;
+    }
+    return l_propertyValue;
+}
+
+/**
+ * @brief An API to print json data on stdout.
+ *
+ * @param[in] i_jsonData - JSON object.
+ */
+inline void printJson(const nlohmann::json& i_jsonData)
+{
+    try
+    {
+        std::cout << i_jsonData.dump(constants::INDENTATION) << std::endl;
+    }
+    catch (const nlohmann::json::type_error& l_ex)
+    {
+        throw std::runtime_error("Failed to dump JSON data, error: " +
+                                 std::string(l_ex.what()));
+    }
+}
+
+/**
+ * @brief An API to convert hex value to string.
+ *
+ * If given data contains printable characters, ASCII formated string value of
+ * the input data will be returned. Otherwise if the data has any non-printable
+ * value, returns the hex represented value of the given data in string format.
+ *
+ * @param[in] i_keywordValue - Data in hex.
+ *
+ * @throw - Throws std::bad_alloc or std::terminate in case of error.
+ *
+ * @return - Returns the converted string value.
+ */
+inline std::string getPrintableValue(const types::BinaryVector& i_keywordValue)
+{
+    bool l_allPrintable =
+        std::all_of(i_keywordValue.begin(), i_keywordValue.end(),
+                    [](const auto& l_byte) { return std::isprint(l_byte); });
+
+    std::ostringstream l_oss;
+    if (l_allPrintable)
+    {
+        l_oss << std::string(i_keywordValue.begin(), i_keywordValue.end());
+    }
+    else
+    {
+        l_oss << "0x";
+        for (const auto& l_byte : i_keywordValue)
+        {
+            l_oss << std::setfill('0') << std::setw(2) << std::hex
+                  << static_cast<int>(l_byte);
+        }
+    }
+
+    return l_oss.str();
+}
+} // namespace utils
+} // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utils.hpp"
+
 #include <string>
 
 namespace vpd
@@ -17,6 +19,44 @@ namespace vpd
  */
 class VpdTool
 {
+    /**
+     * @brief Get any Inventory Propery in JSON.
+     *
+     * API to get any property of a FRU in JSON format.
+     *
+     * @param[in] i_objectPath - DBus object path
+     *
+     * @param[in] i_interface - Interface name
+     *
+     * @param[in] i_propertyName - Property name
+     *
+     * @return On success, returns the property and its value in JSON format,
+     * otherwise return empty JSON.
+     * {"SN" : "ABCD"}
+     *
+     * @throw Does not throw
+     */
+    template <typename PropertyType>
+    nlohmann::json getInventoryPropertyJson(
+        const std::string& i_objectPath, const std::string& i_interface,
+        const std::string& i_propertyName) const noexcept;
+
+    /**
+     * @brief Get VINI properties.
+     *
+     * API to get properties [SN, PN, CC, FN, DR] under VINI interface in JSON
+     * format.
+     *
+     * @param[in] i_fruPath - DBus object path.
+     *
+     * @return On success, returns JSON output with the above properties under
+     * VINI interface, otherwise returns empty JSON.
+     *
+     * @throw Does not throw.
+     */
+    nlohmann::json
+        getVINIPropertiesJson(const std::string& i_fruPath) const noexcept;
+
   public:
     /**
      * @brief Read keyword value.
@@ -39,5 +79,22 @@ class VpdTool
                     const std::string& i_recordName,
                     const std::string& i_keywordName, const bool i_onHardware,
                     const std::string& i_fileToSave = {});
+
+    /**
+     * @brief Dump the given inventory object in JSON format.
+     *
+     * For a given Object Path of a FRU, this API dumps the following properties
+     * of the FRU in JSON format:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     *
+     * @param[in] i_fruPath - DBus object path.
+     *
+     * @param[in] io_resultJson - JSON object which holds the result.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int dumpObject(const std::string& i_fruPath,
+                   nlohmann::json& io_resultJson) const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -96,5 +96,17 @@ class VpdTool
      */
     int dumpObject(const std::string& i_fruPath,
                    nlohmann::json& io_resultJson) const noexcept;
+
+    /**
+     * @brief Dump all the objects in Inventory in JSON format.
+     *
+     * This API dumps the following properties
+     * of all the FRUs in the Inventory in JSON format:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int dumpInventory() const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -8,6 +8,11 @@ endif
 sdbusplus = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
 dependency_list = [CLI11_dep, sdbusplus]
 
+conf_data = configuration_data()
+conf_data.set_quoted('INVENTORY_JSON_SYM_LINK', get_option('INVENTORY_JSON_SYM_LINK'))
+configure_file(output: 'config.h',
+            configuration : conf_data)
+
 sources = ['src/vpd_tool_main.cpp',
             'src/vpd_tool.cpp']
 

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -5,7 +5,8 @@ else
     CLI11_dep = dependency('CLI11')
 endif
 
-dependency_list = [CLI11_dep]
+sdbusplus = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
+dependency_list = [CLI11_dep, sdbusplus]
 
 sources = ['src/vpd_tool_main.cpp',
             'src/vpd_tool.cpp']

--- a/vpd-tool/meson.options
+++ b/vpd-tool/meson.options
@@ -1,0 +1,1 @@
+option('INVENTORY_JSON_SYM_LINK', type: 'string', value: '/var/lib/vpd/vpd_inventory.json',  description: 'Symbolic link to vpd inventory json.')

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -1,5 +1,11 @@
 #include "vpd_tool.hpp"
 
+#include "tool_constants.hpp"
+#include "tool_types.hpp"
+#include "utils.hpp"
+
+#include <iostream>
+
 namespace vpd
 {
 int VpdTool::readKeyword(const std::string& i_fruPath,
@@ -8,13 +14,60 @@ int VpdTool::readKeyword(const std::string& i_fruPath,
                          const bool i_onHardware,
                          const std::string& i_fileToSave)
 {
-    // ToDo: Need to add implementation details
-    (void)i_fruPath;
-    (void)i_recordName;
-    (void)i_keywordName;
-    (void)i_onHardware;
-    (void)i_fileToSave;
+    int l_rc = -1;
+    try
+    {
+        types::DbusVariantType l_keywordValue;
+        if (i_onHardware)
+        {
+            // TODO: Implement read keyword's value from hardware
+        }
+        else
+        {
+            std::string l_inventoryObjectPath(constants::baseInventoryPath +
+                                              i_fruPath);
 
-    return 0;
+            l_keywordValue = utils::readDbusProperty(
+                constants::inventoryManagerService, l_inventoryObjectPath,
+                constants::ipzVpdInfPrefix + i_recordName, i_keywordName);
+        }
+
+        if (const auto l_value =
+                std::get_if<types::BinaryVector>(&l_keywordValue))
+        {
+            const std::string& l_keywordStrValue =
+                utils::getPrintableValue(*l_value);
+
+            if (i_fileToSave.empty())
+            {
+                nlohmann::json l_resultInJson = nlohmann::json::object({});
+                nlohmann::json l_keywordValInJson = nlohmann::json::object({});
+
+                l_keywordValInJson.emplace(i_keywordName, l_keywordStrValue);
+                l_resultInJson.emplace(i_fruPath, l_keywordValInJson);
+
+                utils::printJson(l_resultInJson);
+            }
+            else
+            {
+                // TODO: Write result to a given file path.
+            }
+            l_rc = 0;
+        }
+        else
+        {
+            // TODO: Enable logging when verbose is enabled.
+            // std::cout << "Invalid data type received." << std::endl;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cerr << "Read keyword's value for FRU path: " << i_fruPath
+                  << ", Record: " << i_recordName
+                  << ", Keyword: " << i_keywordName
+                  << ", failed with exception: " << l_ex.what() << std::endl;*/
+    }
+    return l_rc;
 }
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -1,4 +1,5 @@
 #include "tool_constants.hpp"
+#include "vpd_tool.hpp"
 
 #include <CLI/CLI.hpp>
 
@@ -47,19 +48,21 @@ int main(int argc, char** argv)
 
     CLI11_PARSE(l_app, argc, argv);
 
-    if (*l_objectOption && l_vpdPath.empty())
+    if ((l_objectOption->count() > 0) && l_vpdPath.empty())
     {
         std::cout << "Given path is empty." << std::endl;
-        return -1;
+        return l_rc;
     }
 
-    if (*l_recordOption && (l_recordName.size() != vpd::constants::RECORD_SIZE))
+    if ((l_recordOption->count() > 0) &&
+        (l_recordName.size() != vpd::constants::RECORD_SIZE))
     {
         std::cerr << "Record " << l_recordName << " is not supported."
                   << std::endl;
+        return l_rc;
     }
 
-    if (*l_keywordOption &&
+    if ((l_keywordOption->count() > 0) &&
         (l_keywordName.size() != vpd::constants::KEYWORD_SIZE))
     {
         std::cerr << "Keyword " << l_keywordName << " is not supported."
@@ -67,18 +70,24 @@ int main(int argc, char** argv)
         return l_rc;
     }
 
-    if (*l_hardwareFlag && !std::filesystem::exists(l_vpdPath))
-    {
-        std::cerr << "Given EEPROM file path doesn't exist : " + l_vpdPath
-                  << std::endl;
-        return l_rc;
-    }
-
     (void)l_fileOption;
 
-    if (*l_readFlag)
+    if (l_readFlag->count() > 0)
     {
-        // TODO: call read keyword implementation from here.
+        if ((l_hardwareFlag->count() > 0) &&
+            !std::filesystem::exists(l_vpdPath))
+        {
+            std::cerr << "Given EEPROM file path doesn't exist : " + l_vpdPath
+                      << std::endl;
+            return l_rc;
+        }
+
+        bool l_isHardwareOperation = ((l_hardwareFlag->count() > 0) ? true
+                                                                    : false);
+        vpd::VpdTool l_vpdToolObj;
+
+        l_rc = l_vpdToolObj.readKeyword(l_vpdPath, l_recordName, l_keywordName,
+                                        l_isHardwareOperation, l_filePath);
     }
     else
     {

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -26,8 +26,8 @@ int main(int argc, char** argv)
         "        From hardware to console: "
         "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
         "        From hardware to file: "
-        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>"
-        "Dump Object:\n"
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "\nDump Object:\n"
         "        From DBus to console: "
         "vpd-tool --dumpObject/-o --object/-O <DBus Object Path>");
 
@@ -51,6 +51,9 @@ int main(int argc, char** argv)
 
     auto l_dumpObjFlag = l_app.add_flag("--dumpObject, -o", "Dump Object")
                              ->needs(l_objectOption);
+
+    auto l_dumpInventoryFlag = l_app.add_flag("--dumpInventory, -i",
+                                              "Dump inventory");
 
     CLI11_PARSE(l_app, argc, argv);
 
@@ -109,6 +112,11 @@ int main(int argc, char** argv)
                 vpd::utils::printJson(l_resultInJson);
             }
         }
+    }
+    else if (*l_dumpInventoryFlag)
+    {
+        vpd::VpdTool l_vpdToolObj;
+        l_rc = l_vpdToolObj.dumpInventory();
     }
     else
     {

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -26,7 +26,10 @@ int main(int argc, char** argv)
         "        From hardware to console: "
         "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
         "        From hardware to file: "
-        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>"
+        "Dump Object:\n"
+        "        From DBus to console: "
+        "vpd-tool --dumpObject/-o --object/-O <DBus Object Path>");
 
     auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
                                            "File path");
@@ -45,6 +48,9 @@ int main(int argc, char** argv)
 
     auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
                                          "CAUTION: Developer only option.");
+
+    auto l_dumpObjFlag = l_app.add_flag("--dumpObject, -o", "Dump Object")
+                             ->needs(l_objectOption);
 
     CLI11_PARSE(l_app, argc, argv);
 
@@ -88,6 +94,21 @@ int main(int argc, char** argv)
 
         l_rc = l_vpdToolObj.readKeyword(l_vpdPath, l_recordName, l_keywordName,
                                         l_isHardwareOperation, l_filePath);
+    }
+    else if (l_dumpObjFlag->count() > 0)
+    {
+        if (l_objectOption->count() > 0)
+        {
+            vpd::VpdTool l_vpdToolObj;
+
+            nlohmann::json l_resultInJson = nlohmann::json::array({});
+            l_rc = l_vpdToolObj.dumpObject(l_vpdPath, l_resultInJson);
+
+            if (0 == l_rc)
+            {
+                vpd::utils::printJson(l_resultInJson);
+            }
+        }
     }
     else
     {


### PR DESCRIPTION

This commit implements dump inventory functionality in vpd-tool.
 Dump inventory option in vpd-tool is used to dump the following
 properties of all the FRUs in the inventory JSON, in JSON format
 to the console:
    
    - Present property, Pretty Name, Location Code, Sub Model
    - SN, PN, CC, FN, DR keywords under VINI record.
    
    Test:
    
    Tested on a rainier2s2u system with two binaries:
    1. old vpd-tool copied from another system.
    2. vpd-tool is the new binary from this commit
    
    '''
    root@valid-hostname:/tmp/sr# ./vpd-tool -i  > ./newInvDump.json
    
    root@valid-hostname:/tmp/sr# ./old-vpd-tool -i > ./oldInvDump.json
    
    Compare both JSON files and see that both have 339 FRU entries with
    following properties populated:
    - Present property, Pretty Name, Location Code, Sub Model
    - SN, PN, CC, FN, DR keywords under VINI record.
    '''
[newVpdToolDumpInv.json](https://github.com/user-attachments/files/17844194/newVpdToolDumpInv.json)
[oldInvDump.json](https://github.com/user-attachments/files/17844196/oldInvDump.json)

<img width="1306" alt="Screenshot 2024-11-21 at 2 55 48 PM" src="https://github.com/user-attachments/assets/ace3a998-8a2c-48fe-ac2c-1a5755bec2fd">
