### PR TITLE
Filter "unit" object paths for dump inventory table only, add -u flag to vpd-tool writeKeyword

### DIFF
--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -1102,6 +1102,7 @@ int VpdTool::handleMoreOption(
                 }
                 else
                 {
+                    std::cout << "No mismatch found." << std::endl << std::endl;
                     printFixSystemVpdOption(types::UserOption::NewValueOnBoth);
                     printFixSystemVpdOption(types::UserOption::SkipCurrent);
                     printFixSystemVpdOption(types::UserOption::Exit);

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -722,14 +722,6 @@ int VpdTool::dumpInventory(bool i_dumpTable) const noexcept
 
             std::for_each(l_objectPaths.begin(), l_objectPaths.end(),
                           [&](const auto& l_objectPath) {
-                // if object path ends in "unit([0-9][0-9]?)", skip the object
-                // path.
-                if (std::regex_search(l_objectPath,
-                                      std::regex("unit([0-9][0-9]?)")))
-                {
-                    return;
-                }
-
                 const auto l_fruJson = getFruProperties(l_objectPath);
                 if (!l_fruJson.empty())
                 {
@@ -775,6 +767,14 @@ int VpdTool::dumpInventory(bool i_dumpTable) const noexcept
                 // iterate through the json array
                 for (const auto& l_fruEntry : l_resultInJson[0].items())
                 {
+                    // if object path ends in "unit([0-9][0-9]?)", skip adding
+                    // the object path in the table
+                    if (std::regex_search(l_fruEntry.key(),
+                                          std::regex("unit([0-9][0-9]?)")))
+                    {
+                        continue;
+                    }
+
                     std::vector<std::string> l_row;
                     for (const auto& l_column : l_tableColumns)
                     {
@@ -806,6 +806,7 @@ int VpdTool::dumpInventory(bool i_dumpTable) const noexcept
             {
                 // print JSON to console
                 utils::printJson(l_resultInJson);
+                l_rc = constants::SUCCESS;
             }
         }
     }

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -195,13 +195,13 @@ void updateFooter(CLI::App& i_app)
         "Write:\n"
         "    IPZ Format:\n"
         "        On DBus: "
-        "vpd-tool -w -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
+        "vpd-tool -w/-u -O <DBus Object Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
         "        On DBus, take keyword value from file:\n"
-        "              vpd-tool -w -O <DBus Object Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "              vpd-tool -w/-u -O <DBus Object Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
         "        On hardware: "
-        "vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
+        "vpd-tool -w/-u -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> -V <Keyword Value>\n"
         "        On hardware, take keyword value from file:\n"
-        "              vpd-tool -w -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
+        "              vpd-tool -w/-u -H -O <EEPROM Path> -R <Record Name> -K <Keyword Name> --file <File Path>\n"
         "Dump Object:\n"
         "    From DBus to console: "
         "vpd-tool -o -O <DBus Object Path>\n"
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
     auto l_writeFlag =
         l_app
             .add_flag(
-                "--writeKeyword, -w",
+                "--writeKeyword, -w,--updateKeyword, -u",
                 "Write keyword, Note: Irrespective of DBus or hardware path provided, primary and backup, redundant EEPROM(if any) paths will get updated with given key value")
             ->needs(l_objectOption)
             ->needs(l_recordOption)


### PR DESCRIPTION
1. This commit adds back object paths ending in "unit" back to the JSON
    view of vpd-tool dump inventory option. The object paths ending in
    "unit" are filtered only for the table view.
    
    This commit also fixes dump inventory JSON option returning 255 even on
    success case.

2. This commit adds -u, --updateKeyword flag to vpd-tool writeKeyword
    option. -u option is just an alias for -w option and the functionality
    of writeKeyword is unchanged.

Test results pasted with respective commit messages.
