### PR TITLE
vpd-manager:Update redundant D-bus property

### DIFF
--- a/vpd-manager/include/constants.hpp
+++ b/vpd-manager/include/constants.hpp
@@ -120,6 +120,7 @@ constexpr auto kwdVpdInf = "com.ibm.ipzvpd.VINI";
 constexpr auto vsysInf = "com.ibm.ipzvpd.VSYS";
 constexpr auto utilInf = "com.ibm.ipzvpd.UTIL";
 constexpr auto vcenInf = "com.ibm.ipzvpd.VCEN";
+constexpr auto vr10Inf = "com.ibm.ipzvpd.VR10";
 constexpr auto kwdCCIN = "CC";
 constexpr auto kwdRG = "RG";
 constexpr auto kwdAMM = "D0";

--- a/vpd-manager/include/utility/dbus_utility.hpp
+++ b/vpd-manager/include/utility/dbus_utility.hpp
@@ -14,6 +14,19 @@ namespace vpd
 namespace dbusUtility
 {
 
+// Map of redundant D-bus interface and D-bus property pair
+static const std::map<std::pair<std::string, std::string>,
+                      std::tuple<std::string, std::string, std::string>>
+    redundantDbusPropertyPairs{
+        {{constants::kwdVpdInf, "SN"},
+         {constants::assetInf, "SerialNumber", "ASCII"}},
+        {{constants::kwdVpdInf, "PN"},
+         {constants::assetInf, "PartNumber", "ASCII"}},
+        {{constants::kwdVpdInf, "FN"},
+         {constants::assetInf, "SparePartNumber", "ASCII"}},
+        {{constants::kwdVpdInf, "CC"}, {constants::assetInf, "Model", "ASCII"}},
+        {{constants::vr10Inf, "DC"},
+         {constants::assetInf, "BuildDate", "DATE"}}};
 /**
  * @brief An API to get Map of service and interfaces for an object path.
  *

--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -552,5 +552,15 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
                             " with error: " + std::string(l_ex.what()));
     }
 }
+
+inline std::string toString(const types::DbusVariantType& i_data)
+{
+    if (const auto l_data = std::get_if<types::BinaryVector>(&i_data);
+        l_data && !l_data->empty())
+    {
+        return std::string(l_data->begin(), l_data->end());
+    }
+    return std::string();
+}
 } // namespace vpdSpecificUtility
 } // namespace vpd


### PR DESCRIPTION
This commit has implementation to update corresponding redundant D-bus property(if any) whenever there is a VPD keyword update.

Test:
vpd-tool -w -O /system/chassis/motherboard/base_op_panel_blyth -R VINI -K SN -V "YA30UF05W02V" Data updated successfully

busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth
.SerialNumber                                         property  s         "YA30UF05W02V"

Change-Id: Ibd2c181a055a2cd69ea5f070da6977126ad3c340