### PR TITLE
vpd-manager:Check for essential FRUs

### DIFF
--- a/vpd-manager/include/manager.hpp
+++ b/vpd-manager/include/manager.hpp
@@ -231,6 +231,14 @@ class Manager
      * @param[in] i_msg - The callback message.
      */
     void processAssetTagChangeCallback(sdbusplus::message_t& i_msg);
+
+    /**
+     * @brief API to check the presence of essential FRUs.
+     *
+     * This API is to check if the FRUs' which are essential are present on the
+     * system. If not present, PEL is logged.
+     */
+    void checkEssentialFrus();
 #endif
 
     /**

--- a/vpd-manager/include/types.hpp
+++ b/vpd-manager/include/types.hpp
@@ -188,5 +188,6 @@ enum ErrorType
 using InventoryCalloutData = std::tuple<std::string, CalloutPriority>;
 using DeviceCalloutData = std::tuple<std::string, std::string>;
 using I2cBusCalloutData = std::tuple<std::string, std::string, std::string>;
+using MapOfObjectsToService = std::unordered_map<std::string, std::string>;
 } // namespace types
 } // namespace vpd

--- a/vpd-manager/include/utility/json_utility.hpp
+++ b/vpd-manager/include/utility/json_utility.hpp
@@ -1049,5 +1049,48 @@ inline std::vector<std::string>
     return l_frusReplaceableAtStandby;
 }
 
+/**
+ * @brief API to get D-bus object paths of all essential FRUs.
+ *
+ * This API is to get the D-bus object paths of FRUs marked as "essentialFru" in
+ * system config JSON along with the service name in which the object paths are
+ * hosted.
+ *
+ * @param[in] i_sysCfgJsonObj - System config JSON object.
+ * @param[out] o_essentialFrus - Map to store essential FRUs object paths and
+ * the service.
+ */
+inline void
+    getEssentialFruObjects(const nlohmann::json& i_sysCfgJsonObj,
+                           types::MapOfObjectsToService& o_essentialFrus)
+{
+    if (i_sysCfgJsonObj.empty() || !i_sysCfgJsonObj.contains("frus"))
+    {
+        logging::logMessage(
+            "System config JSON object is empty/Missing frus section.");
+        return;
+    }
+
+    const nlohmann::json& l_fruList =
+        i_sysCfgJsonObj["frus"].get_ref<const nlohmann::json::object_t&>();
+
+    for (const auto& l_fru : l_fruList.items())
+    {
+        if (i_sysCfgJsonObj["frus"][l_fru.key()].at(0).contains(
+                "essentialFru") &&
+            i_sysCfgJsonObj["frus"][l_fru.key()].at(0)["essentialFru"])
+        {
+            if (i_sysCfgJsonObj["frus"][l_fru.key()].at(0).contains(
+                    "inventoryPath") &&
+                i_sysCfgJsonObj["frus"][l_fru.key()].at(0).contains(
+                    "serviceName"))
+            {
+                o_essentialFrus.emplace(
+                    i_sysCfgJsonObj["frus"][l_fru.key()].at(0)["inventoryPath"],
+                    i_sysCfgJsonObj["frus"][l_fru.key()].at(0)["serviceName"]);
+            }
+        }
+    }
+}
 } // namespace jsonUtility
 } // namespace vpd

--- a/vpd-manager/src/manager.cpp
+++ b/vpd-manager/src/manager.cpp
@@ -795,7 +795,8 @@ void Manager::hostStateChangeCallBack(sdbusplus::message_t& i_msg)
             if (*l_hostState == "xyz.openbmc_project.State.Host.HostState."
                                 "TransitioningToRunning")
             {
-                // TODO: check for all the essential FRUs in the system.
+                // check for all the essential FRUs in the system.
+                checkEssentialFrus();
 
                 // Perform recollection.
                 performVpdRecollection();
@@ -851,6 +852,47 @@ void Manager::performVpdRecollection()
         // TODO Log PEL
         logging::logMessage("VPD recollection failed with error: " +
                             std::string(l_ex.what()));
+    }
+}
+
+void Manager::checkEssentialFrus()
+{
+    const nlohmann::json& l_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
+
+    types::MapOfObjectsToService l_essentialFruObjects;
+    jsonUtility::getEssentialFruObjects(l_sysCfgJsonObj, l_essentialFruObjects);
+
+    if (l_essentialFruObjects.empty())
+    {
+        logging::logMessage("No essential FRUs found.");
+        return;
+    }
+
+    for (const auto& l_essentialFru : l_essentialFruObjects)
+    {
+        const auto& l_essentialFruObject = l_essentialFru.first;
+
+        // Read Present property to check the physical presence of the FRU
+        const auto l_essentialFruPresence = dbusUtility::readDbusProperty(
+            l_essentialFru.second, l_essentialFruObject,
+            constants::inventoryItemInf, "Present");
+
+        if (const auto l_present = std::get_if<bool>(&l_essentialFruPresence))
+        {
+            if (!*l_present)
+            {
+                logging::logMessage("Essential FRU " + l_essentialFruObject +
+                                    " not present.");
+                // TODO: Remove the log and create PEL
+            }
+        }
+        else
+        {
+            logging::logMessage(
+                "Present property is not found on D-bus for the essential FRU " +
+                l_essentialFruObject);
+            // TODO: Remove the log and create PEL
+        }
     }
 }
 } // namespace vpd


### PR DESCRIPTION
This commit implements an API to check if all the essential FRUs are present on the system. If not error is logged.

Test:
1. Essential FRU not found busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth xyz.openbmc_project.Inventory.Item Present b false

vpd-manager[1577]: FileName: /usr/src/debug/openpower-fru-vpd/1.0+git/ vpd-manager/src/manager.cpp, Line: 884, Func: void vpd::Manager::checkEssentialFrus(), Essential FRU /xyz/openbmc_project/ inventory/system/chassis/motherboard/base_op_panel_blyth not present.

Change-Id: Ibeba4b9064907a7751c6ed3ec79b966fa44feca9