### PR TITLE
vpd-tool: fixSystemVPD command more option stub

### DIFF
--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -159,6 +159,15 @@ class VpdTool
     int updateAllKeywords(const nlohmann::json& i_parsedJsonObj,
                           bool i_useBackupData) const noexcept;
 
+    /**
+     * @brief API to handle more option for fix system VPD command.
+     *
+     * @param i_parsedJsonObj - Parsed JSON object.
+     *
+     * @return On success return 0, otherwise return -1.
+     */
+    int handleMoreOption(const nlohmann::json& i_parsedJsonObj) const noexcept;
+
   public:
     /**
      * @brief Read keyword value.


### PR DESCRIPTION
This commit implements stub API to handle more option for fixSystemVPD command.

This commit shows different user options for list of keywords found in the backup and restore JSON, depend upon whether the keyword’s value found on the source and destination is same or not.

Output:
‘’’
./vpd-tool --fixSystemVPD
Enter 1 => If you choose the data on backup for all mismatching record-keyword pairs Enter 2 => If you choose the data on primary for all mismatching record-keyword pairs Enter 3 => If you wish to explore more options
Enter 0 => To exit successfully : 3

===============================================================================================================================================================================================

S.No  Record  Keyword  Backup Data                                                                Primary Data                                                               Data Mismatch
1     VSYS    BR       12                                                                         S0                                                                         YES
===============================================================================================================================================================================================
Enter 4 => If you choose the data on backup as the right value
Enter 5 => If you choose the data on primary as the right value
Enter 6 => If you wish to enter a new value to update both on backup and primary
Enter 7 => If you wish to skip the above record-keyword pair
Enter 0 => To exit successfully : 7

Skipped the above record-keyword pair. Continue to the next available pair.

S.No  Record  Keyword  Backup Data                                                                Primary Data                                                               Data Mismatch
2     VSYS    TM                                                                                                                                                             NO
===============================================================================================================================================================================================
Enter 6 => If you wish to enter a new value to update both on backup and primary
Enter 7 => If you wish to skip the above record-keyword pair
Enter 0 => To exit successfully : 0
Exit successfully
‘’’