### PR TITLE
Add Reboot Guard in Parser updateVpdKeyword API

### DIFF
--- a/vpd-manager/include/constants.hpp
+++ b/vpd-manager/include/constants.hpp
@@ -187,5 +187,10 @@ static constexpr auto eventLoggingServiceName = "xyz.openbmc_project.Logging";
 static constexpr auto eventLoggingObjectPath = "/xyz/openbmc_project/logging";
 static constexpr auto eventLoggingInterface =
     "xyz.openbmc_project.Logging.Create";
+
+static constexpr auto systemdService = "org.freedesktop.systemd1";
+static constexpr auto systemdObjectPath = "/org/freedesktop/systemd1";
+static constexpr auto systemdManagerInterface =
+    "org.freedesktop.systemd1.Manager";
 } // namespace constants
 } // namespace vpd


### PR DESCRIPTION
BMC Reboot Guard needs to be enabled before any write to hardware
operation, to prevent data or ECC corruption.
Reboot Guard needs to stay enabled until following steps are all 
complete:
1. Write keyword value to Primary EEPROM
2. Update keyword value to PIM(D-Bus)
3. Write keyword value on redundant EEPROM(if any)

This commit adds Enable Reboot Guard and Disable Reboot Guard API calls
to Parser's updateVpdKeyword public API.

Test:
    
    '''
    1. Use WriteKeyword API to update an IPZ Keyword:
    
    root@p10bmc:~# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager
    com.ibm.VPD.Manager WriteKeyword sv
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ssay\) "UTIL" "D0" 1 0
    i 1
    
    2. Immediately execute a "reboot" command from another terminal and see
       that the "reboot" command fails with following error:
       "Failed to talk to init daemon: Interrupted system call"
    
    3. Observe journal log:
    
    Dec 10 06:00:35 p10bmc systemd[1]: Starting Enable a guard that blocks
    BMC reboot...
    Dec 10 06:00:35 p10bmc systemd[1]: reboot-guard-enable.service:
    Deactivated successfully.
    Dec 10 06:00:35 p10bmc systemd[1]: Finished Enable a guard that blocks
    BMC reboot.
    Dec 10 06:00:37 p10bmc vpd-manager[1051]: FileName:
    /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/
    parser_factory.cpp, Line: 113, Func: static
    std::shared_ptr<vpd::ParserInterface>
    vpd::ParserFactory::getParser(const vpd::types::BinaryVector&, const
    std::string&, size_t), IPZ parser selected for VPD file path
    /sys/bus/i2c/drivers/at24/8-0050/eeprom
    Dec 10 06:00:37 p10bmc vpd-manager[1051]: FileName:
    /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/ipz_parser.cpp,
    Line: 832, Func: virtual int vpd::IpzVpdParser::writeKeywordOnHardware
    (vpd::types::WriteVpdParams), 1 bytes updated successfully on hardware
    for UTIL:D0
    Dec 10 06:00:38 p10bmc vpd-manager[1051]: FileName:
    /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/
    parser_factory.cpp, Line: 113, Func: static
    std::shared_ptr<vpd::ParserInterface> vpd::ParserFactory::
    getParser(const vpd::types::BinaryVector&, const std::string&, size_t),
    IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/8-0050/eeprom
    Dec 10 06:00:38 p10bmc vpd-manager[1051]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/src/parser.cpp, Line: 109, Func:
    int vpd::Parser::updateVpdKeyword(const vpd::types::WriteVpdParams&),
    Performing VPD read on /sys/bus/i2c/drivers/at24/8-0050/eeprom
    Dec 10 06:00:38 p10bmc systemd[1]: Starting Removes the guard that
    blocks BMC reboot...
    Dec 10 06:00:39 p10bmc systemd[1]: reboot-guard-disable.service:
    Deactivated successfully.
    Dec 10 06:00:39 p10bmc systemd[1]: Finished Removes the guard that
    blocks BMC reboot.
    
    4. Use ReadKeyword API to verify that the Keyword was
       successfully updated:
    
    busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager
    ReadKeyword sv "/sys/bus/i2c/drivers/at24/8-0050/eeprom" \(ss\) "UTIL" "D0"
    v ay 1 0
   5. Execute a "reboot" command and see that it succeeds.

6. Test the Re-try logic:
       Change the Disable Reboot Guard DBus call so that it fails.
    
       Now do a WriteKeyword API call and observe journal log:
    
    Dec 13 13:48:13 p10bmc systemd[1]: Starting Enable a guard that
    blocks BMC reboot...
    Dec 13 13:48:13 p10bmc systemd[1]: reboot-guard-enable.service:
    Deactivated successfully.
    Dec 13 13:48:13 p10bmc systemd[1]: Finished Enable a guard that blocks
    BMC reboot.
    Dec 13 13:48:14 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/src/parser_factory.cpp, Line: 113
    IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/8-0050/
    eeprom
    Dec 13 13:48:14 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/src/ipz_parser.cpp, Line: 832 1
    bytes updated successfully on hardware for UTIL:D0
    Dec 13 13:48:15 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/src/parser_factory.cpp, Line: 113
    IPZ parser selected for VPD file path /sys/bus/i2c/drivers/at24/8-0050/eeprom
    Dec 13 13:48:15 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/src/parser.cpp, Line: 117
    Performing VPD read on /sys/bus/i2c/drivers/at24/8-0050/eeprom
    Dec 13 13:48:15 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/include/utility/dbus_utility.hpp,
    Line: 537 Disable Reboot Guard retry : 0
    Dec 13 13:48:16 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/include/utility/dbus_utility.hpp,
    Line: 537 Disable Reboot Guard retry : 1
    Dec 13 13:48:17 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/include/utility/dbus_utility.hpp,
    Line: 537 Disable Reboot Guard retry : 2
    Dec 13 13:48:18 p10bmc vpd-manager[1057]: FileName: /usr/src/debug/
    openpower-fru-vpd/1.0+git/vpd-manager/include/utility/dbus_utility.hpp,
    Line: 556 Failed to Disable Reboot Guard

'''
