### PR TITLE
Take input from file for write keyword

### DIFF
--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -723,5 +723,75 @@ class Table
     }
 };
 
+/**
+ * @brief API to read value from file.
+ *
+ * The API reads the file and returns the read value.
+ *
+ * @param[in] i_filePath - File path.
+ *
+ * @return - Value read.
+ *
+ * @throw std::runtime_error
+ */
+inline std::string readValueFromFile(const std::string& i_filePath)
+{
+    std::error_code l_ec;
+    if (!std::filesystem::exists(i_filePath, l_ec))
+    {
+        std::string l_message{"filesystem call exists failed for file: " +
+                              i_filePath};
+
+        if (l_ec)
+        {
+            l_message += ", error: " + l_ec.message();
+        }
+
+        throw std::runtime_error(l_message);
+    }
+
+    if (std::filesystem::is_empty(i_filePath, l_ec))
+    {
+        throw std::runtime_error("Empty file: " + i_filePath);
+    }
+    else if (l_ec)
+    {
+        throw std::runtime_error("is_empty file system call failed for file: " +
+                                 i_filePath + ", error: " + l_ec.message());
+    }
+
+    std::ifstream l_fileStream;
+    l_fileStream.exceptions(std::ifstream::badbit | std::ifstream::failbit);
+    try
+    {
+        l_fileStream.open(i_filePath, std::ifstream::in);
+
+        if (l_fileStream.is_open())
+        {
+            std::string l_valueRead;
+
+            std::getline(l_fileStream, l_valueRead);
+
+            l_fileStream.close();
+            return l_valueRead;
+        }
+        else
+        {
+            throw std::runtime_error("Error while opening the file " +
+                                     i_filePath);
+        }
+    }
+    catch (const std::ios_base::failure& l_ex)
+    {
+        if (l_fileStream.is_open())
+        {
+            l_fileStream.close();
+        }
+
+        throw std::runtime_error("Failed to read to file: " + i_filePath +
+                                 ", error: " + l_ex.what());
+    }
+}
+
 } // namespace utils
 } // namespace vpd

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -1,4 +1,5 @@
 #include "tool_constants.hpp"
+#include "tool_utils.hpp"
 #include "vpd_tool.hpp"
 
 #include <CLI/CLI.hpp>
@@ -43,51 +44,70 @@ int doMfgClean(const auto& i_mfgCleanConfirmFlag)
  * @param[in] i_recordName - Record to be updated.
  * @param[in] i_keywordName - Keyword to be updated.
  * @param[in] i_keywordValue - Value to be updated in keyword.
+ * @param[in] i_fileOption - Option to take keyword's value from file.
+ * @param[in] i_filePath - File path to take keyword's value.
  *
  * @return Status of writeKeyword operation, failure otherwise.
  */
 int writeKeyword(const auto& i_hardwareFlag, const auto& i_keywordValueOption,
                  const std::string& i_vpdPath, const std::string& i_recordName,
                  const std::string& i_keywordName,
-                 const std::string& i_keywordValue)
+                 const std::string& i_keywordValue, const auto& i_fileOption,
+                 const std::string& i_filePath)
 {
+    int l_rc = vpd::constants::FAILURE;
     std::error_code l_ec;
 
     if (!i_hardwareFlag->empty() && !std::filesystem::exists(i_vpdPath, l_ec))
     {
-        std::cerr << "Given EEPROM file path doesn't exist : " + i_vpdPath
-                  << std::endl;
-        return vpd::constants::FAILURE;
+        std::string l_message{"Given EEPROM file path doesn't exist : " +
+                              i_vpdPath};
+        if (l_ec)
+        {
+            l_message = "filesystem call exists failed for file: " + i_vpdPath +
+                        ", error: " + l_ec.message();
+        }
+        std::cerr << l_message << std::endl;
+        return l_rc;
     }
 
-    if (l_ec)
+    if (!i_keywordValueOption->empty() && !i_fileOption->empty())
     {
-        std::cerr << "filesystem call exists failed for file: " << i_vpdPath
-                  << ", reason: " + l_ec.message() << std::endl;
-        return vpd::constants::FAILURE;
+        std::cerr
+            << "Please provide keyword value.\nUse either --value or --file to give "
+               "keyword value. Refer --help."
+            << std::endl;
+        return l_rc;
     }
-
-    if (!i_keywordValueOption->empty() && i_keywordValue.empty())
+    else if ((i_keywordValueOption->empty() && i_fileOption->empty()) ||
+             (!i_keywordValueOption->empty() && i_keywordValue.empty()) ||
+             (!i_fileOption->empty() && i_filePath.empty()))
     {
         std::cerr
             << "Please provide keyword value.\nUse --value/--file to give "
                "keyword value. Refer --help."
             << std::endl;
-        return vpd::constants::FAILURE;
+        return l_rc;
     }
 
-    if (i_keywordValueOption->empty())
+    std::string l_keywordValue = i_keywordValue;
+
+    if (!i_filePath.empty())
     {
-        std::cerr
-            << "Please provide keyword value.\nUse --value/--file to give "
-               "keyword value. Refer --help."
-            << std::endl;
-        return vpd::constants::FAILURE;
+        try
+        {
+            l_keywordValue = vpd::utils::readValueFromFile(i_filePath);
+        }
+        catch (const std::exception& l_ex)
+        {
+            std::cerr << l_ex.what() << std::endl;
+            return l_rc;
+        }
     }
 
     vpd::VpdTool l_vpdToolObj;
     return l_vpdToolObj.writeKeyword(i_vpdPath, i_recordName, i_keywordName,
-                                     i_keywordValue, !i_hardwareFlag->empty());
+                                     l_keywordValue, !i_hardwareFlag->empty());
 }
 
 /**
@@ -236,9 +256,8 @@ int main(int argc, char** argv)
     auto l_keywordOption = l_app.add_option("--keyword, -K", l_keywordName,
                                             "Keyword name");
 
-    // Enable when file option is implemented.
-    /*auto l_fileOption = l_app.add_option("--file", l_filePath,
-                                         "Absolute file path");*/
+    auto l_fileOption = l_app.add_option("--file", l_filePath,
+                                         "Absolute file path");
 
     auto l_keywordValueOption =
         l_app.add_option("--value, -V", l_keywordValue,
@@ -304,7 +323,8 @@ int main(int argc, char** argv)
     if (!l_writeFlag->empty())
     {
         return writeKeyword(l_hardwareFlag, l_keywordValueOption, l_vpdPath,
-                            l_recordName, l_keywordName, l_keywordValue);
+                            l_recordName, l_keywordName, l_keywordValue,
+                            l_fileOption, l_filePath);
     }
 
     if (!l_dumpObjFlag->empty())


### PR DESCRIPTION
This commit adds code to read keyword’s value from the local file to update keyword’s value. User can provide file path where the value exists using --file option.

Output:
‘’’
Write keyword using object path (both primary and backup path VPD gets updated)

Before update:
root@p10bmc:/tmp# ./vpd-tool -O /system/chassis/motherboard -R VSYS -K BR -r {
    "/system/chassis/motherboard": {
        "BR": "S0"
    }
}
root@p10bmc:/tmp# ./vpd-tool -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R VSYS -K BR -r -H {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "BR": "S0"
    }
}

Input file (In ASCII format):
root@p10bmc:/tmp# cat input.txt
A2

Update keyword command:
root@p10bmc:/tmp# ./vpd-tool -O /system/chassis/motherboard -R VSYS -K BR -w --file input.txt Data updated successfully

After update:
root@p10bmc:/tmp# ./vpd-tool -O /system/chassis/motherboard -R VSYS -K BR -r {
    "/system/chassis/motherboard": {
        "BR": "A2"
    }
}
root@p10bmc:/tmp# ./vpd-tool -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R VSYS -K BR -r -H {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "BR": "A2"
    }
}

Write keyword using hardware path (updates only given hardware path):

Input file (In hexadecimal format):
root@p10bmc:/tmp# cat input.txt
0x5330

Update keyword command:
root@p10bmc:/tmp# ./vpd-tool -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R VSYS -K BR -w -H --file input.txt Data updated successfully

After update:
root@p10bmc:/tmp# ./vpd-tool -O /system/chassis/motherboard -R VSYS -K BR -r {
    "/system/chassis/motherboard": {
        "BR": "A2"
    }
}
root@p10bmc:/tmp# ./vpd-tool -O /sys/bus/i2c/drivers/at24/8-0050/eeprom -R VSYS -K BR -r -H {
    "/sys/bus/i2c/drivers/at24/8-0050/eeprom": {
        "BR": "S0"
    }
}
‘’’