### PR TITLE
limit number of threds

### DIFF
--- a/vpd-manager/include/constants.hpp
+++ b/vpd-manager/include/constants.hpp
@@ -171,6 +171,9 @@ static constexpr auto CMD_BUFFER_LENGTH = 256;
 // To be explicitly used for string comparision.
 static constexpr auto STR_CMP_SUCCESS = 0;
 
+// Just a random value. Can be adjusted as required.
+static constexpr uint8_t MAX_THREADS = 30;
+
 constexpr auto bmcStateService = "xyz.openbmc_project.State.BMC";
 constexpr auto bmcZeroStateObject = "/xyz/openbmc_project/state/bmc0";
 constexpr auto bmcStateInterface = "xyz.openbmc_project.State.BMC";

--- a/vpd-manager/include/worker.hpp
+++ b/vpd-manager/include/worker.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "constants.hpp"
 #include "types.hpp"
 
 #include <nlohmann/json.hpp>
 
 #include <mutex>
 #include <optional>
+#include <semaphore>
 #include <tuple>
 
 namespace vpd
@@ -498,5 +500,9 @@ class Worker
 
     // Mutex to guard critical resource m_activeCollectionThreadCount.
     std::mutex m_mutex;
+
+    // Counting semaphore to limit the number of threads.
+    std::counting_semaphore<constants::MAX_THREADS> m_semaphore{
+        constants::MAX_THREADS};
 };
 } // namespace vpd


### PR DESCRIPTION
Triggering all the FRU collection threads at a time can cause CPU utilization issue.
Hence the commit implements a configurable semaphore to limit the number of threads at a particular time.