### PR TITLE
Update udev paths for updated device tree paths

### DIFF
--- a/ibm_vpd_app.cpp
+++ b/ibm_vpd_app.cpp
@@ -1746,8 +1746,11 @@ int main(int argc, char** argv)
                                    jsonToParse));
         }
 
-        // Check if it's a udev path - patterned as(/ahb/ahb:apb/ahb:apb:bus@)
-        if (file.find("/ahb:apb") != string::npos)
+        // Check if it's a udev path - patterned as(/ahb/1e780000.apb/ for I2C
+        // or /ahb/1e790000.apb/ for FSI)
+        if (file.find("/ahb:apb") != string::npos ||
+            file.find("/ahb/1e780000.apb") != string::npos ||
+            file.find("/ahb/1e790000.apb") != string::npos)
         {
             // Translate udev path to a generic /sys/bus/.. file path.
             udevToGenericPath(file, driver);


### PR DESCRIPTION
The new device tree has a different set up for the AHB and APB, so update the udev path check appropriately.

Change-Id: I9eeb619bfae304f990f525ff01d52e40a53b2b9e