### PR TITLE
API to update keyword on Hardware

### DIFF
--- a/vpd-manager/include/manager.hpp
+++ b/vpd-manager/include/manager.hpp
@@ -64,6 +64,30 @@ class Manager
                       const types::WriteVpdParams i_paramsToWriteData);
 
     /**
+     * @brief Update keyword value on hardware.
+     *
+     * This API is used to update keyword value on hardware. Updates only on the
+     * given input hardware path, does not look for corresponding redundant or
+     * primary path against the given path. To update corresponding paths, make
+     * separate call with respective path.
+     *
+     * To update IPZ type VPD, input parameter for writing should be in the form
+     * of (Record, Keyword, Value). Eg: ("VINI", "SN", {0x01, 0x02, 0x03}).
+     *
+     * To update Keyword type VPD, input parameter for writing should be in the
+     * form of (Keyword, Value). Eg: ("PE", {0x01, 0x02, 0x03}).
+     *
+     * @param[in] i_fruPath - EEPROM path of the FRU.
+     * @param[in] i_paramsToWriteData - Input details.
+     *
+     * @return On success returns number of bytes written, on failure returns
+     * -1.
+     */
+    int updateKeywordOnHardware(
+        const types::Path i_fruPath,
+        const types::WriteVpdParams i_paramsToWriteData) noexcept;
+
+    /**
      * @brief Read keyword value.
      *
      * API can be used to read VPD keyword from the given input path.

--- a/vpd-manager/include/parser.hpp
+++ b/vpd-manager/include/parser.hpp
@@ -69,6 +69,25 @@ class Parser
      */
     int updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData);
 
+    /**
+     * @brief Update keyword value on hardware.
+     *
+     * This API is used to update keyword value on the hardware path.
+     *
+     * To update IPZ type VPD, input parameter for writing should be in the form
+     * of (Record, Keyword, Value). Eg: ("VINI", "SN", {0x01, 0x02, 0x03}).
+     *
+     * To update Keyword type VPD, input parameter for writing should be in the
+     * form of (Keyword, Value). Eg: ("PE", {0x01, 0x02, 0x03}).
+     *
+     * @param[in] i_paramsToWriteData - Input details.
+     *
+     * @return On success returns number of bytes written, on failure returns
+     * -1.
+     */
+    int updateVpdKeywordOnHardware(
+        const types::WriteVpdParams& i_paramsToWriteData);
+
   private:
     /**
      * @brief Update keyword value on redundant path.


### PR DESCRIPTION
This commit implements an API to update keyword value on hardware path. This API updates keyword only on the provided hardware path, doesn't sync with redundant hardware path/cache. Using this API can create mismatch between primary and secondary vpd. This should be barely used with the requirement of updating only on the hardware path.

Test:
```
root@p10bmc:~# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager ReadKeyword sv "/sys/bus/i2c/drivers/at24/9-0050/eeprom" "(ss)" "VINI" "FG"
 v ay 4 86 78 71 82
root@p10bmc:~# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager WriteKeywordOnHardware sv "/sys/bus/i2c/drivers/at24/9-0050/eeprom" "(ssay)" "VINI" "FG" 4 0x50 0x51 0x52 0x53
 i 4
root@p10bmc:~# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager ReadKeyword sv "/sys/bus/i2c/drivers/at24/9-0050/eeprom" "(ss)" "VINI" "FG" 
v ay 4 80 81 82 83

```