### PR TITLE
Revert "Everest:Missing EXP_PRSNT GPIO pin for PCIe cards (#426)"

### DIFF
--- a/config/ibm/50003000.json
+++ b/config/ibm/50003000.json
@@ -2570,11 +2570,6 @@
                 "concurrentlyMaintainable": true,
                 "devAddress": "16-0052",
                 "pcaChipAddress": "16-0062",
-                "presence": {
-                    "pin": "expander-cable-card1",
-                    "value": 0,
-                    "gpioI2CAddress": "4-0065"
-                },
                 "preAction": {
                     "pin": "presence-cable-card1",
                     "value": 1,
@@ -2641,11 +2636,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card2",
-                    "value": 0,
-                    "gpioI2CAddress": "4-0065"
-                },
                 "preAction": {
                     "pin": "presence-cable-card2",
                     "value": 1,
@@ -2714,11 +2704,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card3",
-                    "value": 0,
-                    "gpioI2CAddress": "4-0065"
-                },
                 "preAction": {
                     "pin": "presence-cable-card3",
                     "value": 1,
@@ -2787,11 +2772,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card4",
-                    "value": 0,
-                    "gpioI2CAddress": "4-0065"
-                },
                 "preAction": {
                     "pin": "presence-cable-card4",
                     "value": 1,
@@ -2860,11 +2840,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card5",
-                    "value": 0,
-                    "gpioI2CAddress": "4-0065"
-                },
                 "preAction": {
                     "pin": "presence-cable-card5",
                     "value": 1,
@@ -2933,11 +2908,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card6",
-                    "value": 0,
-                    "gpioI2CAddress": "5-0066"
-                },
                 "preAction": {
                     "pin": "presence-cable-card6",
                     "value": 1,
@@ -2975,11 +2945,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card7",
-                    "value": 0,
-                    "gpioI2CAddress": "5-0066"
-                },
                 "preAction": {
                     "pin": "presence-cable-card7",
                     "value": 1,
@@ -3048,11 +3013,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card8",
-                    "value": 0,
-                    "gpioI2CAddress": "5-0066"
-                },
                 "preAction": {
                     "pin": "presence-cable-card8",
                     "value": 1,
@@ -3121,11 +3081,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card9",
-                    "value": 0,
-                    "gpioI2CAddress": "5-0066"
-                },
                 "preAction": {
                     "pin": "presence-cable-card9",
                     "value": 1,
@@ -3163,11 +3118,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card10",
-                    "value": 0,
-                    "gpioI2CAddress": "5-0066"
-                },
                 "preAction": {
                     "pin": "presence-cable-card10",
                     "value": 1,
@@ -3236,11 +3186,6 @@
                 "busType": "i2c",
                 "driverType": "at24",
                 "concurrentlyMaintainable": true,
-                "presence": {
-                    "pin": "expander-cable-card11",
-                    "value": 0,
-                    "gpioI2CAddress": "5-0066"
-                },
                 "preAction": {
                     "pin": "presence-cable-card11",
                     "value": 1,


### PR DESCRIPTION
This reverts commit db9a46fc0f5ebd64754f7bbd8248fefebb3181f4.