### PR TITLE
Populate RackMount as default chassis type

### DIFF
--- a/configuration/ibm/50001000.json
+++ b/configuration/ibm/50001000.json
@@ -87,7 +87,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"

--- a/configuration/ibm/50001000_v2.json
+++ b/configuration/ibm/50001000_v2.json
@@ -109,7 +109,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"

--- a/configuration/ibm/50001001.json
+++ b/configuration/ibm/50001001.json
@@ -87,7 +87,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"

--- a/configuration/ibm/50001001_v2.json
+++ b/configuration/ibm/50001001_v2.json
@@ -109,7 +109,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"

--- a/configuration/ibm/50001002.json
+++ b/configuration/ibm/50001002.json
@@ -99,7 +99,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"

--- a/configuration/ibm/50003000.json
+++ b/configuration/ibm/50003000.json
@@ -104,7 +104,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"

--- a/configuration/ibm/50003000_v2.json
+++ b/configuration/ibm/50003000_v2.json
@@ -104,7 +104,9 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "isSystemVpd": true,
                 "extraInterfaces": {
-                    "xyz.openbmc_project.Inventory.Item.Chassis": null,
+                    "xyz.openbmc_project.Inventory.Item.Chassis": {
+                        "Type": "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                    },
                     "xyz.openbmc_project.Inventory.Item.Global": null,
                     "com.ibm.ipzvpd.Location": {
                         "LocationCode": "Ufcs"


### PR DESCRIPTION
This commit updates to populate "RackMount" as default chassis type under "xyz.openbmc_project.Inventory.Item.Chassis" interface.

Output:

```
root@p10bmc:~# busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis xyz.openbmc_project.Inventory.Item.Chassis Type
s "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
```
