### PR TITLE
Implement vpd-tool mfgClean option

### DIFF
--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -16,5 +16,9 @@ constexpr auto inventoryManagerService =
     "xyz.openbmc_project.Inventory.Manager";
 constexpr auto baseInventoryPath = "/xyz/openbmc_project/inventory";
 constexpr auto ipzVpdInfPrefix = "com.ibm.ipzvpd.";
+
+constexpr auto vpdManagerService = "com.ibm.VPD.Manager";
+constexpr auto vpdManagerObjectPath = "/com/ibm/VPD/Manager";
+constexpr auto vpdManagerInfName = "com.ibm.VPD.Manager";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -20,5 +20,9 @@ constexpr auto ipzVpdInfPrefix = "com.ibm.ipzvpd.";
 constexpr auto vpdManagerService = "com.ibm.VPD.Manager";
 constexpr auto vpdManagerObjectPath = "/com/ibm/VPD/Manager";
 constexpr auto vpdManagerInfName = "com.ibm.VPD.Manager";
+constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
+constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
+constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
+constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -24,5 +24,8 @@ constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
+
+// To be explicitly used for string comparision.
+static constexpr auto STR_CMP_SUCCESS = 0;
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_json_utility.hpp
+++ b/vpd-tool/include/tool_json_utility.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+
+namespace vpd
+{
+namespace jsonUtility
+{
+
+/**
+ * @brief API to parse respective JSON.
+ *
+ * Exception is thrown in case of JSON parse error.
+ *
+ * @param[in] i_pathToJson - Path to JSON.
+ * @return Parsed JSON.
+ * @throw std::runtime_error
+ */
+inline nlohmann::json getParsedJson(const std::string& i_pathToJson)
+{
+    if (i_pathToJson.empty())
+    {
+        throw std::runtime_error("Path to JSON is missing");
+    }
+
+    if (!std::filesystem::exists(i_pathToJson) ||
+        std::filesystem::is_empty(i_pathToJson))
+    {
+        throw std::runtime_error("Incorrect File Path or empty file = " +
+                                 i_pathToJson);
+    }
+
+    std::ifstream jsonFile(i_pathToJson);
+    if (!jsonFile)
+    {
+        throw std::runtime_error("Failed to access Json path = " +
+                                 i_pathToJson);
+    }
+
+    try
+    {
+        return nlohmann::json::parse(jsonFile);
+    }
+    catch (const nlohmann::json::parse_error& e)
+    {
+        throw std::runtime_error("Failed to parse JSON file");
+    }
+}
+
+} // namespace jsonUtility
+} // namespace vpd

--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <tuple>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -52,5 +53,8 @@ using WriteVpdParams = std::variant<IpzData, KwData>;
 using IpzType = std::tuple<Record, Keyword>;
 using ReadVpdParams = std::variant<IpzType, Keyword>;
 
+using KeywordDefaultValue = BinaryVector;
+using MfgCleanKeywordMap = std::unordered_map<Keyword,KeywordDefaultValue>;
+using MfgCleanRecordMap = std::unordered_map<Record,MfgCleanKeywordMap>;
 } // namespace types
 } // namespace vpd

--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -40,5 +40,12 @@ using DbusVariantType = std::variant<
     std::vector<std::tuple<sdbusplus::message::object_path, std::string,
                            std::string, std::string>>
  >;
+
+//IpzType contains tuple of <Record, Keyword>
+using IpzType = std::tuple<std::string, std::string>;
+
+//ReadVpdParams either of IPZ or keyword format
+using ReadVpdParams = std::variant<IpzType, std::string>;
+
 } // namespace types
 } // namespace vpd

--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -41,11 +41,16 @@ using DbusVariantType = std::variant<
                            std::string, std::string>>
  >;
 
-//IpzType contains tuple of <Record, Keyword>
-using IpzType = std::tuple<std::string, std::string>;
 
-//ReadVpdParams either of IPZ or keyword format
-using ReadVpdParams = std::variant<IpzType, std::string>;
+using Record = std::string;
+using Keyword = std::string;
+
+using KwData = std::tuple<Keyword, BinaryVector>;
+using IpzData = std::tuple<Record, Keyword, BinaryVector>;
+using WriteVpdParams = std::variant<IpzData, KwData>;
+
+using IpzType = std::tuple<Record, Keyword>;
+using ReadVpdParams = std::variant<IpzType, Keyword>;
 
 } // namespace types
 } // namespace vpd

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -271,5 +271,35 @@ inline types::BinaryVector convertToBinary(const std::string& i_value)
     }
     return l_binaryValue;
 }
+
+/** @brief An API to compare two strings
+ *
+ * This API compares two strings. The comparison can be case sensitive or
+ * insensitive.
+ * @param[in] i_str1 - String 1
+ * @param[in] i_str2 - String 2
+ * @param[in] i_caseSensitive - Flag which indicates comparison should be case
+ * sensitive or not.
+ *
+ * @return true if strings are equal, false otherwise.
+ */
+inline bool equalStrings(const std::string& i_str1, const std::string& i_str2,
+                         const bool i_caseSensitive = true)
+{
+    const auto compareChar = [](const char i_ch1, const char i_ch2) {
+        return std::tolower(i_ch1) == std::tolower(i_ch2);
+    };
+
+    if (i_caseSensitive)
+    {
+        return i_str1.compare(i_str2) == constants::STR_CMP_SUCCESS;
+    }
+    else
+    {
+        return std::equal(i_str1.begin(), i_str1.end(), i_str2.begin(),
+                          i_str2.end(), compareChar);
+    }
+}
+
 } // namespace utils
 } // namespace vpd

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -125,5 +125,51 @@ inline std::string getPrintableValue(const types::BinaryVector& i_keywordValue)
 
     return l_oss.str();
 }
+
+/**
+ * @brief API to read keyword's value from hardware.
+ *
+ * This API reads keyword's value by requesting DBus service(vpd-manager) who
+ * hosts the 'ReadKeyword' method to read keyword's value.
+ *
+ * @param[in] i_eepromPath - EEPROM file path.
+ * @param[in] i_paramsToReadData - Property whose value has to be read.
+ *
+ * @return - Value read from Dbus
+ *
+ * @throw std::runtime_error
+ */
+inline types::DbusVariantType
+    readKeywordFromHardware(const std::string& i_eepromPath,
+                            const types::ReadVpdParams i_paramsToReadData)
+{
+    if (i_eepromPath.empty())
+    {
+        throw std::runtime_error("Empty EEPROM path");
+    }
+
+    try
+    {
+        types::DbusVariantType l_propertyValue;
+
+        auto l_bus = sdbusplus::bus::new_default();
+
+        auto l_method = l_bus.new_method_call(
+            std::string(constants::vpdManagerService).c_str(),
+            std::string(constants::vpdManagerObjectPath).c_str(),
+            std::string(constants::vpdManagerInfName).c_str(), "ReadKeyword");
+
+        l_method.append(i_eepromPath, i_paramsToReadData);
+        auto l_result = l_bus.call(l_method);
+
+        l_result.read(l_propertyValue);
+
+        return l_propertyValue;
+    }
+    catch (const sdbusplus::exception::SdBusError& l_error)
+    {
+        throw std::runtime_error(std::string(l_error.what()));
+    }
+}
 } // namespace utils
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -38,7 +38,7 @@ class VpdTool
     int readKeyword(const std::string& i_vpdPath,
                     const std::string& i_recordName,
                     const std::string& i_keywordName, const bool i_onHardware,
-                    const std::string& i_fileToSave = {});
+                    const std::string& i_fileToSave = {}) const noexcept;
 
     /**
      * @brief Write keyword's value.
@@ -64,7 +64,7 @@ class VpdTool
                      const std::string& i_recordName,
                      const std::string& i_keywordName,
                      const std::string& i_keywordValue, const bool i_onHardware,
-                     const std::string& i_filePath = {});
+                     const std::string& i_filePath = {}) const noexcept;
 
     /**
      * @brief Reset specific keywords on System VPD to default value.

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -39,5 +39,31 @@ class VpdTool
                     const std::string& i_recordName,
                     const std::string& i_keywordName, const bool i_onHardware,
                     const std::string& i_fileToSave = {});
+
+    /**
+     * @brief Write keyword's value.
+     *
+     * API to update VPD keyword's value to the given input path.
+     * If i_onHardware value in true, i_fruPath is considered has hardware path
+     * otherwise it will be considered as DBus object path.
+     *
+     * Regardless of given input path is primary path or secondary path,
+     * internally both paths will get updated with new keyword's value.
+     *
+     * @param[in] i_vpdPath - DBus object path or EEPROM path.
+     * @param[in] i_recordName - Record name.
+     * @param[in] i_keywordName - Keyword name.
+     * @param[in] i_keywordValue - Keyword value.
+     * @param[in] i_onHardware - True if i_vpdPath is EEPROM path, false
+     * otherwise.
+     * @param[in] i_filePath - File path to take keyword's value.
+     *
+     * @return On success return 0, otherwise return -1.
+     */
+    int writeKeyword(const std::string& i_vpdPath,
+                     const std::string& i_recordName,
+                     const std::string& i_keywordName,
+                     const std::string& i_keywordValue, const bool i_onHardware,
+                     const std::string& i_filePath = {});
 };
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -65,5 +65,22 @@ class VpdTool
                      const std::string& i_keywordName,
                      const std::string& i_keywordValue, const bool i_onHardware,
                      const std::string& i_filePath = {});
+
+    /**
+     * @brief Reset specific keywords on System VPD to default value.
+     *
+     * This API resets specific System VPD keywords to default value. The
+     * keyword values are reset on:
+     * 1. Primary EEPROM path.
+     * 2. Secondary EEPROM path.
+     * 3. D-Bus cache.
+     *
+     * @param[in] i_recordName - Record name.
+     * @param[in] i_keywordName - Keyword name.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int cleanSystemVpd(const std::string& i_recordName,
+                       const std::string& i_keywordName) const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -8,6 +8,11 @@ endif
 sdbusplus = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
 dependency_list = [CLI11_dep, sdbusplus]
 
+conf_data = configuration_data()
+conf_data.set_quoted('INVENTORY_JSON_SYM_LINK', get_option('INVENTORY_JSON_SYM_LINK'))
+configure_file(output: 'config.h',
+            configuration : conf_data)
+
 sources = ['src/vpd_tool_main.cpp',
             'src/vpd_tool.cpp']
 

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -10,6 +10,7 @@ dependency_list = [CLI11_dep, sdbusplus]
 
 conf_data = configuration_data()
 conf_data.set_quoted('INVENTORY_JSON_SYM_LINK', get_option('INVENTORY_JSON_SYM_LINK'))
+conf_data.set_quoted('SYSTEM_VPD_FILE_PATH', get_option('SYSTEM_VPD_FILE_PATH'))
 configure_file(output: 'config.h',
             configuration : conf_data)
 

--- a/vpd-tool/meson.options
+++ b/vpd-tool/meson.options
@@ -1,0 +1,1 @@
+option('INVENTORY_JSON_SYM_LINK', type: 'string', value: '/var/lib/vpd/vpd_inventory.json',  description: 'Symbolic link to vpd inventory json.')

--- a/vpd-tool/meson.options
+++ b/vpd-tool/meson.options
@@ -1,1 +1,2 @@
 option('INVENTORY_JSON_SYM_LINK', type: 'string', value: '/var/lib/vpd/vpd_inventory.json',  description: 'Symbolic link to vpd inventory json.')
+option('SYSTEM_VPD_FILE_PATH', type: 'string', value: '/sys/bus/i2c/drivers/at24/8-0050/eeprom',  description: 'EEPROM path of system VPD.')

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -5,6 +5,7 @@
 #include "tool_utils.hpp"
 
 #include <iostream>
+#include <tuple>
 
 namespace vpd
 {
@@ -71,6 +72,50 @@ int VpdTool::readKeyword(const std::string& i_vpdPath,
                   << ", Record: " << i_recordName
                   << ", Keyword: " << i_keywordName
                   << " is failed, exception: " << l_ex.what() << std::endl;*/
+    }
+    return l_rc;
+}
+
+int VpdTool::writeKeyword(const std::string& i_vpdPath,
+                          const std::string& i_recordName,
+                          const std::string& i_keywordName,
+                          const std::string& i_keywordValue,
+                          const bool i_onHardware,
+                          const std::string& i_filePath)
+{
+    int l_rc = -1;
+    try
+    {
+        if (i_vpdPath.empty() || i_recordName.empty() || i_keywordName.empty())
+        {
+            throw std::runtime_error("Received input is empty.");
+        }
+
+        if (!i_filePath.empty())
+        {
+            // ToDo: Take keyword value from the file
+        }
+
+        std::string l_vpdPath{i_vpdPath};
+        if (!i_onHardware)
+        {
+            l_vpdPath = constants::baseInventoryPath + i_vpdPath;
+        }
+
+        auto l_paramsToWrite =
+            std::make_tuple(i_recordName, i_keywordName,
+                            utils::convertToBinary(i_keywordValue));
+        l_rc = utils::writeKeyword(
+            constants::vpdManagerService, constants::vpdManagerObjectPath,
+            constants::vpdManagerInfName, l_vpdPath, l_paramsToWrite);
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cerr << "Write keyword's value for path: " << i_vpdPath
+                  << ", Record: " << i_recordName
+                  << ", Keyword: " << i_keywordName
+                  << " is failed. Exception: " << l_ex.what() << std::endl;*/
     }
     return l_rc;
 }

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -119,4 +119,47 @@ int VpdTool::writeKeyword(const std::string& i_vpdPath,
     }
     return l_rc;
 }
+
+int VpdTool::cleanSystemVpd(const std::string& i_recordName,
+                            const std::string& i_keywordName) const noexcept
+{
+    int l_rc{-1};
+
+    // Map of Keywords which can be reset by vpd-tool manufacturing clean
+    // option
+    // {Record1 : {{Keyword1, Default value1},{Keyword2, Default value2} }},
+    // {Record2 : {{Keyword1, Default value1},{Keyword2, Default value2} }}
+    static const types::MfgCleanRecordMap l_mfgCleanKeywordMap{
+        {"UTIL",
+         {{"D0", types::BinaryVector{1, 0x00}},
+          {"D1", types::BinaryVector{1, 0x00}},
+          {"F0", types::BinaryVector{8, 0x00}},
+          {"F5", types::BinaryVector{16, 0x00}},
+          {"F6", types::BinaryVector{16, 0x00}}}},
+        {"VSYS",
+         {{"BR", types::BinaryVector{2, 0x20}},
+          {"TM", types::BinaryVector{8, 0x20}},
+          {"RG", types::BinaryVector{4, 0x20}},
+          {"SE", types::BinaryVector{7, 0x20}},
+          {"SU", types::BinaryVector{6, 0x20}},
+          {"RB", types::BinaryVector{4, 0x20}},
+          {"WN", types::BinaryVector{12, 0x20}},
+          {"FV", types::BinaryVector{32, 0x20}}}},
+        {"VCEN", {{"SE", types::BinaryVector{7, 0x20}}}}};
+
+    /* TODO:
+        search l_recordName in map
+       search l_keywordName in map
+       get default value of l_keywordName
+       use readKeyword API to read hardware value from hardware
+       if hardware value != default value,
+        use writeKeyword API to update default value on hardware, backup and
+       D-Bus*/
+
+    (void)i_recordName;
+    (void)i_keywordName;
+
+    return l_rc;
+}
+
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -20,7 +20,8 @@ int VpdTool::readKeyword(const std::string& i_vpdPath,
         types::DbusVariantType l_keywordValue;
         if (i_onHardware)
         {
-            // TODO: Implement read keyword's value from hardware
+            l_keywordValue = utils::readKeywordFromHardware(
+                i_vpdPath, std::make_tuple(i_recordName, i_keywordName));
         }
         else
         {

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -157,7 +157,13 @@ int main(int argc, char** argv)
             return l_rc;
         }
 
-        // ToDo: implementation of write keyword
+        bool l_isHardwareOperation = ((l_hardwareFlag->count() > 0) ? true
+                                                                    : false);
+
+        vpd::VpdTool l_vpdToolObj;
+        l_vpdToolObj.writeKeyword(l_vpdPath, l_recordName, l_keywordName,
+                                  l_keywordValue, l_isHardwareOperation,
+                                  l_filePath);
     }
     else
     {

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -15,6 +15,7 @@ int main(int argc, char** argv)
     std::string l_recordName{};
     std::string l_keywordName{};
     std::string l_filePath{};
+    std::string l_keywordValue{};
 
     l_app.footer(
         "Read:\n"
@@ -26,7 +27,17 @@ int main(int argc, char** argv)
         "        From hardware to console: "
         "vpd-tool -r -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name>\n"
         "        From hardware to file: "
-        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
+        "vpd-tool -r -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "Write:\n"
+        "    IPZ Format:\n"
+        "        On dbus: "
+        "vpd-tool -w -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
+        "        On dbus, Take keyword value from file:\n"
+        "              vpd-tool -w -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "        On hardware: "
+        "vpd-tool -w -H -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
+        "        On hardware, Take keyword value from file:\n"
+        "              vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>");
 
     auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
                                            "File path");
@@ -38,13 +49,23 @@ int main(int argc, char** argv)
     auto l_fileOption = l_app.add_option("--file", l_filePath,
                                          "Absolute file path");
 
+    auto l_keywordValueOption =
+        l_app.add_option("--value, -V", l_keywordValue,
+                         "Keyword value in ascii/hex format."
+                         " ascii ex: 01234; hex ex: 0x30313233");
+
+    auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
+                                         "CAUTION: Developer only option.");
+
     auto l_readFlag = l_app.add_flag("--readKeyword, -r", "Read keyword")
                           ->needs(l_objectOption)
                           ->needs(l_recordOption)
                           ->needs(l_keywordOption);
 
-    auto l_hardwareFlag = l_app.add_flag("--Hardware, -H",
-                                         "CAUTION: Developer only option.");
+    auto l_writeFlag = l_app.add_flag("--writeKeyword, -w", "Write keyword")
+                           ->needs(l_objectOption)
+                           ->needs(l_recordOption)
+                           ->needs(l_keywordOption);
 
     // ToDo: Take offset value from user for hardware path.
 
@@ -99,6 +120,44 @@ int main(int argc, char** argv)
 
         l_rc = l_vpdToolObj.readKeyword(l_vpdPath, l_recordName, l_keywordName,
                                         l_isHardwareOperation, l_filePath);
+    }
+    else if (l_writeFlag->count() > 0)
+    {
+        if ((l_hardwareFlag->count() > 0) &&
+            !std::filesystem::exists(l_vpdPath))
+        {
+            std::cerr << "Given EEPROM file path doesn't exist : " + l_vpdPath
+                      << std::endl;
+            return l_rc;
+        }
+
+        if ((l_fileOption->count() > 0) && !std::filesystem::exists(l_filePath))
+        {
+            std::cerr
+                << "Please provide a valid absolute file path which has keyword value.\nUse --value/--file to give "
+                   "keyword value. Refer --help."
+                << std::endl;
+            return l_rc;
+        }
+        else if ((l_keywordValueOption->count() > 0) && l_keywordValue.empty())
+        {
+            std::cerr
+                << "Please provide keyword value.\nUse --value/--file to give "
+                   "keyword value. Refer --help."
+                << std::endl;
+            return l_rc;
+        }
+        else if ((l_fileOption->count() == 0) &&
+                 (l_keywordValueOption->count() == 0))
+        {
+            std::cerr
+                << "Please provide keyword value.\nUse --value/--file to give "
+                   "keyword value. Refer --help."
+                << std::endl;
+            return l_rc;
+        }
+
+        // ToDo: implementation of write keyword
     }
     else
     {


### PR DESCRIPTION
This commit implements vpd-tool --mfgClean option.
    This API resets specific System VPD keywords to default value.
    The specified keyword values are reset on:
      - Primary EEPROM path.
      - Redundant EEPROM path(if any)
      - D-Bus cache.
      - 
The specific System VPD keywords are maintained as a static read only
    map in the code.
