### PR TITLE
Implement vpd-tool object dump

### DIFF
--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -20,5 +20,9 @@ constexpr auto ipzVpdInfPrefix = "com.ibm.ipzvpd.";
 constexpr auto vpdManagerService = "com.ibm.VPD.Manager";
 constexpr auto vpdManagerObjectPath = "/com/ibm/VPD/Manager";
 constexpr auto vpdManagerInfName = "com.ibm.VPD.Manager";
+constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
+constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
+constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
+constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -24,5 +24,8 @@ constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
+constexpr auto powerSupplyInterface =
+    "xyz.openbmc_project.Inventory.Item.PowerSupply";
+constexpr auto fanInterface = "xyz.openbmc_project.Inventory.Item.Fan";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_json_utility.hpp
+++ b/vpd-tool/include/tool_json_utility.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+
+namespace vpd
+{
+namespace jsonUtility
+{
+
+/**
+ * @brief API to parse respective JSON.
+ *
+ * Exception is thrown in case of JSON parse error.
+ *
+ * @param[in] i_pathToJson - Path to JSON.
+ * @return Parsed JSON.
+ * @throw std::runtime_error
+ */
+inline nlohmann::json getParsedJson(const std::string& i_pathToJson)
+{
+    if (i_pathToJson.empty())
+    {
+        throw std::runtime_error("Path to JSON is missing");
+    }
+
+    try
+    {
+        if (!std::filesystem::exists(i_pathToJson) ||
+            std::filesystem::is_empty(i_pathToJson))
+        {
+            throw std::runtime_error("Incorrect File Path or empty file = " +
+                                     i_pathToJson);
+        }
+    }
+    catch (std::exception& l_ex)
+    {
+        throw std::runtime_error("Failed to check file path: " + i_pathToJson +
+                                 " Error: " + l_ex.what());
+    }
+
+    std::ifstream l_jsonFile(i_pathToJson);
+    if (!l_jsonFile)
+    {
+        throw std::runtime_error("Failed to access Json path = " +
+                                 i_pathToJson);
+    }
+
+    try
+    {
+        return nlohmann::json::parse(l_jsonFile);
+    }
+    catch (const nlohmann::json::parse_error& l_ex)
+    {
+        throw std::runtime_error("Failed to parse JSON file: " + i_pathToJson +
+                                 " Error: " + l_ex.what());
+    }
+}
+
+} // namespace jsonUtility
+} // namespace vpd

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tool_constants.hpp"
 #include "tool_types.hpp"
 
 #include <nlohmann/json.hpp>

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -75,6 +75,8 @@ inline types::DbusVariantType readDbusProperty(const std::string& i_serviceName,
  * @brief An API to print json data on stdout.
  *
  * @param[in] i_jsonData - JSON object.
+ *
+ * @throw std::runtime_error
  */
 inline void printJson(const nlohmann::json& i_jsonData)
 {

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "tool_utils.hpp"
+
 #include <nlohmann/json.hpp>
 
 #include <string>
@@ -29,7 +31,7 @@ class VpdTool
      * - SN, PN, CC, FN, DR keywords under VINI record.
      * - type and TYPE of the FRU
      *
-     * @param[in] i_fruPath - DBus object path
+     * @param[in] i_objectPath - DBus object path
      *
      * @return On success, returns the properties of the FRU in JSON format,
      * otherwise returns an empty JSON object.
@@ -38,7 +40,67 @@ class VpdTool
      *
      * @throw std::runtime_error
      */
-    nlohmann::json getFruPropertiesJson(const std::string& i_fruPath) const;
+    nlohmann::json getFruPropertiesJson(const std::string& i_objectPath) const;
+
+    /**
+     * @brief Get any Inventory Property in JSON.
+     *
+     * API to get any property of a FRU in JSON format. Given an object path,
+     * interface and property name, this API does a D-Bus read property on PIM
+     * to get the value of that property and returns it in JSON format. This API
+     * returns empty JSON in case of failure. The caller of the API must check
+     * for empty JSON.
+     *
+     * @param[in] i_objectPath - DBus object path
+     *
+     * @param[in] i_interface - Interface name
+     *
+     * @param[in] i_propertyName - Property name
+     *
+     * @return On success, returns the property and its value in JSON format,
+     * otherwise return empty JSON.
+     * {"SN" : "ABCD"}
+     */
+    template <typename PropertyType>
+    nlohmann::json getInventoryPropertyJson(
+        const std::string& i_objectPath, const std::string& i_interface,
+        const std::string& i_propertyName) const noexcept;
+
+    /**
+     * @brief API to get properties [SN, PN, CC, FN, DR] under VINI interface of
+     * PIM in JSON format.
+     *
+     * API to get properties [SN, PN, CC, FN, DR] under VINI interface in JSON
+     * format. Given an object path, this API does a D-Bus read property on PIM
+     * to get the value of properties [SN, PN, CC, FN, DR] under VINI interface
+     * and returns it in JSON format. This API returns empty JSON in case of
+     * failure. The caller of the API must check for empty JSON.
+     *
+     * @param[in] i_objectPath - DBus object path.
+     *
+     * @return On success, returns JSON output with the above properties under
+     * VINI interface, otherwise returns empty JSON.
+     */
+    nlohmann::json
+        getVINIPropertiesJson(const std::string& i_objectPath) const noexcept;
+
+    /**
+     * @brief Get the "type" and "TYPE" properties for a FRU.
+     *
+     * Given a FRU path, and parsed System Config JSON, this API returns the
+     * "type" and "TYPE" properties for the FRU in JSON format. This API gets
+     * these properties from the System Config JSON.
+     *
+     * @param[in] i_eepromPath - EEPROM path for a FRU.
+     * @param[in] i_sysConfigJson - Parsed System Config JSON.
+     *
+     * @return On success, returns the "TYPE" and "type" properties in JSON
+     * format. "type" property is emplaced only if the same is present in the
+     * System Config JSON. On failure, returns empty JSON.
+     */
+    nlohmann::json getFruTypeProperty(
+        const std::string& i_eepromPath,
+        const nlohmann::json& i_sysCfgJsonObj) const noexcept;
 
   public:
     /**

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
+
 #include <string>
 
 namespace vpd
@@ -17,6 +19,27 @@ namespace vpd
  */
 class VpdTool
 {
+  private:
+    /**
+     * @brief Get specific properties of a FRU in JSON format.
+     *
+     * For a given Object Path of a FRU, this API returns the following
+     * properties of the FRU in JSON format:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     * - type and TYPE of the FRU
+     *
+     * @param[in] i_fruPath - DBus object path
+     *
+     * @return On success, returns the properties of the FRU in JSON format,
+     * otherwise returns an empty JSON object.
+     * Note: The caller of this API should
+     * check for empty JSON object
+     *
+     * @throw std::runtime_error
+     */
+    nlohmann::json getFruPropertiesJson(const std::string& i_fruPath) const;
+
   public:
     /**
      * @brief Read keyword value.
@@ -39,5 +62,20 @@ class VpdTool
                     const std::string& i_recordName,
                     const std::string& i_keywordName, const bool i_onHardware,
                     const std::string& i_fileToSave = {});
+
+    /**
+     * @brief Dump the given inventory object in JSON format to console.
+     *
+     * For a given Object Path of a FRU, this API dumps the following properties
+     * of the FRU in JSON format to console:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     * - type and TYPE of the FRU
+     *
+     * @param[in] i_fruPath - DBus object path.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int dumpObject(const std::string& i_fruPath) const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -13,7 +13,7 @@ sources = ['src/vpd_tool_main.cpp',
 
 vpd_tool_exe = executable('vpd-tool',
                           sources,
-                          include_directories : ['include/'],
+                          include_directories : ['include/','../'],
                           dependencies: dependency_list,
                           install: true
                         )

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -1,6 +1,9 @@
+#include "config.h"
+
 #include "vpd_tool.hpp"
 
 #include "tool_constants.hpp"
+#include "tool_json_utility.hpp"
 #include "tool_types.hpp"
 #include "tool_utils.hpp"
 
@@ -74,4 +77,36 @@ int VpdTool::readKeyword(const std::string& i_vpdPath,
     }
     return l_rc;
 }
+
+int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
+{
+    int l_rc{constants::FAILURE};
+    try
+    {
+        const nlohmann::json l_resultJson = getFruPropertiesJson(i_fruPath);
+        if (!l_resultJson.empty())
+        {
+            utils::printJson(l_resultJson);
+            l_rc = constants::SUCCESS;
+        }
+    }
+    catch (std::exception& l_ex)
+    {
+        std::cerr << "Dump Object failed for FRU: " << i_fruPath
+                  << " Error: " << l_ex.what() << std::endl;
+    }
+    return l_rc;
+}
+
+nlohmann::json VpdTool::getFruPropertiesJson(const std::string& i_fruPath) const
+{
+    nlohmann::json l_resultInJson = nlohmann::json::array({});
+    const nlohmann::json& l_sysCfgJsonObj =
+        vpd::jsonUtility::getParsedJson(INVENTORY_JSON_SYM_LINK);
+    // TODO: Implement getFruPropertiesJson
+    (void)i_fruPath;
+    (void)l_sysCfgJsonObj;
+    return l_resultInJson;
+}
+
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -98,14 +98,213 @@ int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
     return l_rc;
 }
 
-nlohmann::json VpdTool::getFruPropertiesJson(const std::string& i_fruPath) const
+nlohmann::json
+    VpdTool::getFruPropertiesJson(const std::string& i_objectPath) const
 {
     nlohmann::json l_resultInJson = nlohmann::json::array({});
     const nlohmann::json& l_sysCfgJsonObj =
         vpd::jsonUtility::getParsedJson(INVENTORY_JSON_SYM_LINK);
-    // TODO: Implement getFruPropertiesJson
-    (void)i_fruPath;
-    (void)l_sysCfgJsonObj;
+
+    // validate the system config JSON.
+    if (!l_sysCfgJsonObj.contains("frus"))
+    {
+        throw std::runtime_error("System Config JSON is not valid");
+    }
+
+    std::string l_eepromPath{};
+    // get the EEPROM path for this object path
+    l_eepromPath = jsonUtility::getFruPathFromJson(l_sysCfgJsonObj,
+                                                   i_objectPath);
+
+    nlohmann::json l_fruJson = nlohmann::json::object_t({});
+    l_fruJson.emplace(i_objectPath, nlohmann::json::object_t({}));
+
+    auto& l_fruObject = l_fruJson[i_objectPath];
+
+    const auto l_presentPropertyInJson = getInventoryPropertyJson<bool>(
+        i_objectPath, constants::inventoryItemInf, "Present");
+    if (!l_presentPropertyInJson.empty())
+    {
+        l_fruObject.insert(l_presentPropertyInJson.cbegin(),
+                           l_presentPropertyInJson.cend());
+    }
+
+    const auto l_prettyNameInJson = getInventoryPropertyJson<std::string>(
+        i_objectPath, constants::inventoryItemInf, "PrettyName");
+    if (!l_prettyNameInJson.empty())
+    {
+        l_fruObject.insert(l_prettyNameInJson.cbegin(),
+                           l_prettyNameInJson.cend());
+    }
+
+    const auto l_locationCodeInJson = getInventoryPropertyJson<std::string>(
+        i_objectPath, constants::locationCodeInf, "LocationCode");
+    if (!l_locationCodeInJson.empty())
+    {
+        l_fruObject.insert(l_locationCodeInJson.cbegin(),
+                           l_locationCodeInJson.cend());
+    }
+
+    const auto l_subModelInJson = getInventoryPropertyJson<std::string>(
+        i_objectPath, constants::assetInf, "SubModel");
+
+    if (!l_subModelInJson.empty() &&
+        !l_subModelInJson.value("SubModel", "").empty())
+    {
+        l_fruObject.insert(l_subModelInJson.cbegin(), l_subModelInJson.cend());
+    }
+
+    const auto l_viniPropertiesInJson = getVINIPropertiesJson(i_objectPath);
+    if (!l_viniPropertiesInJson.empty())
+    {
+        l_fruObject.insert(l_viniPropertiesInJson.cbegin(),
+                           l_viniPropertiesInJson.cend());
+    }
+
+    const auto l_typePropertyJson = getFruTypeProperty(l_eepromPath,
+                                                       l_sysCfgJsonObj);
+    if (!l_typePropertyJson.empty())
+    {
+        l_fruObject.insert(l_typePropertyJson.cbegin(),
+                           l_typePropertyJson.cend());
+    }
+
+    if (l_resultInJson.empty())
+    {
+        l_resultInJson += l_fruJson;
+    }
+    else
+    {
+        l_resultInJson.at(0).insert(l_fruJson.cbegin(), l_fruJson.cend());
+    }
+    return l_resultInJson;
+}
+
+nlohmann::json VpdTool::getVINIPropertiesJson(
+    const std::string& i_objectPath) const noexcept
+{
+    nlohmann::json l_resultInJson = nlohmann::json::object({});
+
+    const std::array<std::string, 5> l_viniKeyWords{"SN", "PN", "CC", "FN",
+                                                    "DR"};
+
+    auto l_readKeyWord = [i_objectPath, &l_resultInJson,
+                          this](const std::string& i_keyWord) {
+        nlohmann::json l_keyWordJson =
+            getInventoryPropertyJson<vpd::types::BinaryVector>(
+                i_objectPath, constants::kwdVpdInf, i_keyWord);
+        l_resultInJson.insert(l_keyWordJson.cbegin(), l_keyWordJson.cend());
+    };
+
+    std::for_each(l_viniKeyWords.cbegin(), l_viniKeyWords.cend(),
+                  l_readKeyWord);
+    return l_resultInJson;
+}
+
+template <typename PropertyType>
+nlohmann::json VpdTool::getInventoryPropertyJson(
+    const std::string& i_objectPath, const std::string& i_interface,
+    const std::string& i_propertyName) const noexcept
+{
+    nlohmann::json l_resultInJson = nlohmann::json::object({});
+    try
+    {
+        types::DbusVariantType l_keyWordValue;
+
+        l_keyWordValue =
+            utils::readDbusProperty(constants::inventoryManagerService,
+                                    i_objectPath, i_interface, i_propertyName);
+
+        if (const auto l_value = std::get_if<PropertyType>(&l_keyWordValue))
+        {
+            if constexpr (std::is_same<PropertyType, std::string>::value)
+            {
+                l_resultInJson.emplace(i_propertyName, *l_value);
+            }
+            else if constexpr (std::is_same<PropertyType, bool>::value)
+            {
+                l_resultInJson.emplace(i_propertyName,
+                                       *l_value ? "true" : "false");
+            }
+            else if constexpr (std::is_same<PropertyType,
+                                            types::BinaryVector>::value)
+            {
+                const std::string& l_keywordStrValue =
+                    vpd::utils::getPrintableValue(*l_value);
+
+                l_resultInJson.emplace(i_propertyName, l_keywordStrValue);
+            }
+        }
+        else
+        {
+            // TODO: Enable logging when verbose is enabled.
+            // std::cout << "Invalid data type received." << std::endl;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cerr << "Read " << i_propertyName << " value for FRU path: " <<
+           i_objectPath
+                  << ", failed with exception: " << l_ex.what() << std::endl;*/
+    }
+    return l_resultInJson;
+}
+
+nlohmann::json VpdTool::getFruTypeProperty(
+    const std::string& i_eepromPath,
+    const nlohmann::json& i_sysCfgJsonObj) const noexcept
+{
+    nlohmann::json l_resultInJson = nlohmann::json::object({});
+
+    if (!i_sysCfgJsonObj.contains("frus") ||
+        !i_sysCfgJsonObj["frus"].contains(i_eepromPath))
+    {
+        return l_resultInJson;
+    }
+
+    const auto& l_fruObj = i_sysCfgJsonObj["frus"][i_eepromPath].at(0);
+
+    std::string l_fruType{"FRU"};
+
+    // check if our FRU has a "type" tag
+    if (l_fruObj.contains("type"))
+    {
+        l_fruType = l_fruObj.at("type");
+    }
+
+    l_resultInJson.emplace("TYPE", l_fruType);
+
+    if (l_fruObj.contains("inventoryPath"))
+    {
+        const std::string l_invPath = l_fruObj.at("inventoryPath");
+
+        if (l_invPath.find("powersupply") != std::string::npos)
+        {
+            l_resultInJson.emplace("type", constants::powerSupplyInterface);
+        }
+        else if (l_invPath.find("fan") != std::string::npos)
+        {
+            l_resultInJson.emplace("type", constants::fanInterface);
+        }
+        else
+        {
+            // get the "type" property from "extraInterfaces"
+            if (l_fruObj.contains("extraInterfaces"))
+            {
+                const auto& l_extraInfObj = l_fruObj["extraInterfaces"];
+
+                for (const auto& l_exProperty : l_extraInfObj.items())
+                {
+                    if (l_exProperty.key().find("Item") != std::string::npos &&
+                        l_exProperty.value().is_null())
+                    {
+                        l_resultInJson.emplace("type", l_exProperty.key());
+                    }
+                }
+            }
+        }
+    }
     return l_resultInJson;
 }
 

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -1,4 +1,6 @@
 #include "tool_constants.hpp"
+#include "tool_json_utility.hpp"
+#include "tool_utils.hpp"
 #include "vpd_tool.hpp"
 
 #include <CLI/CLI.hpp>
@@ -8,7 +10,7 @@
 
 int main(int argc, char** argv)
 {
-    int l_rc = -1;
+    int l_rc = vpd::constants::FAILURE;
     CLI::App l_app{"VPD Command Line Tool"};
 
     std::string l_vpdPath{};
@@ -26,7 +28,10 @@ int main(int argc, char** argv)
         "        From hardware to console: "
         "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
         "        From hardware to file: "
-        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "Dump Object:\n"
+        "    From dbus to console: "
+        "vpd-tool -o -O <DBus Object Path>");
 
     auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
                                            "File path");
@@ -45,6 +50,9 @@ int main(int argc, char** argv)
 
     auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
                                          "CAUTION: Developer only option.");
+
+    auto l_dumpObjFlag = l_app.add_flag("--dumpObject, -o", "Dump Object")
+                             ->needs(l_objectOption);
 
     // ToDo: Take offset value from user for hardware path.
 
@@ -99,6 +107,11 @@ int main(int argc, char** argv)
 
         l_rc = l_vpdToolObj.readKeyword(l_vpdPath, l_recordName, l_keywordName,
                                         l_isHardwareOperation, l_filePath);
+    }
+    else if (!l_dumpObjFlag->empty())
+    {
+        vpd::VpdTool l_vpdToolObj;
+        l_rc = l_vpdToolObj.dumpObject(l_vpdPath);
     }
     else
     {


### PR DESCRIPTION
 This commit implements object dump functionality in vpd-tool.
  For a given Object path, the object dump functionality prints the
    following properties in a JSON format to the console:
    1. Present property, Pretty Name, Location Code, Sub Model
    2. SN, PN, CC, FN, DR keywords under VINI record
    
    Test:
    Tested on a rainier2s2u system
    root@p10bmc:~# ./vpd-tool -o -O \
    /xyz/openbmc_project/inventory/system/chassis/motherboard
    [
        {
            "/xyz/openbmc_project/inventory/system/chassis/motherboard": {
                "CC": "2E2D",
                "DR": "SYSTEM BACKPLANE",
                "FN": "02WG676",
                "LocationCode": "U78DA.ND0.WZS0042-P0",
                "PN": "02WG678",
                "Present": "true",
                "PrettyName": "System backplane",
                "SN": "Y131UF07302T"
            }
        }
    ]
    
    root@p10bmc:~# ./vpd-tool -o -O \
    /xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0
    [
        {
            "/xyz/openbmc_project/inventory/
            system/chassis/motherboard/vdd_vrm0": {
                "CC": "2E32",
                "DR": "CPU POWER CARD  ",
                "FN": "02CM285",
                "LocationCode": "U78DA.ND0.WZS0042-P0-C14",
                "PN": "02CM286",
                "Present": "true",
                "PrettyName": "Voltage regulator module for
                    system processor module 0",
                "SN": "YH30A005M11C"
            }
        }
    ]

root@rain104bmctest:# ./vpd-tool -o -O "InvalidObjectPath"
    root@rain104bmctest:# echo $?
    255

Note: This commit does not include changes to add `"type"` and `"TYPE"` properties to the object dump. These will be added when inventory json is parsed by `vpd-tool`.

Screenshots below show old `vpd-tool --dumpObject` output vs. new `vpd-tool --dumpObject` output:

<img width="880" alt="Screenshot 2024-11-20 at 11 37 07 PM" src="https://github.com/user-attachments/assets/78648a8e-9138-4704-8b8f-1a5545d13d56">
<img width="963" alt="Screenshot 2024-11-20 at 11 38 46 PM" src="https://github.com/user-attachments/assets/5241557c-5bc4-4334-a56e-81303f61fec4">
