### PR TITLE
Update sleep in wait-vpd-parser service

### DIFF
--- a/scripts/wait-vpd-status.sh
+++ b/scripts/wait-vpd-status.sh
@@ -3,6 +3,7 @@ retries=100
 echo "Checking every 2s for VPD collection status ...."
 while [ "$retries" -ne 0 ]
 do
+    sleep 2
     output=$(busctl get-property com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager CollectionStatus)
 
     if echo "$output" | grep -q "Completed" ; then
@@ -12,7 +13,6 @@ do
 
     retries="$((retries - 1))"
     echo "Waiting for VPD status update. Retries remaining: $retries"
-    sleep 2
 done
 echo "Exit wait for VPD services to finish with timeout"
 exit 1


### PR DESCRIPTION
The commit implements wait-vpd-parser service to first waits for 2 seconds before checking on VPD collection status, it is too early to check on the VPD collection status as vpd-manager needs to finish collecting all the FRU’s VPD.

Initial delay will avoid early DBus call failure, which is unnecessary.