### PR TITLE
vpd-tool: Dump Inventory in Table format

### DIFF
--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -500,5 +500,191 @@ inline std::vector<std::string> GetSubTreePaths(
     return l_objectPaths;
 }
 
+/**
+ * @brief A class to print data in tabular format
+ *
+ * This class implements methods to print data in a two dimensional tabular
+ * format. All entries in the table must be in string format.
+ *
+ */
+class Table
+{
+    // A column is a pair of Column Header string and its width
+    using ColumnNameSizePair = std::pair<std::string, std::size_t>;
+    class Column : public ColumnNameSizePair
+    {
+      public:
+        /**
+         * @brief API to get the name of the Column
+         *
+         * @return Name of the Column.
+         */
+        const std::string& Name() const
+        {
+            return this->first;
+        }
+
+        /**
+         * @brief API to get the width of the Column
+         *
+         * @return Width of the Column.
+         */
+        std::size_t Width() const
+        {
+            return this->second;
+        }
+    };
+
+    // Current width of the table
+    std::size_t m_currentWidth;
+
+    // Character to be used as fill character between entries
+    char m_fillCharacter;
+
+    // Separator character to be used between columns
+    char m_separator;
+
+    // Array of columns
+    std::vector<Column> m_columns;
+
+    /**
+     * @brief API to Print Header
+     *
+     * Header line prints the names of the Column headers separated by the
+     * specified separator character and spaced accordingly.
+     *
+     * @throw std::out_of_range, std::length_error, std::bad_alloc
+     */
+    void PrintHeader() const
+    {
+        for (const auto& l_column : m_columns)
+        {
+            PrintEntry(l_column.Name(), l_column.Width());
+        }
+        std::cout << m_separator << std::endl;
+    }
+
+    /**
+     * @brief API to Print Horizontal Line
+     *
+     * A horizontal line is a sequence of '*'s.
+     *
+     * @throw std::out_of_range, std::length_error, std::bad_alloc
+     */
+    void PrintHorizontalLine() const
+    {
+        std::cout << std::string(m_currentWidth, '*') << std::endl;
+    }
+
+    /**
+     * @brief API to print an entry in the table
+     *
+     * An entry is a separator character followed by the text to print.
+     * The text is centre-aligned.
+     *
+     * @param[in] i_text - text to print
+     * @param[in] i_columnWidth - width of the column
+     *
+     * @throw std::out_of_range, std::length_error, std::bad_alloc
+     */
+    void PrintEntry(const std::string& i_text, std::size_t i_columnWidth) const
+    {
+        const std::size_t l_textLength{i_text.length()};
+
+        constexpr std::size_t l_minFillChars{3};
+        const std::size_t l_numFillChars =
+            ((l_textLength >= i_columnWidth ? l_minFillChars
+                                            : i_columnWidth - l_textLength)) -
+            1; // -1 for the separator character
+
+        const unsigned l_oddFill = l_numFillChars % 2;
+
+        std::cout << m_separator
+                  << std::string((l_numFillChars / 2) + l_oddFill,
+                                 m_fillCharacter)
+                  << i_text << std::string(l_numFillChars / 2, m_fillCharacter);
+    }
+
+  public:
+    /**
+     * @brief Table Constructor
+     *
+     * Parameterized constructor for a Table object
+     *
+     */
+    constexpr explicit Table(const char i_fillCharacter = ' ',
+                             const char i_separator = '|') noexcept :
+        m_currentWidth{0}, m_fillCharacter{i_fillCharacter},
+        m_separator{i_separator}
+    {}
+
+    // deleted methods
+    Table(const Table&) = delete;
+    Table operator=(const Table&) = delete;
+    Table(const Table&&) = delete;
+    Table operator=(const Table&&) = delete;
+
+    ~Table() = default;
+
+    /**
+     * @brief API to add column to Table
+     *
+     * @param[in] i_name - Name of the column.
+     *
+     * @param[in] i_width - Width to allocate for the column.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int AddColumn(const std::string& i_name, std::size_t i_width)
+    {
+        if (i_width < i_name.length())
+            return constants::FAILURE;
+        m_columns.emplace_back(ColumnNameSizePair(i_name, i_width));
+        m_currentWidth += i_width;
+        return constants::SUCCESS;
+    }
+
+    /**
+     * @brief API to print the Table to console.
+     *
+     * This API prints the table data to console.
+     *
+     * @param[in] i_tableData - The data to be printed.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     *
+     * @throw std::out_of_range, std::length_error, std::bad_alloc
+     */
+    int Print(const std::vector<std::vector<std::string>>& i_tableData) const
+    {
+        PrintHorizontalLine();
+        PrintHeader();
+        PrintHorizontalLine();
+
+        // print the table data
+        for (const auto& l_row : i_tableData)
+        {
+            unsigned l_columnNumber{0};
+
+            // number of columns in input data is greater than the number of
+            // columns specified in Table
+            if (l_row.size() > m_columns.size())
+            {
+                return constants::FAILURE;
+            }
+
+            for (const auto& l_entry : l_row)
+            {
+                PrintEntry(l_entry, m_columns[l_columnNumber].Width());
+
+                ++l_columnNumber;
+            }
+            std::cout << m_separator << std::endl;
+        }
+        PrintHorizontalLine();
+        return constants::SUCCESS;
+    }
+};
+
 } // namespace utils
 } // namespace vpd

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -458,5 +458,47 @@ inline types::MapperGetObject GetServiceInterfacesForObject(
     return l_serviceInfMap;
 }
 
+/** @brief API to get list of sub tree paths for a given object path
+ *
+ * Given a DBus object path, this API returns a list of object paths under that
+ * object path in the DBus tree. This API calls DBus method GetSubTreePaths
+ * hosted by ObjectMapper DBus service.
+ *
+ * @param[in] i_objectPath - DBus object path.
+ * @param[in] i_constrainingInterfaces - An array of result set constraining
+ * interfaces.
+ * @param[in] i_depth - The maximum subtree depth for which results should be
+ * fetched. For unconstrained fetches use a depth of zero.
+ *
+ * @return On success, returns a std::vector<std::string> of object paths in
+ * Phosphor Inventory Manager DBus service's tree, else returns an empty vector.
+ * The caller of this API should check for empty vector.
+ */
+inline std::vector<std::string> GetSubTreePaths(
+    const std::string i_objectPath, const int i_depth = 0,
+    const std::vector<std::string>& i_constrainingInterfaces = {}) noexcept
+{
+    std::vector<std::string> l_objectPaths;
+
+    try
+    {
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method = l_bus.new_method_call(
+            constants::objectMapperService, constants::objectMapperObjectPath,
+            constants::objectMapperInfName, "GetSubTreePaths");
+
+        l_method.append(i_objectPath, i_depth, i_constrainingInterfaces);
+
+        auto l_result = l_bus.call(l_method);
+        l_result.read(l_objectPaths);
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        // TODO: log only when verbose is enabled
+        std::cerr << std::string(l_ex.what()) << std::endl;
+    }
+    return l_objectPaths;
+}
+
 } // namespace utils
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -200,5 +200,20 @@ class VpdTool
      * @return On success returns 0, otherwise returns -1.
      */
     int cleanSystemVpd() const noexcept;
+
+    /**
+     * @brief Dump all the inventory objects in JSON format to console.
+     *
+     * This API dumps specific properties of all the objects in Phosphor
+     * Inventory Manager DBus tree to console in JSON format to console. For
+     * each object, the following properties are dumped to console:
+     * - Present property, Pretty Name, Location Code, Sub Model
+     * - SN, PN, CC, FN, DR keywords under VINI record.
+     * If the "Present" property of a FRU is false, the FRU is not dumped to
+     * console.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int dumpInventory() const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -202,18 +202,23 @@ class VpdTool
     int cleanSystemVpd() const noexcept;
 
     /**
-     * @brief Dump all the inventory objects in JSON format to console.
+     * @brief Dump all the inventory objects in JSON or Table format to console.
      *
      * This API dumps specific properties of all the objects in Phosphor
-     * Inventory Manager DBus tree to console in JSON format to console. For
-     * each object, the following properties are dumped to console:
+     * Inventory Manager DBus tree to console in JSON or Table format to
+     * console. For each object, the following properties are dumped to console:
      * - Present property, Pretty Name, Location Code, Sub Model
      * - SN, PN, CC, FN, DR keywords under VINI record.
      * If the "Present" property of a FRU is false, the FRU is not dumped to
      * console.
+     * FRUs whose object path end in "unit([0-9][0-9]?)" are also not dumped to
+     * console.
+     *
+     * @param[in] i_dumpTable - Flag which specifies if the inventory should be
+     * dumped in Table format or not.
      *
      * @return On success returns 0, otherwise returns -1.
      */
-    int dumpInventory() const noexcept;
+    int dumpInventory(bool i_dumpTable = false) const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -394,4 +394,10 @@ bool VpdTool::isFruPresent(const std::string& i_objectPath) const noexcept
     return l_returnValue;
 }
 
+int VpdTool::dumpInventory() const noexcept
+{
+    int l_rc{constants::FAILURE};
+    return l_rc;
+}
+
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -397,6 +397,48 @@ bool VpdTool::isFruPresent(const std::string& i_objectPath) const noexcept
 int VpdTool::dumpInventory() const noexcept
 {
     int l_rc{constants::FAILURE};
+
+    try
+    {
+        // get all object paths under PIM
+        const auto l_objectPaths = utils::GetSubTreePaths(
+            constants::baseInventoryPath, 0,
+            std::vector<std::string>{constants::inventoryItemInf});
+
+        if (!l_objectPaths.empty())
+        {
+            nlohmann::json l_resultInJson = nlohmann::json::array({});
+
+            std::for_each(l_objectPaths.begin(), l_objectPaths.end(),
+                          [&](const auto& l_objectPath) {
+                const auto l_fruJson = getFruProperties(l_objectPath);
+                if (!l_fruJson.empty())
+                {
+                    if (l_resultInJson.empty())
+                    {
+                        l_resultInJson += l_fruJson;
+                    }
+                    else
+                    {
+                        l_resultInJson.at(0).insert(l_fruJson.cbegin(),
+                                                    l_fruJson.cend());
+                    }
+                }
+            });
+
+            // TODO: Dump Inventory in Tabular format
+
+            utils::printJson(l_resultInJson);
+
+            l_rc = constants::SUCCESS;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        std::cerr << "Dump inventory failed. Error: " << l_ex.what()
+                  << std::endl;
+    }
     return l_rc;
 }
 

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -213,8 +213,10 @@ void updateFooter(CLI::App& i_app)
         "        Flag to clean and reset specific keywords on system VPD to its default value.\n"
         "        vpd-tool --mfgClean\n"
         "Dump Inventory:\n"
-        "    From DBus to console: "
-        "vpd-tool -i");
+        "   From DBus to console in JSON format: "
+        "vpd-tool -i\n"
+        "   From DBus to console in Table format: "
+        "vpd-tool -i -t\n");
 }
 
 int main(int argc, char** argv)
@@ -282,6 +284,9 @@ int main(int argc, char** argv)
         "--yes", "Using this flag with --mfgClean option, assumes "
                  "yes to proceed without confirmation.");
 
+    auto l_dumpInventoryTableFlag =
+        l_app.add_flag("--table, -t", "Dump inventory in table format");
+
     CLI11_PARSE(l_app, argc, argv);
 
     if (checkOptionValuePair(l_objectOption, l_vpdPath, l_recordOption,
@@ -324,7 +329,7 @@ int main(int argc, char** argv)
     if (!l_dumpInventoryFlag->empty())
     {
         vpd::VpdTool l_vpdToolObj;
-        return l_vpdToolObj.dumpInventory();
+        return l_vpdToolObj.dumpInventory(!l_dumpInventoryTableFlag->empty());
     }
 
     std::cout << l_app.help() << std::endl;

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -211,7 +211,10 @@ void updateFooter(CLI::App& i_app)
         "    vpd-tool --fixSystemVPD\n"
         "MfgClean:\n"
         "        Flag to clean and reset specific keywords on system VPD to its default value.\n"
-        "        vpd-tool --mfgClean\n");
+        "        vpd-tool --mfgClean\n"
+        "Dump Inventory:\n"
+        "    From DBus to console: "
+        "vpd-tool -i");
 }
 
 int main(int argc, char** argv)
@@ -269,6 +272,8 @@ int main(int argc, char** argv)
     auto l_fixSystemVpdFlag = l_app.add_flag(
         "--fixSystemVPD",
         "Use this option to interactively fix critical system VPD keywords");
+    auto l_dumpInventoryFlag = l_app.add_flag("--dumpInventory, -i",
+                                              "Dump all the inventory objects");
 
     auto l_mfgCleanFlag = l_app.add_flag(
         "--mfgClean", "Manufacturing clean on system VPD keyword");
@@ -314,6 +319,12 @@ int main(int argc, char** argv)
     if (!l_mfgCleanFlag->empty())
     {
         return doMfgClean(l_mfgCleanConfirmFlag);
+    }
+
+    if (!l_dumpInventoryFlag->empty())
+    {
+        vpd::VpdTool l_vpdToolObj;
+        return l_vpdToolObj.dumpInventory();
     }
 
     std::cout << l_app.help() << std::endl;


### PR DESCRIPTION
This commit implements vpd-tool --dumpInventory option in tabular format
    The properties of  FRUs published in PIM are printed in the form of a 2D
    table to console, with each row representing a FRU.
    If the "Present" property of a FRU is false, no row is created for that
    FRU.
    
    The properties which are printed are:
    1. Object Path
    2. Pretty Name, Location Code, SubModel
    3. SN, PN, CC, FN, DR keywords under VINI record