### PR TITLE
Implement vpd-tool mfgClean

### DIFF
--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <tuple>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -55,5 +56,15 @@ using IpzData = std::tuple<std::string, std::string, BinaryVector>;
 
 //WriteVpdParams either of IPZ or keyword format
 using WriteVpdParams = std::variant<IpzData, KwData>;
+using SystemKeywordInfo =
+    std::tuple<std::string, BinaryVector,
+               bool, std::string, std::string>;
+
+// Map of system backplane records to list of keywords and its related data. {
+//  Record : { Keyword, Default value, Is MFG
+//  reset required, Backup Record, Backup Keyword }}
+using SystemKeywordsMap =
+    std::unordered_map<std::string, std::vector<SystemKeywordInfo>>;
+
 } // namespace types
 } // namespace vpd

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "tool_types.hpp"
+
 #include <nlohmann/json.hpp>
 
 #include <optional>
@@ -21,6 +23,10 @@ namespace vpd
 class VpdTool
 {
   private:
+    // Map of System VPD Keywords which can be reset by vpd-tool manufacturing
+    // clean option
+    static const types::SystemKeywordsMap g_systemVpdKeywordMap;
+
     /**
      * @brief Get specific properties of a FRU in JSON format.
      *
@@ -117,5 +123,19 @@ class VpdTool
                      const std::string& i_keywordName,
                      const std::string& i_keywordValue,
                      const bool i_onHardware) noexcept;
+
+    /**
+     * @brief Reset specific keywords on System VPD to default value.
+     *
+     * This API resets specific System VPD keywords to default value. The
+     * keyword values are reset on:
+     * 1. Primary EEPROM path.
+     * 2. Secondary EEPROM path.
+     * 3. D-Bus cache.
+     * 4. Backup path.
+     *
+     * @return On success returns 0, otherwise returns -1.
+     */
+    int cleanSystemVpd() const noexcept;
 };
 } // namespace vpd

--- a/vpd-tool/meson.build
+++ b/vpd-tool/meson.build
@@ -13,7 +13,7 @@ sources = ['src/vpd_tool_main.cpp',
 
 vpd_tool_exe = executable('vpd-tool',
                           sources,
-                          include_directories : ['include/'],
+                          include_directories : ['include/','../'],
                           dependencies: dependency_list,
                           install: true
                         )

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -9,6 +9,48 @@
 
 namespace vpd
 {
+
+// Map of system backplane records to list of keywords and its related data. {
+//  Record : { Keyword, Default value, Is MFG
+//  reset required, Backup Record, Backup Keyword }}
+const types::SystemKeywordsMap VpdTool::g_systemVpdKeywordMap{
+    {"VSYS",
+     {types::SystemKeywordInfo("BR", types::BinaryVector{2, 0x20}, true, "VSBK",
+                               "BR"),
+      types::SystemKeywordInfo("TM", types::BinaryVector{8, 0x20}, true, "VSBK",
+                               "TM"),
+      types::SystemKeywordInfo("SE", types::BinaryVector{7, 0x20}, true, "VSBK",
+                               "SE"),
+      types::SystemKeywordInfo("SU", types::BinaryVector{6, 0x20}, true, "VSBK",
+                               "SU"),
+      types::SystemKeywordInfo("RB", types::BinaryVector{4, 0x20}, true, "VSBK",
+                               "RB"),
+      types::SystemKeywordInfo("WN", types::BinaryVector{12, 0x20}, true,
+                               "VSBK", "WN"),
+      types::SystemKeywordInfo("RG", types::BinaryVector{4, 0x20}, true, "VSBK",
+                               "RG"),
+      types::SystemKeywordInfo("FV", types::BinaryVector{32, 0x20}, true,
+                               "VSBK", "FV")}},
+    {"VCEN",
+     {types::SystemKeywordInfo("FC", types::BinaryVector{8, 0x20}, false,
+                               "VSBK", "FC"),
+      types::SystemKeywordInfo("SE", types::BinaryVector{7, 0x20}, true, "VSBK",
+                               "ES")}},
+    {"LXR0",
+     {types::SystemKeywordInfo("LX", types::BinaryVector{8, 0x00}, false,
+                               "VSBK", "LX")}},
+    {"UTIL",
+     {types::SystemKeywordInfo("D0", types::BinaryVector{1, 0x00}, true, "VSBK",
+                               "D0"),
+      types::SystemKeywordInfo("D1", types::BinaryVector{1, 0x00}, true, "VSBK",
+                               "D1"),
+      types::SystemKeywordInfo("F0", types::BinaryVector{8, 0x00}, true, "VSBK",
+                               "F0"),
+      types::SystemKeywordInfo("F5", types::BinaryVector{16, 0x00}, true,
+                               "VSBK", "F5"),
+      types::SystemKeywordInfo("F6", types::BinaryVector{16, 0x00}, true,
+                               "VSBK", "F6")}}};
+
 int VpdTool::readKeyword(const std::string& i_vpdPath,
                          const std::string& i_recordName,
                          const std::string& i_keywordName,
@@ -161,4 +203,31 @@ int VpdTool::writeKeyword(std::string i_vpdPath,
     }
     return l_rc;
 }
+int VpdTool::cleanSystemVpd() const noexcept
+{
+    int l_rc{constants::FAILURE};
+    try
+    {
+        // TODO:
+        //     iterate through the keyword map get default value of
+        //     l_keywordName.
+        //     use readKeyword API to read hardware value from hardware.
+        //     if hardware value != default value,
+        //     use writeKeyword API to update default value on hardware,
+        //     backup and D - Bus.
+        (void)g_systemVpdKeywordMap;
+
+        l_rc = constants::SUCCESS;
+    }
+    catch (const std::exception& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cerr << "Manufacturing clean failed for " << i_recordName << ":"
+        //           << i_keywordName << ". Error : " << l_ex.what() <<
+        //           std::endl;
+    }
+
+    return l_rc;
+}
+
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -42,7 +42,10 @@ int main(int argc, char** argv)
         "    From DBus to console: "
         "vpd-tool -o -O <DBus Object Path>\n"
         "Fix System VPD:\n"
-        "    vpd-tool --fixSystemVPD");
+        "    vpd-tool --fixSystemVPD\n"
+        "MfgClean:\n"
+        "        Flag to clean and reset specific keywords on system VPD to its default value.\n"
+        "        vpd-tool --mfgClean\n");
 
     auto l_objectOption = l_app.add_option("--object, -O", l_vpdPath,
                                            "File path");
@@ -87,6 +90,14 @@ int main(int argc, char** argv)
     auto l_fixSystemVpdFlag = l_app.add_flag(
         "--fixSystemVPD",
         "Use this option to interactively fix critical system VPD keywords");
+    auto l_mfgCleanFlag = l_app.add_flag(
+        "--mfgClean", "Manufacturing clean on system VPD keyword");
+
+    auto l_mfgCleanConfirmFlag = l_app.add_flag(
+        "--yes", "Using this flag with --mfgClean option, assumes "
+                 "yes to proceed without confirmation.");
+
+    // ToDo: Take offset value from user for hardware path.
 
     CLI11_PARSE(l_app, argc, argv);
 
@@ -186,6 +197,31 @@ int main(int argc, char** argv)
     {
         vpd::VpdTool l_vpdToolObj;
         l_rc = l_vpdToolObj.fixSystemVpd();
+    }
+    else if (!l_mfgCleanFlag->empty())
+    {
+        bool l_shouldCleanSystemVpd{true};
+        if (l_mfgCleanConfirmFlag->empty())
+        {
+            constexpr auto MAX_CONFIRMATION_STR_LENGTH{3};
+            std::string l_confirmation{};
+            std::cout
+                << "This option resets some of the system VPD keywords to their default values. Do you really wish to proceed further?[yes/no]:";
+            std::cin >> std::setw(MAX_CONFIRMATION_STR_LENGTH) >>
+                l_confirmation;
+
+            if (l_confirmation != "yes")
+            {
+                l_shouldCleanSystemVpd = false;
+                l_rc = vpd::constants::SUCCESS;
+            }
+        }
+
+        if (l_shouldCleanSystemVpd)
+        {
+            vpd::VpdTool l_vpdToolObj;
+            l_rc = l_vpdToolObj.cleanSystemVpd();
+        }
     }
     else
     {


### PR DESCRIPTION
This commit implements vpd-tool --mfgClean option.
    This API resets specific System VPD keywords to default value.

1. The specified keyword values are reset on:

      - Primary EEPROM path.
      - Redundant EEPROM path(if any)
      - D-Bus cache.
      - Backup path.

2. The specific System VPD keywords are maintained as a static read only
    map in the code.
