### PR TITLE
vpd-tool utils: remove unwanted log message

### DIFF
--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -288,11 +288,6 @@ inline int writeKeyword(const std::string& i_vpdPath,
     auto l_result = l_bus.call(l_method);
 
     l_result.read(l_rc);
-
-    if (l_rc > 0)
-    {
-        std::cout << "Data updated successfully " << std::endl;
-    }
     return l_rc;
 }
 

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -277,6 +277,11 @@ int VpdTool::writeKeyword(std::string i_vpdPath,
             i_vpdPath = constants::baseInventoryPath + i_vpdPath;
             l_rc = utils::writeKeyword(i_vpdPath, l_paramsToWrite);
         }
+
+        if (l_rc > 0)
+        {
+            std::cout << "Data updated successfully " << std::endl;
+        }
     }
     catch (const std::exception& l_ex)
     {


### PR DESCRIPTION
This commit removes a log message in vpd-tool utils writeKeyword API: "Data updated successfully ". vpd-tool options like --mfgClean call utils writeKeyword API in a loop, which results in the above message being printed multiple times, polluting the desired output of --mfgClean.

Change-Id: I28e6788087d14dcdbfefb30de6a8db7f7e9c2632