### PR TITLE
Fix typo error in JSON for DIMMs

### DIFF
--- a/configuration/ibm/50003000.json
+++ b/configuration/ibm/50003000.json
@@ -6850,7 +6850,7 @@
                         "LocationCode": "Ufcs-P0-C71"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "Memory Module 39"
+                        "PrettyName": "Memory module 39"
                     },
                     "xyz.openbmc_project.State.Decorator.Availability": {
                         "Available": false

--- a/configuration/ibm/50003000_v2.json
+++ b/configuration/ibm/50003000_v2.json
@@ -6850,7 +6850,7 @@
                         "LocationCode": "Ufcs-P0-C71"
                     },
                     "xyz.openbmc_project.Inventory.Item": {
-                        "PrettyName": "Memory Module 39"
+                        "PrettyName": "Memory module 39"
                     },
                     "xyz.openbmc_project.State.Decorator.Availability": {
                         "Available": false


### PR DESCRIPTION
This commit fixes the typo error in configuration JSON for DIMMs.