### PR TITLE
Update logs and doxygen for vpd-tool

### DIFF
--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -328,10 +328,6 @@ inline int
 
     l_result.read(l_rc);
 
-    if (l_rc > 0)
-    {
-        std::cout << "Data updated successfully " << std::endl;
-    }
     return l_rc;
 }
 

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -74,17 +74,17 @@ int VpdTool::readKeyword(const std::string& i_vpdPath,
         else
         {
             // TODO: Enable logging when verbose is enabled.
-            // std::cout << "Invalid data type or empty data received." <<
-            // std::endl;
+            std::cout << "Invalid data type or empty data received."
+                      << std::endl;
         }
     }
     catch (const std::exception& l_ex)
     {
         // TODO: Enable logging when verbose is enabled.
-        /*std::cerr << "Read keyword's value for path: " << i_vpdPath
+        std::cerr << "Read keyword's value for path: " << i_vpdPath
                   << ", Record: " << i_recordName
                   << ", Keyword: " << i_keywordName
-                  << " is failed, exception: " << l_ex.what() << std::endl;*/
+                  << " is failed, exception: " << l_ex.what() << std::endl;
     }
     return l_rc;
 }

--- a/vpd-tool/src/vpd_tool_main.cpp
+++ b/vpd-tool/src/vpd_tool_main.cpp
@@ -99,7 +99,7 @@ int writeKeyword(const auto& i_hardwareFlag, const auto& i_keywordValueOption,
  * @param[in] i_keywordName - Keyword to be updated.
  * @param[in] i_filePath - File path to save keyword's read value.
  *
- * @return Status of readKeyword operation, failure otherwise.
+ * @return On success return 0, otherwise return -1.
  */
 int readKeyword(const auto& i_hardwareFlag, const std::string& i_vpdPath,
                 const std::string& i_recordName,


### PR DESCRIPTION
This commit updates the following for vpd-tool,
* Removes duplicate success log for write keyword command and updates the doxygen.
* Enables the error log for read keyword in case of error until verbose mode is enabled.