### PR TITLE
Update 1 bit correction flow

### DIFF
--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -675,7 +675,7 @@ const std::string getKwVal(const Parsed& vpdMap, const std::string& rec,
         }
         else
         {
-            std::cout << "Keyword not found" << std::endl;
+            std::cout << "utils: Keyword not found" << std::endl;
         }
     }
     else


### PR DESCRIPTION
In case of 1 bit EEPROM flip ecc check algorithms detects and updates the same in the buffer passed to the algorithm.
The data in case of some FRUs is getting corrupted once the algorithm performs 1 bit correction on th evector.
Hence to avoid any data corruption in that flow, a copy of the buffer is being passed to the API and writing back to the EEPROM has been removed.