### PR TITLE
PEL for Worker class

### DIFF
--- a/vpd-manager/include/worker.hpp
+++ b/vpd-manager/include/worker.hpp
@@ -473,7 +473,10 @@ class Worker
      * @brief API to form asset tag string for the system.
      *
      * @param[in] i_parsedVpdMap - Parsed VPD map.
-     * @return - Formed asset tag string. Empty in case of any error.
+     *
+     * @throw std::runtime_error
+     *
+     * @return - Formed asset tag string.
      */
     std::string
         createAssetTagString(const types::VPDMapVariant& i_parsedVpdMap);


### PR DESCRIPTION
This commit adds code to log informational PEL in worker class, in case of exceptions occurred during creating asset tag and initiating backup & restore.

output:

```
root@testhostname:~# peltool -i 0x5000ED96
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "01/10/2025 15:48:55",
    "Committed at":             "01/10/2025 15:48:55",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000ED96",
    "Entry Id":                 "0x5000ED96",
    "BMC Event Log Id":         "783"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Informational Event",
    "Event Type":               "Miscellaneous, Informational Only",
    "Action Flags": [
                                "Event not customer viewable",
                                "Report Externally"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A VPD data exception occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554001",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-22A",
    "Reporting Serial Number":  "139F230",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1110.00-3.37",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554001_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-22A",
    "Serial Number":            "139F230"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.51 0.80 0.80",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 0h 26m 28s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1110.00-3.37-85-g35b06323a2-dirty",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "DESCRIPTION": "Exception caught while backup and restore VPD keyword's.Test error",
    "FileName": "/usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/worker.cpp",
    "FunctionName": "performBackupAndRestore",
    "InteranlRc": "0",
    "UserData1": "",
    "UserData2": ""
}

```
