### PR TITLE
vpd-tool dumpObject: show Decorator.Asset properties

### DIFF
--- a/vpd-tool/include/tool_types.hpp
+++ b/vpd-tool/include/tool_types.hpp
@@ -67,6 +67,9 @@ using TableInputData = std::vector<TableRowData>;
 // A table column name-size pair
 using TableColumnNameSizePair = std::pair<std::string, std::size_t>;
 
+/* Map<Property, Value>*/
+using PropertyMap = std::map<std::string, DbusVariantType>;
+
 enum UserOption
 {
     Exit,

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -74,6 +74,56 @@ inline types::DbusVariantType readDbusProperty(const std::string& i_serviceName,
 }
 
 /**
+ * @brief An API to get property map for an interface.
+ *
+ * This API returns a map of property and its value with respect to a particular
+ * interface.
+ *
+ * Note: It will be caller's responsibility to check for empty map returned and
+ * generate appropriate error.
+ *
+ * @param[in] i_service - Service name.
+ * @param[in] i_objectPath - object path.
+ * @param[in] i_interface - Interface, for the properties to be listed.
+ *
+ * @return - A map of property and value of an interface, if success.
+ *           if failed, empty map.
+ */
+inline types::PropertyMap
+    getPropertyMap(const std::string& i_service,
+                   const std::string& i_objectPath,
+                   const std::string& i_interface) noexcept
+{
+    types::PropertyMap l_propertyValueMap;
+    if (i_service.empty() || i_objectPath.empty() || i_interface.empty())
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cout << "Invalid parameters to get property map" << std::endl;
+        return l_propertyValueMap;
+    }
+
+    try
+    {
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call(i_service.c_str(), i_objectPath.c_str(),
+                                  "org.freedesktop.DBus.Properties", "GetAll");
+        l_method.append(i_interface);
+        auto l_result = l_bus.call(l_method);
+        l_result.read(l_propertyValueMap);
+    }
+    catch (const sdbusplus::exception::SdBusError& l_ex)
+    {
+        // TODO: Enable logging when verbose is enabled.
+        // std::cerr << "Failed to get property map for service: [" << i_service
+        //           << "], object path: [" << i_objectPath
+        //           << "] Error : " << l_ex.what() << std::endl;
+    }
+
+    return l_propertyValueMap;
+}
+
+/**
  * @brief An API to print json data on stdout.
  *
  * @param[in] i_jsonData - JSON object.

--- a/vpd-tool/include/vpd_tool.hpp
+++ b/vpd-tool/include/vpd_tool.hpp
@@ -38,7 +38,7 @@ class VpdTool
      * If FRU's "Present" property is false, this API returns an empty JSON.
      * Note: The caller of this API should handle empty JSON.
      *
-     * @throw json::exception
+     * @throw json::exception, std::out_of_range, std::bad_alloc
      */
     nlohmann::json getFruProperties(const std::string& i_objectPath) const;
 

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -115,8 +115,8 @@ int VpdTool::dumpObject(std::string i_fruPath) const noexcept
     catch (std::exception& l_ex)
     {
         // TODO: Enable logging when verbose is enabled.
-        // std::cerr << "Dump Object failed for FRU [" << i_fruPath
-        //           << "], Error: " << l_ex.what() << std::endl;
+        std::cerr << "Dump Object failed for FRU [" << i_fruPath
+                  << "], Error: " << l_ex.what() << std::endl;
     }
     return l_rc;
 }
@@ -131,9 +131,15 @@ nlohmann::json VpdTool::getFruProperties(const std::string& i_objectPath) const
 
     nlohmann::json l_fruJson = nlohmann::json::object_t({});
 
-    l_fruJson.emplace(i_objectPath, nlohmann::json::object_t({}));
+    // need to trim out the base inventory path in the FRU JSON.
+    const std::string l_displayObjectPath =
+        (i_objectPath.find(constants::baseInventoryPath) == std::string::npos)
+            ? i_objectPath
+            : i_objectPath.substr(strlen(constants::baseInventoryPath));
 
-    auto& l_fruObject = l_fruJson[i_objectPath];
+    l_fruJson.emplace(l_displayObjectPath, nlohmann::json::object_t({}));
+
+    auto& l_fruObject = l_fruJson[l_displayObjectPath];
 
     const auto l_prettyNameInJson = getInventoryPropertyJson<std::string>(
         i_objectPath, constants::inventoryItemInf, "PrettyName");


### PR DESCRIPTION
This commit adds properties under Decorator.Asset interface such as "Model","SerialNumber", etc. to the vpd-tool --dumpObject JSON. Properties under Decorator.Asset interface are derived from VINI keywords.
If a FRU doesn't have properties under VINI interface on PIM, we need to get the properties from Decorator.Asset interface.

Test:

```
root@p10bmc:~# ./vpd-tool -i
    [
        {
            "/cables/dp0_cable0": {
                "PrettyName": "NVMe Backplane Cable",
                "TYPE": "FRU",
                "type": "xyz.openbmc_project.Inventory.Item.Cable"
            },
            "/cables/dp0_cable1": {
                "PrettyName": "NVMe Backplane Cable",
                "TYPE": "FRU",
                "type": "xyz.openbmc_project.Inventory.Item.Cable"
            },
            "/system": {
                "BuildDate": "",
                "LocationCode": "U9824.42A.139EF60",
                "Manufacturer": "Inspur Power Systems",
                "Model": "9824-42A",
                "PartNumber": "",
                "PrettyName": "System",
                "SerialNumber": "139EF60",
                "SparePartNumber": "",
                "SubModel": "S0",
                "TYPE": "FRU",
                "type": "xyz.openbmc_project.Inventory.Item.System"
            },
            "/system/chassis": {
                "CC": "2E2D",
                "DR": "SYSTEM BACKPLANE",
                "FN": "03KP470",
                "LocationCode": "U78DA.ND0.WZS004A",
                "PN": "03KP542",
                "PrettyName": "Chassis",
                "SN": "YT10UF28301N",
                "TYPE": "FRU",
                "type": "xyz.openbmc_project.Inventory.Item.Chassis"
            },
            "/system/chassis/motherboard": {
                "CC": "2E2D",
                "DR": "SYSTEM BACKPLANE",
                "FN": "03KP470",
                "LocationCode": "U78DA.ND0.WZS004A-P0",
                "PN": "03KP542",
                "PrettyName": "System backplane",
                "SN": "YT10UF28301N",
                "TYPE": "FRU",
                "type": "xyz.openbmc_project.Inventory.Item.Board.Motherboard"
            },
            "/system/chassis/motherboard/base_op_panel_blyth": {
                "CC": "6B85",
                "DR": "CEC OP PANEL    ",
                "FN": "02PX028",
                "LocationCode": "U78DA.ND0.WZS004A-D0",
                "PN": "02WF427",
                "PrettyName": "Control panel",
                "SN": "YA30UF05W00R",
                "TYPE": "FRU",
                "type": "xyz.openbmc_project.Inventory.Item.Panel"
            },

```

Change-Id: Ib72738143f34a4206da15e159f450715f15b066e