### PR TITLE
Create Sync Pel

### DIFF
--- a/vpd-manager/include/event_logger.hpp
+++ b/vpd-manager/include/event_logger.hpp
@@ -131,6 +131,36 @@ class EventLogger
                                const std::optional<std::string> i_symFru,
                                const std::optional<std::string> i_procedure);
 
+    /**
+     * @brief An API to create PEL.
+     *
+     * This API makes synchronous call to phosphor-logging Create method.
+     *
+     * @param[in] i_errorType - Enum to map with event message name.
+     * @param[in] i_severity - Severity of the event.
+     * @param[in] i_fileName - File name.
+     * @param[in] i_funcName - Function name.
+     * @param[in] i_internalRc - Internal return code.
+     * @param[in] i_description - Error description.
+     * @param[in] i_userData1 - Additional user data [optional].
+     * @param[in] i_userData2 - Additional user data [optional].
+     * @param[in] i_symFru - Symblolic FRU callout data [optional].s
+     * @param[in] i_procedure - Procedure callout data [optional].
+     *
+     * @todo: Symbolic FRU and procedure callout needs to be handled in this
+     * API.
+     */
+    static void createSyncPel(const types::ErrorType& i_errorType,
+                              const types::SeverityType& i_severity,
+                              const std::string& i_fileName,
+                              const std::string& i_funcName,
+                              const uint8_t i_internalRc,
+                              const std::string& i_description,
+                              const std::optional<std::string> i_userData1,
+                              const std::optional<std::string> i_userData2,
+                              const std::optional<std::string> i_symFru,
+                              const std::optional<std::string> i_procedure);
+
   private:
     static const std::unordered_map<types::SeverityType, std::string>
         m_severityMap;

--- a/vpd-manager/src/event_logger.cpp
+++ b/vpd-manager/src/event_logger.cpp
@@ -236,4 +236,62 @@ void EventLogger::createAsyncPel(const types::ErrorType& i_errorType,
                             std::string(l_ex.what()));
     }
 }
+
+void EventLogger::createSyncPel(const types::ErrorType& i_errorType,
+                                const types::SeverityType& i_severity,
+                                const std::string& i_fileName,
+                                const std::string& i_funcName,
+                                const uint8_t i_internalRc,
+                                const std::string& i_description,
+                                const std::optional<std::string> i_userData1,
+                                const std::optional<std::string> i_userData2,
+                                const std::optional<std::string> i_symFru,
+                                const std::optional<std::string> i_procedure)
+{
+    (void)i_symFru;
+    (void)i_procedure;
+    try
+    {
+        if (m_errorMsgMap.find(i_errorType) == m_errorMsgMap.end())
+        {
+            throw std::runtime_error("Unsupported error type received");
+            // TODO: Need to handle, instead of throwing an exception.
+        }
+
+        const std::string& l_message = m_errorMsgMap.at(i_errorType);
+
+        const std::string& l_severity =
+            (m_severityMap.find(i_severity) != m_severityMap.end()
+                 ? m_severityMap.at(i_severity)
+                 : m_severityMap.at(types::SeverityType::Informational));
+
+        const std::string l_description =
+            ((!i_description.empty() ? i_description : "VPD generic error"));
+
+        const std::string l_userData1 = ((i_userData1) ? (*i_userData1) : "");
+
+        const std::string l_userData2 = ((i_userData2) ? (*i_userData2) : "");
+
+        std::map<std::string, std::string> l_additionalData{
+            {"FileName", i_fileName},
+            {"FunctionName", i_funcName},
+            {"DESCRIPTION", l_description},
+            {"InteranlRc", std::to_string(i_internalRc)},
+            {"UserData1", l_userData1.c_str()},
+            {"UserData2", l_userData2.c_str()}};
+
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call(constants::eventLoggingServiceName,
+                                  constants::eventLoggingObjectPath,
+                                  constants::eventLoggingInterface, "Create");
+        l_method.append(l_message, l_severity, l_additionalData);
+        l_bus.call(l_method);
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        logging::logMessage("Sync PEL creation failed with an error: " +
+                            std::string(l_ex.what()));
+    }
+}
 } // namespace vpd


### PR DESCRIPTION
This commit adds code to implement sync PEL creation.

output:
```
root@p10bmc:/tmp# peltool -i 0x5000212D
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "01/02/2025 09:24:03",
    "Committed at":             "01/02/2025 09:24:03",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000212D",
    "Entry Id":                 "0x5000212D",
    "BMC Event Log Id":         "509"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Informational Event",
    "Event Type":               "Miscellaneous, Informational Only",
    "Action Flags": [
                                "Event not customer viewable",
                                "Report Externally"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A VPD data exception occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554001",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "        ",
    "Reporting Serial Number":  "       ",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1110.00-3.34",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554001_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "        ",
    "Serial Number":            "       "
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "1.07 1.29 0.71",
    "BMCState": "Quiesced",
    "BMCUptime": "0y 0d 0h 6m 6s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1110.00-3.34-2-g45a17a06f3-dirty",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "DESCRIPTION": "VPD Manager service failed with : Test Error",
    "FileName": "/usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/manager_main.cpp",
    "FunctionName": "main",
    "InternalRc": "0",
    "UserData1": "BMC0001",
    "UserData2": ""
}
}

```