### PR TITLE
Add write keyword API and rename existing one

### DIFF
--- a/vpd-manager/src/manager.cpp
+++ b/vpd-manager/src/manager.cpp
@@ -51,9 +51,19 @@ Manager::Manager(
         // set callback to detect host state change.
         registerHostStateChangeCallback();
 
-        // Register methods under com.ibm.VPD.Manager interface
+        // For backward compatibility. Should be depricated.
         iFace->register_method(
             "WriteKeyword",
+            [this](const sdbusplus::message::object_path i_path,
+                   const std::string i_recordName, const std::string i_keyword,
+                   const types::BinaryVector i_value) -> int {
+            return this->updateKeyword(
+                i_path, std::make_tuple(i_recordName, i_keyword, i_value));
+        });
+
+        // Register methods under com.ibm.VPD.Manager interface
+        iFace->register_method(
+            "UpdateKeyword",
             [this](const types::Path i_vpdPath,
                    const types::WriteVpdParams i_paramsToWriteData) -> int {
             return this->updateKeyword(i_vpdPath, i_paramsToWriteData);


### PR DESCRIPTION
Write keyword API is exposed over Dbus for backward compatibility. It is planned to be deprecated, once done UpdateKeyword will be renamed as WriteKeyword over DBus.