### PR TITLE
PEL for vpd_specific_utility file

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include "constants.hpp"
+#include "event_logger.hpp"
 #include "exceptions.hpp"
 #include "logger.hpp"
 #include "types.hpp"
@@ -202,10 +203,12 @@ inline void insertOrMerge(types::InterfaceMap& map,
         }
         catch (const std::exception& l_ex)
         {
-            // ToDo:: Log PEL
-            logging::logMessage(
-                "Inserting properties into interface[" + interface +
-                "] map is failed, reason: " + std::string(l_ex.what()));
+            EventLogger::createSyncPel(
+                types::ErrorType::InvalidVpdMessage,
+                types::SeverityType::Informational, __FILE__, __FUNCTION__, 0,
+                "Inserting properties into interface [" + interface +
+                    "] map is failed, reason: " + std::string(l_ex.what()),
+                std::nullopt, std::nullopt, std::nullopt, std::nullopt);
         }
     }
     else
@@ -335,10 +338,14 @@ inline std::string
             expanded.replace(pos, 3, firstKwdValue + "." + secondKwdValue);
         }
     }
-    catch (const std::exception& ex)
+    catch (const std::exception& l_ex)
     {
-        logging::logMessage("Failed to expand location code with exception: " +
-                            std::string(ex.what()));
+        EventLogger::createSyncPel(
+            types::ErrorType::InvalidVpdMessage,
+            types::SeverityType::Informational, __FILE__, __FUNCTION__, 0,
+            "Failed to expand location code [ " + unexpandedLocationCode +
+                " ] with exception: " + std::string(l_ex.what()),
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     }
 
     return expanded;
@@ -548,8 +555,12 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
     }
     catch (const std::exception& l_ex)
     {
-        logging::logMessage("Failed to remove VPD for FRU: " + i_objectPath +
-                            " with error: " + std::string(l_ex.what()));
+        EventLogger::createSyncPel(
+            types::ErrorType::InvalidVpdMessage,
+            types::SeverityType::Informational, __FILE__, __FUNCTION__, 0,
+            "Failed to remove VPD for FRU: " + i_objectPath +
+                " with error: " + std::string(l_ex.what()),
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
     }
 }
 } // namespace vpdSpecificUtility


### PR DESCRIPTION
This commit adds code to log PEL in vpd_specific_utility file, in case of exceptions occurred while reset data under PIM and get expanded location code.

output:
```
root@p10bmc:~# peltool -i 0x500024E0
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "01/15/2025 08:03:41",
    "Committed at":             "01/15/2025 08:03:41",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x500024E0",
    "Entry Id":                 "0x500024E0",
    "BMC Event Log Id":         "753"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Informational Event",
    "Event Type":               "Miscellaneous, Informational Only",
    "Action Flags": [
                                "Event not customer viewable",
                                "Report Externally"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A VPD data exception occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554001",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "        ",
    "Reporting Serial Number":  "       ",
    "FW Released Ver":          "RB1110_025",
    "FW SubSys Version":        "fw1110.00-3.53",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554001_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "        ",
    "Serial Number":            "       "
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.82 0.82 0.68",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 0h 17m 41s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1110.00-3.53-1110.2503.20250109a (RB1110_025)",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "DESCRIPTION": "Failed to remove VPD for FRU: /xyz/openbmc_project/inventory/system/chassis/motherboard/tpm_wilson with error: Test Error",
    "FileName": "/usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/include/utility/vpd_specific_utility.hpp",
    "FunctionName": "resetDataUnderPIM",
    "InteranlRc": "0",
    "UserData1": "",
    "UserData2": ""
}
}

```