### PR TITLE
Implement vpd-tool mfgClean stub

### DIFF
--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -131,5 +131,19 @@ class VpdTool
                      const std::string& i_keywordName,
                      const std::string& i_keywordValue,
                      const bool i_onHardware) noexcept;
+
+    /**
+     * @brief Reset specific keywords on System VPD to default value.
+     *
+     * This API resets specific System VPD keywords to default value. The
+     * keyword values are reset on:
+     * 1. Primary EEPROM path.
+     * 2. Secondary EEPROM path.
+     * 3. D-Bus cache.
+     * 4. Backup path.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int cleanSystemVpd() const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -191,4 +191,29 @@ nlohmann::json VpdTool::getBackupRestoreCfgJsonObj() const noexcept
 
     return l_parsedBackupRestoreJson;
 }
+
+int VpdTool::cleanSystemVpd() const noexcept
+{
+    int l_rc{constants::FAILURE};
+    try
+    {
+        // TODO:
+        //     get the keyword map from backup_restore json
+        //     iterate through the keyword map get default value of
+        //     l_keywordName.
+        //     use readKeyword API to read hardware value from hardware.
+        //     if hardware value != default value,
+        //     use writeKeyword API to update default value on hardware,
+        //     backup and D - Bus.
+
+        l_rc = constants::SUCCESS;
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        std::cerr << l_ex.what() << std::endl;
+    }
+    return l_rc;
+}
+
 } // namespace vpd


### PR DESCRIPTION
This commit implements vpd-tool mfgClean stub which allows the user to
select --mfgClean option. The actual implementation of mfgClean is yet
to be implemented.

Test:

```
root@p10bmc:/tmp# ./vpd-tool --mfgClean --yes
root@p10bmc:# echo $?
0
root@p10bmc:/tmp# ./vpd-tool --mfgClean
This option resets some of the system VPD keywords to their default
values. Do you really wish to proceed further?[yes/no]:yes
root@p10bmc:# echo $?
0
```
