### PR TITLE
Implement vpd-tool dumpObject stub

### DIFF
--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -23,5 +23,9 @@ constexpr auto ipzVpdInfPrefix = "com.ibm.ipzvpd.";
 constexpr auto vpdManagerService = "com.ibm.VPD.Manager";
 constexpr auto vpdManagerObjectPath = "/com/ibm/VPD/Manager";
 constexpr auto vpdManagerInfName = "com.ibm.VPD.Manager";
+constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
+constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
+constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
+constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
+
 #include <string>
 
 namespace vpd
@@ -17,6 +19,25 @@ namespace vpd
  */
 class VpdTool
 {
+  private:
+    /**
+     * @brief Get specific properties of a FRU in JSON format.
+     *
+     * For a given object path of a FRU, this API returns the following
+     * properties of the FRU in JSON format:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     *
+     * @param[in] i_fruPath - DBus object path
+     *
+     * @return On success, returns the properties of the FRU in JSON format,
+     * otherwise throws a std::runtime_error exception.
+     * Note: The caller of this API should handle this exception.
+     *
+     * @throw std::runtime_error
+     */
+    nlohmann::json getFruProperties(const std::string& i_fruPath) const;
+
   public:
     /**
      * @brief Read keyword value.
@@ -39,5 +60,19 @@ class VpdTool
                     const std::string& i_recordName,
                     const std::string& i_keywordName, const bool i_onHardware,
                     const std::string& i_fileToSave = {});
+
+    /**
+     * @brief Dump the given inventory object in JSON format to console.
+     *
+     * For a given object path of a FRU, this API dumps the following properties
+     * of the FRU in JSON format to console:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     *
+     * @param[in] i_fruPath - DBus object path.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int dumpObject(const std::string& i_fruPath) const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -85,4 +85,33 @@ int VpdTool::readKeyword(const std::string& i_vpdPath,
     }
     return l_rc;
 }
+
+int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
+{
+    int l_rc{constants::FAILURE};
+    try
+    {
+        const nlohmann::json l_resultJson = getFruProperties(i_fruPath);
+
+        utils::printJson(l_resultJson);
+        l_rc = constants::SUCCESS;
+    }
+    catch (std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cerr << "Dump Object failed for FRU: " << i_fruPath
+        //           << " Error: " << l_ex.what() << std::endl;
+    }
+    return l_rc;
+}
+
+nlohmann::json VpdTool::getFruProperties(const std::string& i_fruPath) const
+{
+    nlohmann::json l_resultInJson = nlohmann::json::array({});
+
+    // TODO: Implement getFruProperties
+    (void)i_fruPath;
+    return l_resultInJson;
+}
+
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -37,7 +37,10 @@ int main(int argc, char** argv)
         "        On hardware: "
         "vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
         "        On hardware, take keyword value from file:\n"
-        "              vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+        "              vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "Dump Object:\n"
+        "    From DBus to console: "
+        "vpd-tool -o -O <DBus Object Path>");
 
     auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
                                            "File path");
@@ -70,6 +73,12 @@ int main(int argc, char** argv)
             ->needs(l_objectOption)
             ->needs(l_recordOption)
             ->needs(l_keywordOption);
+
+    auto l_dumpObjFlag =
+        l_app
+            .add_flag("--dumpObject, -o",
+                      "Dump specific properties of an inventory object")
+            ->needs(l_objectOption);
 
     // ToDo: Take offset value from user for hardware path.
 
@@ -177,6 +186,11 @@ int main(int argc, char** argv)
         }
 
         // ToDo: implementation of write keyword
+    }
+    else if (!l_dumpObjFlag->empty())
+    {
+        vpd::VpdTool l_vpdToolObj;
+        l_rc = l_vpdToolObj.dumpObject(l_vpdPath);
     }
     else
     {


### PR DESCRIPTION
This commit implements `vpd-tool --dumpObject` stub and some associated
    utility methods and constants for the same.
    This commit allows user to provide `--dumpObject` command line option to
    `vpd-tool`.
     
  For a given Object path, the object dump functionality prints the
  following properties in a JSON format to the console:
  1. Present property, Pretty Name, Location Code, Sub Model
  2. SN, PN, CC, FN, DR keywords under VINI record

    Note: This commit does not include actual implementation of
    `--dumpObject`.