### PR TITLE
Remove all logs

### DIFF
--- a/vpd-manager/src/logger.cpp
+++ b/vpd-manager/src/logger.cpp
@@ -14,9 +14,9 @@ void logMessage(std::string_view message, const std::source_location& location)
     /* TODO: Check on this later.
     log << "FileName: " << location.file_name() << ","
         << " Line: " << location.line() << ","
-        << " Func: " << location.function_name() << ", " << message;*/
+        << " Func: " << location.function_name() << ", " << message;
 
-    std::cout << log.str() << std::endl;
+    std::cout << log.str() << std::endl;*/
 }
 } // namespace logging
 } // namespace vpd


### PR DESCRIPTION
All the logs are removed to reduce cpu cycle suring CI and check for failure.
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>