### PR TITLE
Update flow for enable and functional property

### DIFF
--- a/vpd-manager/include/worker.hpp
+++ b/vpd-manager/include/worker.hpp
@@ -436,7 +436,7 @@ class Worker
      * @param[in] i_inventoryObjPath - Inventory path as read from config JSON.
      * @param[in] io_interfaces - Map to hold all the interfaces for the FRU.
      */
-    void processFunctionalPorperty(const std::string& i_inventoryObjPath,
+    void processFunctionalProperty(const std::string& i_inventoryObjPath,
                                    types::InterfaceMap& io_interfaces);
 
     /**


### PR DESCRIPTION
The current flow reads the property over Dbus and if not found populates the property with default value.
Issue with the current flow is that if the path hosting the property is not found, Dbus returns an error which is logged. This results in flooding the journal.

In the new approach the Dbus path required to host the property is looked for on DBus via mapper call and if mapper returns size 0, implying that no such object path is found under PIM, then the property with default value is populated.
Return 0 size from mapper is not an error and hence no journal log in this case. Which prevents the journal from flooding.
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>