### PR TITLE
Enable PEL for manager_main

### DIFF
--- a/vpd-manager/src/manager_main.cpp
+++ b/vpd-manager/src/manager_main.cpp
@@ -1,8 +1,11 @@
 #include "config.h"
 
 #include "bios_handler.hpp"
+#include "event_logger.hpp"
+#include "exceptions.hpp"
 #include "logger.hpp"
 #include "manager.hpp"
+#include "types.hpp"
 
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/asio/object_server.hpp>
@@ -43,9 +46,44 @@ int main(int, char**)
 
         exit(EXIT_SUCCESS);
     }
-    catch (const std::exception& e)
+    catch (const std::exception& l_ex)
     {
-        std::cerr << e.what() << std::endl;
+        if (typeid(l_ex) == typeid(vpd::JsonException))
+        {
+            vpd::EventLogger::createAsyncPel(
+                vpd::types::ErrorType::JsonFailure,
+                vpd::types::SeverityType::Informational, __FILE__, __FUNCTION__,
+                0,
+                std::string("VPD Manager service failed with : ") + l_ex.what(),
+                std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+        }
+        else if (typeid(l_ex) == typeid(vpd::GpioException))
+        {
+            vpd::EventLogger::createAsyncPel(
+                vpd::types::ErrorType::GpioError,
+                vpd::types::SeverityType::Informational, __FILE__, __FUNCTION__,
+                0,
+                std::string("VPD Manager service failed with: ") + l_ex.what(),
+                std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+        }
+        else if (typeid(l_ex) == typeid(sdbusplus::exception_t))
+        {
+            vpd::EventLogger::createAsyncPel(
+                vpd::types::ErrorType::DbusFailure,
+                vpd::types::SeverityType::Informational, __FILE__, __FUNCTION__,
+                0,
+                std::string("VPD Manager service failed with : ") + l_ex.what(),
+                std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+        }
+        else
+        {
+            vpd::EventLogger::createAsyncPel(
+                vpd::types::ErrorType::InvalidVpdMessage,
+                vpd::types::SeverityType::Informational, __FILE__, __FUNCTION__,
+                0,
+                std::string("VPD Manager service failed with : ") + l_ex.what(),
+                "BMC0001", std::nullopt, std::nullopt, std::nullopt);
+        }
     }
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
This commit adds code to log a PEL in manager_main file, in case of error where PEL is required.

Test:
```
root@p10bmc:/tmp# peltool -i 0x50002CA0
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "12/05/2024 07:21:29",
    "Committed at":             "12/05/2024 07:21:29",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50002CA0",
    "Entry Id":                 "0x50002CA0",
    "BMC Event Log Id":         "178"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Informational Event",
    "Event Type":               "Miscellaneous, Informational Only",
    "Action Flags": [
                                "Event not customer viewable",
                                "Report Externally"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E33",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A Json failure occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554003",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E330010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a unit",
            "Procedure":        "BMC0001"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9043-MRX",
    "Reporting Serial Number":  "13E8D2X",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1110.00-3.17",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554003_2E330010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9043-MRX",
    "Serial Number":            "13E8D2X"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.40 0.93 0.99",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 0h 15m 25s",
    "BootState": "OSRunning",
    "ChassisState": "On",
    "FW Version ID": "fw1110.00-3.17-136-gcac6088dbe-dirty",
    "HostState": "Running",
    "System IM": "50003000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "DESCRIPTION": "VPD Manager service failed with : Test Error",
    "FileName": "/usr/src/debug/openpower-fru-vpd/1.0+git/src/manager_main.cpp",
    "FunctionName": "main",
    "InternalRc": "0",
    "UserData1": "",
    "UserData2": ""
}
}
```