### PR TITLE
Add support for replaceableAtRuntime flag

### DIFF
--- a/configuration/ibm/50001000.json
+++ b/configuration/ibm/50001000.json
@@ -1099,6 +1099,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtRuntime": true,
                 "pollingRequired": {
                     "hotPlugging": {
                         "gpioPresence": {
@@ -1853,7 +1854,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -1939,7 +1940,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2025,7 +2026,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2108,7 +2109,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2262,7 +2263,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2305,7 +2306,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2341,7 +2342,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2384,7 +2385,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2427,7 +2428,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2539,7 +2540,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2582,7 +2583,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2727,7 +2728,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2764,7 +2765,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2801,7 +2802,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2838,7 +2839,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2875,7 +2876,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2912,7 +2913,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2949,7 +2950,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2986,7 +2987,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3176,7 +3177,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3212,7 +3213,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3248,7 +3249,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3284,7 +3285,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3320,7 +3321,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3356,7 +3357,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3392,7 +3393,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3428,7 +3429,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {

--- a/configuration/ibm/50001000_v2.json
+++ b/configuration/ibm/50001000_v2.json
@@ -1121,6 +1121,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtRuntime": true,
                 "pollingRequired": {
                     "hotPlugging": {
                         "gpioPresence": {
@@ -1877,7 +1878,7 @@
                 "pcaChipAddress": "20-0060",
                 "replaceableAtStandby": true,
 
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -1967,7 +1968,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2057,7 +2058,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2147,7 +2148,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2305,7 +2306,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2352,7 +2353,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2392,7 +2393,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2439,7 +2440,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2486,7 +2487,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2603,7 +2604,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "pcaChipAddress": "21-0061",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2650,7 +2651,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2799,7 +2800,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2836,7 +2837,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2873,7 +2874,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2910,7 +2911,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2947,7 +2948,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2984,7 +2985,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3021,7 +3022,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3058,7 +3059,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3249,7 +3250,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3286,7 +3287,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3323,7 +3324,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3360,7 +3361,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3397,7 +3398,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3434,7 +3435,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3471,7 +3472,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -3508,7 +3509,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {

--- a/configuration/ibm/50001001.json
+++ b/configuration/ibm/50001001.json
@@ -945,6 +945,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtRuntime": true,
                 "pollingRequired": {
                     "hotPlugging": {
                         "gpioPresence": {
@@ -1699,7 +1700,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -1785,7 +1786,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -1871,7 +1872,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -1957,7 +1958,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2111,7 +2112,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2154,7 +2155,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2190,7 +2191,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2233,7 +2234,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2276,7 +2277,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2388,7 +2389,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2431,7 +2432,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtStandby": true,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "setGpio": {
@@ -2576,7 +2577,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2613,7 +2614,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2650,7 +2651,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2687,7 +2688,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2824,7 +2825,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2861,7 +2862,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2898,7 +2899,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2935,7 +2936,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {

--- a/configuration/ibm/50001001_v2.json
+++ b/configuration/ibm/50001001_v2.json
@@ -951,6 +951,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
+                "replaceableAtRuntime": true,
                 "devAddress": "7-0051",
                 "driverType": "at24",
                 "busType": "i2c",
@@ -1697,7 +1698,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT0_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -1775,7 +1776,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT3_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -1853,7 +1854,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT4_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -1931,7 +1932,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT10_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2077,7 +2078,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT2_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2119,7 +2120,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT6_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2155,7 +2156,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT7_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2198,7 +2199,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT9_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2241,7 +2242,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT11_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2353,7 +2354,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT1_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2396,7 +2397,7 @@
                 "replaceableAtStandby": true,
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "presence": {
                     "pin": "SLOT8_EXPANDER_PRSNT_N",
                     "value": 0,
@@ -2540,7 +2541,7 @@
                 "devAddress": "13-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2577,7 +2578,7 @@
                 "devAddress": "13-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2614,7 +2615,7 @@
                 "devAddress": "13-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2651,7 +2652,7 @@
                 "devAddress": "13-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2788,7 +2789,7 @@
                 "devAddress": "14-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2825,7 +2826,7 @@
                 "devAddress": "14-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2862,7 +2863,7 @@
                 "devAddress": "14-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2899,7 +2900,7 @@
                 "devAddress": "14-0050",
                 "busType": "i2c",
                 "driverType": "at24",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {

--- a/configuration/ibm/50003000.json
+++ b/configuration/ibm/50003000.json
@@ -2466,7 +2466,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2503,7 +2503,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2540,7 +2540,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2577,7 +2577,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2614,7 +2614,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2651,7 +2651,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2688,7 +2688,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2725,7 +2725,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2762,7 +2762,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2799,7 +2799,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2846,7 +2846,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "essentialFru": true,
                 "preAction": {
                     "collection": {
@@ -2871,7 +2871,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "essentialFru": true,
                 "preAction": {
                     "collection": {
@@ -2897,7 +2897,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2919,7 +2919,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2941,7 +2941,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2962,7 +2962,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "handlePresence": false,
                 "preAction": {
                     "collection": {
@@ -2985,7 +2985,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3073,7 +3073,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3163,7 +3163,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3253,7 +3253,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3343,7 +3343,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3433,7 +3433,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3480,7 +3480,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3570,7 +3570,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3660,7 +3660,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3707,7 +3707,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3797,7 +3797,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {

--- a/configuration/ibm/50003000_v2.json
+++ b/configuration/ibm/50003000_v2.json
@@ -2338,7 +2338,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2375,7 +2375,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2412,7 +2412,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2449,7 +2449,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2486,7 +2486,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2523,7 +2523,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2560,7 +2560,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2597,7 +2597,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2634,7 +2634,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2671,7 +2671,7 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "inherit": false,
                 "embedded": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.PCIeDevice": null,
                     "com.ibm.ipzvpd.Location": {
@@ -2718,7 +2718,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "essentialFru": true,
                 "preAction": {
                     "collection": {
@@ -2743,7 +2743,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "essentialFru": true,
                 "preAction": {
                     "collection": {
@@ -2769,7 +2769,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2791,7 +2791,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2813,7 +2813,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2834,7 +2834,7 @@
             {
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "handlePresence": false,
                 "preAction": {
                     "collection": {
@@ -2857,7 +2857,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -2945,7 +2945,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3035,7 +3035,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3125,7 +3125,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3215,7 +3215,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3305,7 +3305,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3352,7 +3352,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3442,7 +3442,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3532,7 +3532,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3579,7 +3579,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {
@@ -3669,7 +3669,7 @@
                 "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11",
                 "replaceableAtStandby": true,
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
-                "concurrentlyMaintainable": true,
+                "replaceableAtRuntime": true,
                 "preAction": {
                     "collection": {
                         "gpioPresence": {

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -150,6 +150,9 @@ constexpr auto systemVpdInvPath =
 constexpr auto assetTagInf = "xyz.openbmc_project.Inventory.Decorator.AssetTag";
 constexpr auto hostObjectPath = "/xyz/openbmc_project/state/host0";
 constexpr auto hostInterface = "xyz.openbmc_project.State.Host";
+constexpr auto hostService = "xyz.openbmc_project.State.Host";
+constexpr auto hostRunningState =
+    "xyz.openbmc_project.State.Host.HostState.Running";
 static constexpr auto BD_YEAR_END = 4;
 static constexpr auto BD_MONTH_END = 7;
 static constexpr auto BD_DAY_END = 10;

--- a/include/manager.hpp
+++ b/include/manager.hpp
@@ -89,9 +89,9 @@ class Manager
 
     /**
      * @brief Collect single FRU VPD
-     * API can be used to perform VPD collection for the given FRU.
-     * The FRU should have concurrentlyMaintainable flag set to true in VPD JSON
-     * to execute this action.
+     * API can be used to perform VPD collection for the given FRU, only if the
+     * current state of the system matches with the state at which the FRU is
+     * allowed for VPD recollection.
      *
      * @param[in] i_dbusObjPath - D-bus object path
      */
@@ -268,6 +268,9 @@ class Manager
 
     // Shared pointer to GpioMonitor class
     std::shared_ptr<GpioMonitor> m_gpioMonitor;
+
+    // Variable to hold current collection status
+    std::string m_vpdCollectionStatus = "NotStarted";
 };
 
 } // namespace vpd

--- a/include/utility/dbus_utility.hpp
+++ b/include/utility/dbus_utility.hpp
@@ -366,5 +366,55 @@ inline bool isChassisPowerOn()
     */
     return false;
 }
+
+/**
+ * @brief API to check if host is in running state.
+ *
+ * This API reads the current host state from D-bus and returns true if the host
+ * is running.
+ *
+ * @return true if host is in running state. false otherwise.
+ */
+inline bool isHostRunning()
+{
+    const auto l_hostState = dbusUtility::readDbusProperty(
+        constants::hostService, constants::hostObjectPath,
+        constants::hostInterface, "CurrentHostState");
+
+    if (const auto l_currHostState = std::get_if<std::string>(&l_hostState))
+    {
+        if (*l_currHostState == constants::hostRunningState)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief API to check if BMC is in ready state.
+ *
+ * This API reads the current state of BMC from D-bus and returns true if BMC is
+ * in ready state.
+ *
+ * @return true if BMC is ready, false otherwise.
+ */
+inline bool isBMCReady()
+{
+    const auto l_bmcState = dbusUtility::readDbusProperty(
+        constants::bmcStateService, constants::bmcZeroStateObject,
+        constants::bmcStateInterface, constants::currentBMCStateProperty);
+
+    if (const auto l_currBMCState = std::get_if<std::string>(&l_bmcState))
+    {
+        if (*l_currBMCState == constants::bmcReadyState)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
 } // namespace dbusUtility
 } // namespace vpd

--- a/include/utility/json_utility.hpp
+++ b/include/utility/json_utility.hpp
@@ -930,5 +930,78 @@ inline bool isFruPowerOffOnly(const nlohmann::json& i_sysCfgJsonObj,
             (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0)["powerOffOnly"]));
 }
 
+/**
+ * @brief API which tells if the FRU is replaceable at runtime
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
+ * @param[in] i_vpdFruPath - EEPROM path.
+ *
+ * @return true if FRU is replaceable at runtime. false otherwise.
+ */
+inline bool isFruReplaceableAtRuntime(const nlohmann::json& i_sysCfgJsonObj,
+                                      const std::string& i_vpdFruPath)
+{
+    try
+    {
+        if (i_vpdFruPath.empty())
+        {
+            throw std::runtime_error("Given FRU path is empty.");
+        }
+
+        if (i_sysCfgJsonObj.empty() || (!i_sysCfgJsonObj.contains("frus")))
+        {
+            throw std::runtime_error("Invalid system config JSON object.");
+        }
+
+        return ((i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0))
+                    .contains("replaceableAtRuntime") &&
+                (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(
+                    0)["replaceableAtRuntime"]));
+    }
+    catch (const std::exception& l_error)
+    {
+        // TODO: Log PEL
+        logging::logMessage(l_error.what());
+    }
+
+    return false;
+}
+
+/**
+ * @brief API which tells if the FRU is replaceable at standby
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
+ * @param[in] i_vpdFruPath - EEPROM path.
+ *
+ * @return true if FRU is replaceable at standby. false otherwise.
+ */
+inline bool isFruReplaceableAtStandby(const nlohmann::json& i_sysCfgJsonObj,
+                                      const std::string& i_vpdFruPath)
+{
+    try
+    {
+        if (i_vpdFruPath.empty())
+        {
+            throw std::runtime_error("Given FRU path is empty.");
+        }
+
+        if (i_sysCfgJsonObj.empty() || (!i_sysCfgJsonObj.contains("frus")))
+        {
+            throw std::runtime_error("Invalid system config JSON object.");
+        }
+
+        return ((i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0))
+                    .contains("replaceableAtStandby") &&
+                (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(
+                    0)["replaceableAtStandby"]));
+    }
+    catch (const std::exception& l_error)
+    {
+        // TODO: Log PEL
+        logging::logMessage(l_error.what());
+    }
+
+    return false;
+}
 } // namespace jsonUtility
 } // namespace vpd


### PR DESCRIPTION
This commit modifies the JSON property name from
concurrentlyMaintainable to isVPDRecollectableAtRuntime for those FRUs which are replaceable at runtime.

This commit also adds the check in vpd-manager SingleFRUCollect API to allow single FRU VPD collection based on the JSON property added.

Test:
1. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager CollectFRUVPD o
"/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26"

>>LOGS:
Single FRU VPD recollection not allowed for
/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26

2. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager CollectFRUVPD o
"/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2"

>>LOGS:
VPD parsing failed for /sys/bus/i2c/drivers/at24/4-0052/eeprom due to error: Could not find file path
/sys/bus/i2c/drivers/at24/4-0052/eeprom
Skipping parser trigger for the EEPROM

3. busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager CollectFRUVPD o
"/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10"

>>LOGS:Setting GPIO: SLOT10_PRSNT_EN_RSVD to 1
Command = echo 11-0050 > /sys/bus/i2c/drivers/at24/bind sh: line 1: echo: write error: Device or resource busy IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/11-0050/eeprom No match found for CCIN

Change-Id: Ib5526bcbc09ae91c1546fb1649ab5931e64ca076