### PR TITLE
Delete FRU VPD if FRU is not present

### DIFF
--- a/vpd-manager/src/gpio_monitor.cpp
+++ b/vpd-manager/src/gpio_monitor.cpp
@@ -42,7 +42,8 @@ void GpioEventHandler::handleChangeInGpioPin(const bool& i_isFruPresent)
         }
         else
         {
-            // TODO -- Add implementation to Delete FRU if FRU is not present.
+            m_worker->deleteFruVpd(jsonUtility::getInventoryObjPathFromJson(
+                m_worker->getSysCfgJsonObj(), m_fruPath));
         }
     }
     catch (std::exception& l_ex)


### PR DESCRIPTION
GPIO event handling continuously monitors the presence of the FRU. If it detects any change, performs deletion of FRU VPD if FRU is not present, otherwise performs VPD collection if FRU gets added.

This commit adds code to perform deletion of FRU VPD over DBus if FRU is not present during GPIO event handling.