### PR TITLE
Increase retries for collection status

### DIFF
--- a/vpd-manager/src/manager.cpp
+++ b/vpd-manager/src/manager.cpp
@@ -224,7 +224,9 @@ void Manager::SetTimerToDetectSVPDOnDbus()
 
 void Manager::SetTimerToDetectVpdCollectionStatus()
 {
-    static constexpr auto MAX_RETRY = 5;
+    // Keeping max retry for 2 minutes. TODO: Make it cinfigurable based on
+    // system type.
+    static constexpr auto MAX_RETRY = 40;
 
     static boost::asio::steady_timer l_timer(*m_ioContext);
     static uint8_t l_timerRetry = 0;

--- a/vpd-manager/src/worker.cpp
+++ b/vpd-manager/src/worker.cpp
@@ -1502,6 +1502,9 @@ void Worker::collectFrusFromJson()
 
             if (!m_activeCollectionThreadCount)
             {
+                logging::logMessage(
+                    "Active threads = " +
+                    std::to_string(m_activeCollectionThreadCount));
                 m_isAllFruCollected = true;
             }
             else


### PR DESCRIPTION
The number of retries has been increased to wait max 2 minutes for VPD collection of all the FRUs.
It is just a large number selected for now, will be made configurable based on system types in future.