### PR TITLE
vpd-tool: Fix dump object path

### DIFF
--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -205,7 +205,7 @@ class VpdTool
      *
      * @return On success returns 0, otherwise returns -1.
      */
-    int dumpObject(const std::string& i_fruPath) const noexcept;
+    int dumpObject(std::string i_fruPath) const noexcept;
 
     /**
      * @brief API to fix system VPD keywords.

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -89,11 +89,14 @@ int VpdTool::readKeyword(const std::string& i_vpdPath,
     return l_rc;
 }
 
-int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
+int VpdTool::dumpObject(std::string i_fruPath) const noexcept
 {
     int l_rc{constants::FAILURE};
     try
     {
+        // ToDo: For PFuture system take only full path from the user.
+        i_fruPath = constants::baseInventoryPath + i_fruPath;
+
         nlohmann::json l_resultJsonArray = nlohmann::json::array({});
         const nlohmann::json l_fruJson = getFruProperties(i_fruPath);
         if (!l_fruJson.empty())
@@ -104,16 +107,16 @@ int VpdTool::dumpObject(const std::string& i_fruPath) const noexcept
         }
         else
         {
-            std::cout << "FRU " << i_fruPath << " is not present in the system"
-                      << std::endl;
+            std::cout << "FRU [" << i_fruPath
+                      << "] is not present in the system" << std::endl;
         }
         l_rc = constants::SUCCESS;
     }
     catch (std::exception& l_ex)
     {
         // TODO: Enable logging when verbose is enabled.
-        // std::cerr << "Dump Object failed for FRU: " << i_fruPath
-        //           << " Error: " << l_ex.what() << std::endl;
+        // std::cerr << "Dump Object failed for FRU [" << i_fruPath
+        //           << "], Error: " << l_ex.what() << std::endl;
     }
     return l_rc;
 }


### PR DESCRIPTION
This commit adds the base inventory path which is, ‘/xyz/openbmc_project/inventory’ to the user given object path. As the user of the vpd-tool gives object path, which starts after this base path.

Output:
‘’’
Command without base path:
root@p10bmc:/tmp# ./vpd-tool -o -O /system/chassis
[
    {
        "/xyz/openbmc_project/inventory/system/chassis": {
            "CC": "2E33",
            "DR": "SYSTEM BACKPLANE",
            "FN": "F040221",
            "LocationCode": "U780C.ND0.1234567",
            "PN": "PN12345",
            "PrettyName": "Chassis",
            "SN": "YL2E33010000",
            "type": "xyz.openbmc_project.Inventory.Item.Chassis"
        }
    }
]

Command with base path:
root@p10bmc:/tmp# ./vpd-tool -o -O /xyz/openbmc_project/inventory/system/chassis
FRU [/xyz/openbmc_project/inventory/xyz/openbmc_project/inventory/system/chassis] is not present in the system
‘’’