### PR TITLE
Enable PEL for dbus_utility file

### DIFF
--- a/vpd-manager/include/utility/dbus_utility.hpp
+++ b/vpd-manager/include/utility/dbus_utility.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "constants.hpp"
+#include "event_logger.hpp"
 #include "logger.hpp"
 #include "types.hpp"
 
@@ -100,7 +101,11 @@ inline types::PropertyMap getPropertyMap(const std::string& i_service,
     }
     catch (const sdbusplus::exception::SdBusError& l_ex)
     {
-        logging::logMessage(l_ex.what());
+        EventLogger::createSyncPel(
+            types::ErrorType::DbusFailure, types::SeverityType::Informational,
+            __FILE__, __FUNCTION__, 0,
+            "Failed to get property map, error: " + std::string(l_ex.what()),
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     }
 
     return l_propertyValueMap;
@@ -150,7 +155,11 @@ inline types::MapperGetSubTree
     }
     catch (const sdbusplus::exception::SdBusError& l_ex)
     {
-        logging::logMessage(l_ex.what());
+        EventLogger::createSyncPel(
+            types::ErrorType::DbusFailure, types::SeverityType::Informational,
+            __FILE__, __FUNCTION__, 0,
+            "Failed to get object subTree, error: " + std::string(l_ex.what()),
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     }
 
     return l_subTreeMap;
@@ -323,9 +332,12 @@ inline bool isServiceRunning(const std::string& i_serviceName)
     }
     catch (const sdbusplus::exception::SdBusError& l_ex)
     {
-        logging::logMessage(
+        EventLogger::createSyncPel(
+            types::ErrorType::DbusFailure, types::SeverityType::Informational,
+            __FILE__, __FUNCTION__, 0,
             "Call to check service status failed with exception: " +
-            std::string(l_ex.what()));
+                std::string(l_ex.what()),
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     }
 
     return l_retVal;
@@ -362,11 +374,12 @@ inline types::BiosAttributeCurrentValue
     }
     catch (const sdbusplus::exception::SdBusError& l_ex)
     {
-        logging::logMessage(
+        EventLogger::createSyncPel(
+            types::ErrorType::DbusFailure, types::SeverityType::Informational,
+            __FILE__, __FUNCTION__, 0,
             "Failed to read BIOS Attribute: " + i_attributeName +
-            " due to error " + std::string(l_ex.what()));
-
-        // TODO: Log an informational PEL here.
+                " due to error " + std::string(l_ex.what()),
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     }
 
     return std::get<1>(l_attributeVal);
@@ -396,13 +409,11 @@ inline bool isChassisPowerOn()
         return false;
     }
 
-    /*
-        TODO: Add PEL.
-        Callout: Firmware callout
-        Type: Informational
-        Description: Chassis state can't be determined, defaulting to chassis
-        off. : e.what()
-    */
+    EventLogger::createSyncPel(
+        types::ErrorType::DbusFailure, types::SeverityType::Informational,
+        __FILE__, __FUNCTION__, 0,
+        "Chassis state can't be determined, defaulting to chassis off.",
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     return false;
 }
 


### PR DESCRIPTION
This commit adds code to log a PEL in dbus_utility file, in case of exceptions occurred while doing DBus calls.

output:
```
root@p10bmc:~# peltool -i 0x5000000e
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "01/16/2025 04:47:34",
    "Committed at":             "01/16/2025 04:47:34",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000000E",
    "Entry Id":                 "0x5000000E",
    "BMC Event Log Id":         "14"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Informational Event",
    "Event Type":               "Miscellaneous, Informational Only",
    "Action Flags": [
                                "Event not customer viewable",
                                "Report Externally"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A Dbus internal error occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554005",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a unit",
            "Procedure":        "BMC0001"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-22A",
    "Reporting Serial Number":  "139EF60",
    "FW Released Ver":          "RB1110_025",
    "FW SubSys Version":        "fw1110.00-3.53",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554005_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-22A",
    "Serial Number":            "139EF60"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.80 0.95 0.87",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 0h 51m 27s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1110.00-3.53-1110.2503.20250109a (RB1110_025)",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "DESCRIPTION": "Failed to get object subTree, error: Test Error: org.freedesktop.DBus.Error.AccessDenied: Operation not permitted",
    "FileName": "/usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/include/utility/dbus_utility.hpp",
    "FunctionName": "getObjectSubTree",
    "InteranlRc": "0",
    "UserData1": "",
    "UserData2": ""
}
}
```
