### PR TITLE
Implement vpd-tool object dump

### DIFF
--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -27,5 +27,8 @@ constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
 constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
 constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
+constexpr auto objectMapperService = "xyz.openbmc_project.ObjectMapper";
+constexpr auto objectMapperObjectPath = "/xyz/openbmc_project/object_mapper";
+constexpr auto objectMapperInfName = "xyz.openbmc_project.ObjectMapper";
 } // namespace constants
 } // namespace vpd

--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -55,5 +55,8 @@ using IpzData = std::tuple<std::string, std::string, BinaryVector>;
 
 //WriteVpdParams either of IPZ or keyword format
 using WriteVpdParams = std::variant<IpzData, KwData>;
+// Return type of ObjectMapper GetObject API
+using MapperGetObject = std::map<std::string,std::vector<std::string>>;
+
 } // namespace types
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "tool_utils.hpp"
+
 #include <nlohmann/json.hpp>
 
 #include <optional>
@@ -26,18 +28,69 @@ class VpdTool
      *
      * For a given object path of a FRU, this API returns the following
      * properties of the FRU in JSON format:
-     * - Present property, Pretty Name, Location Code, Sub Model
+     * - Pretty Name, Location Code, Sub Model
      * - SN, PN, CC, FN, DR keywords under VINI record.
      *
-     * @param[in] i_fruPath - DBus object path
+     * @param[in] i_objectPath - DBus object path
      *
      * @return On success, returns the properties of the FRU in JSON format,
-     * otherwise throws a std::runtime_error exception.
-     * Note: The caller of this API should handle this exception.
+     * otherwise returns an empty JSON.
+     * If FRU's "Present" property is false, this API returns an empty JSON.
+     * Note: The caller of this API should handle empty JSON.
      *
-     * @throw std::runtime_error
+     * @throw json::exception
      */
-    nlohmann::json getFruProperties(const std::string& i_fruPath) const;
+    nlohmann::json getFruProperties(const std::string& i_objectPath) const;
+
+    /**
+     * @brief Get any inventory property in JSON.
+     *
+     * API to get any property of a FRU in JSON format. Given an object path,
+     * interface and property name, this API does a D-Bus read property on PIM
+     * to get the value of that property and returns it in JSON format. This API
+     * returns empty JSON in case of failure. The caller of the API must check
+     * for empty JSON.
+     *
+     * @param[in] i_objectPath - DBus object path
+     * @param[in] i_interface - Interface name
+     * @param[in] i_propertyName - Property name
+     *
+     * @return On success, returns the property and its value in JSON format,
+     * otherwise return empty JSON.
+     * {"SN" : "ABCD"}
+     */
+    template <typename PropertyType>
+    nlohmann::json getInventoryPropertyJson(
+        const std::string& i_objectPath, const std::string& i_interface,
+        const std::string& i_propertyName) const noexcept;
+
+    /**
+     * @brief Get the "type" property for a FRU.
+     *
+     * Given a FRU path, and parsed System Config JSON, this API returns the
+     * "type" property for the FRU in JSON format. This API gets
+     * these properties from Phosphor Inventory Manager.
+     *
+     * @param[in] i_objectPath - DBus object path.
+     *
+     * @return On success, returns the "type" property in JSON
+     * format, otherwise returns empty JSON. The caller of this API should
+     * handle empty JSON.
+     */
+    nlohmann::json
+        getFruTypeProperty(const std::string& i_objectPath) const noexcept;
+
+    /**
+     * @brief Check if a FRU is present in the system.
+     *
+     * Given a FRU's object path, this API checks if the FRU is present in the
+     * system by reading the "Present" property of the FRU.
+     *
+     * @param[in] i_objectPath - DBus object path.
+     *
+     * @return true if FRU's "Present" property is true, false otherwise.
+     */
+    bool isFruPresent(const std::string& i_objectPath) const noexcept;
 
     /**
      * @brief An API to get backup-restore config JSON of the system.
@@ -81,8 +134,10 @@ class VpdTool
      *
      * For a given object path of a FRU, this API dumps the following properties
      * of the FRU in JSON format to console:
-     * - Present property, Pretty Name, Location Code, Sub Model
+     * - Pretty Name, Location Code, Sub Model
      * - SN, PN, CC, FN, DR keywords under VINI record.
+     * If the FRU's "Present" property is not true, the above properties are not
+     * dumped to console.
      *
      * @param[in] i_fruPath - DBus object path.
      *

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -94,9 +94,19 @@ int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
     int l_rc{constants::FAILURE};
     try
     {
-        const nlohmann::json l_resultJson = getFruProperties(i_fruPath);
+        nlohmann::json l_resultJsonArray = nlohmann::json::array({});
+        const nlohmann::json l_fruJson = getFruProperties(i_fruPath);
+        if (!l_fruJson.empty())
+        {
+            l_resultJsonArray += l_fruJson;
 
-        utils::printJson(l_resultJson);
+            utils::printJson(l_resultJsonArray);
+        }
+        else
+        {
+            std::cout << "FRU " << i_fruPath << " is not present in the system"
+                      << std::endl;
+        }
         l_rc = constants::SUCCESS;
     }
     catch (std::exception& l_ex)
@@ -108,12 +118,127 @@ int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
     return l_rc;
 }
 
-nlohmann::json VpdTool::getFruProperties(const std::string& i_fruPath) const
+nlohmann::json VpdTool::getFruProperties(const std::string& i_objectPath) const
 {
-    nlohmann::json l_resultInJson = nlohmann::json::array({});
+    // check if FRU is present in the system
+    if (!isFruPresent(i_objectPath))
+    {
+        return nlohmann::json::object_t();
+    }
 
-    // TODO: Implement getFruProperties
-    (void)i_fruPath;
+    nlohmann::json l_fruJson = nlohmann::json::object_t({});
+
+    l_fruJson.emplace(i_objectPath, nlohmann::json::object_t({}));
+
+    auto& l_fruObject = l_fruJson[i_objectPath];
+
+    const auto l_prettyNameInJson = getInventoryPropertyJson<std::string>(
+        i_objectPath, constants::inventoryItemInf, "PrettyName");
+    if (!l_prettyNameInJson.empty())
+    {
+        l_fruObject.insert(l_prettyNameInJson.cbegin(),
+                           l_prettyNameInJson.cend());
+    }
+
+    const auto l_locationCodeInJson = getInventoryPropertyJson<std::string>(
+        i_objectPath, constants::locationCodeInf, "LocationCode");
+    if (!l_locationCodeInJson.empty())
+    {
+        l_fruObject.insert(l_locationCodeInJson.cbegin(),
+                           l_locationCodeInJson.cend());
+    }
+
+    const auto l_subModelInJson = getInventoryPropertyJson<std::string>(
+        i_objectPath, constants::assetInf, "SubModel");
+
+    if (!l_subModelInJson.empty() &&
+        !l_subModelInJson.value("SubModel", "").empty())
+    {
+        l_fruObject.insert(l_subModelInJson.cbegin(), l_subModelInJson.cend());
+    }
+
+    // Get the properties under VINI interface.
+
+    nlohmann::json l_viniPropertiesInJson = nlohmann::json::object({});
+
+    auto l_readViniKeyWord = [i_objectPath, &l_viniPropertiesInJson,
+                              this](const std::string& i_keyWord) {
+        const nlohmann::json l_keyWordJson =
+            getInventoryPropertyJson<vpd::types::BinaryVector>(
+                i_objectPath, constants::kwdVpdInf, i_keyWord);
+        l_viniPropertiesInJson.insert(l_keyWordJson.cbegin(),
+                                      l_keyWordJson.cend());
+    };
+
+    const std::vector<std::string> l_viniKeywords = {"SN", "PN", "CC", "FN",
+                                                     "DR"};
+
+    std::for_each(l_viniKeywords.cbegin(), l_viniKeywords.cend(),
+                  l_readViniKeyWord);
+
+    if (!l_viniPropertiesInJson.empty())
+    {
+        l_fruObject.insert(l_viniPropertiesInJson.cbegin(),
+                           l_viniPropertiesInJson.cend());
+    }
+
+    const auto l_typePropertyJson = getFruTypeProperty(i_objectPath);
+    if (!l_typePropertyJson.empty())
+    {
+        l_fruObject.insert(l_typePropertyJson.cbegin(),
+                           l_typePropertyJson.cend());
+    }
+
+    return l_fruJson;
+}
+
+template <typename PropertyType>
+nlohmann::json VpdTool::getInventoryPropertyJson(
+    const std::string& i_objectPath, const std::string& i_interface,
+    const std::string& i_propertyName) const noexcept
+{
+    nlohmann::json l_resultInJson = nlohmann::json::object({});
+    try
+    {
+        types::DbusVariantType l_keyWordValue;
+
+        l_keyWordValue =
+            utils::readDbusProperty(constants::inventoryManagerService,
+                                    i_objectPath, i_interface, i_propertyName);
+
+        if (const auto l_value = std::get_if<PropertyType>(&l_keyWordValue))
+        {
+            if constexpr (std::is_same<PropertyType, std::string>::value)
+            {
+                l_resultInJson.emplace(i_propertyName, *l_value);
+            }
+            else if constexpr (std::is_same<PropertyType, bool>::value)
+            {
+                l_resultInJson.emplace(i_propertyName,
+                                       *l_value ? "true" : "false");
+            }
+            else if constexpr (std::is_same<PropertyType,
+                                            types::BinaryVector>::value)
+            {
+                const std::string& l_keywordStrValue =
+                    vpd::utils::getPrintableValue(*l_value);
+
+                l_resultInJson.emplace(i_propertyName, l_keywordStrValue);
+            }
+        }
+        else
+        {
+            // TODO: Enable logging when verbose is enabled.
+            // std::cout << "Invalid data type received." << std::endl;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        /*std::cerr << "Read " << i_propertyName << " value for FRU path: " <<
+           i_objectPath
+                  << ", failed with exception: " << l_ex.what() << std::endl;*/
+    }
     return l_resultInJson;
 }
 
@@ -214,6 +339,59 @@ int VpdTool::cleanSystemVpd() const noexcept
         std::cerr << l_ex.what() << std::endl;
     }
     return l_rc;
+}
+
+nlohmann::json
+    VpdTool::getFruTypeProperty(const std::string& i_objectPath) const noexcept
+{
+    nlohmann::json l_resultInJson = nlohmann::json::object({});
+    std::vector<std::string> l_pimInfList;
+
+    auto l_serviceInfMap = utils::GetServiceInterfacesForObject(
+        i_objectPath, std::vector<std::string>{constants::inventoryItemInf});
+    if (l_serviceInfMap.contains(constants::inventoryManagerService))
+    {
+        l_pimInfList = l_serviceInfMap[constants::inventoryManagerService];
+
+        // iterate through the list and find
+        // "xyz.openbmc_project.Inventory.Item.*"
+        for (const auto& l_interface : l_pimInfList)
+        {
+            if (l_interface.find(constants::inventoryItemInf) !=
+                    std::string::npos &&
+                l_interface.length() >
+                    std::string(constants::inventoryItemInf).length())
+            {
+                l_resultInJson.emplace("type", l_interface);
+            }
+        }
+    }
+    return l_resultInJson;
+}
+
+bool VpdTool::isFruPresent(const std::string& i_objectPath) const noexcept
+{
+    bool l_returnValue{false};
+    try
+    {
+        types::DbusVariantType l_keyWordValue;
+
+        l_keyWordValue = utils::readDbusProperty(
+            constants::inventoryManagerService, i_objectPath,
+            constants::inventoryItemInf, "Present");
+
+        if (const auto l_value = std::get_if<bool>(&l_keyWordValue))
+        {
+            l_returnValue = *l_value;
+        }
+    }
+    catch (const std::runtime_error& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cerr << "Failed to check \"Present\" property for FRU "
+        //           << i_objectPath << " Error: " << l_ex.what() << std::endl;
+    }
+    return l_returnValue;
 }
 
 } // namespace vpd


### PR DESCRIPTION
This commit implements object dump functionality in vpd-tool.
For a given Object path, the object dump functionality prints the
following properties in a JSON format to the console:
1. Pretty Name, Location Code, Sub Model
2. SN, PN, CC, FN, DR keywords under VINI record

The above properties are dumped to console only if the FRU's Present
property is true, otherwise "FRU <object path> is not present in the
system is printed on console.