### PR TITLE
Fix: Pretty Name not showing on bmc UI

### DIFF
--- a/include/utility/vpd_specific_utility.hpp
+++ b/include/utility/vpd_specific_utility.hpp
@@ -192,8 +192,21 @@ inline void insertOrMerge(types::InterfaceMap& map,
 {
     if (map.find(interface) != map.end())
     {
-        auto& prop = map.at(interface);
-        prop.insert(propertyMap.begin(), propertyMap.end());
+        try
+        {
+            auto& prop = map.at(interface);
+            std::for_each(propertyMap.begin(), propertyMap.end(),
+                          [&prop](auto l_keyValue) {
+                prop[l_keyValue.first] = l_keyValue.second;
+            });
+        }
+        catch (const std::exception& l_ex)
+        {
+            // ToDo:: Log PEL
+            logging::logMessage(
+                "Inserting properties into interface[" + interface +
+                "] map is failed, reason: " + std::string(l_ex.what()));
+        }
     }
     else
     {
@@ -371,7 +384,6 @@ inline void getVpdDataInVector(const std::string& vpdFilePath,
 }
 
 /**
-<<<<<<< HEAD
  * @brief An API to get D-bus representation of given VPD keyword.
  *
  * @param[in] i_keywordName - VPD keyword name.


### PR DESCRIPTION
For the defect 665516, where name of VRM and fabric adapters in inventory page is not coming correctly.

In insertOrMerge API insert call on std::map object was not overwriting properties value, if the property key is already found in the map. Which causing empty PrettyName value got published on the DBus. Hence bmc web was not showing correct prettyName for FRUs, who’s VPD collection is failed and prime inventory is called.

This commit has fix for the above issue. I tested the changes, observed name was showing correctly for VRM and fabric adapters on bmc web.