### PR TITLE
Log PEL in case of invalid system type

### DIFF
--- a/const.hpp
+++ b/const.hpp
@@ -139,7 +139,7 @@ constexpr auto errIntfForEccCheckFail = "com.ibm.VPD.Error.EccCheckFailed";
 constexpr auto errIntfForJsonFailure = "com.ibm.VPD.Error.InvalidJson";
 constexpr auto errIntfForBusFailure = "com.ibm.VPD.Error.DbusFailure";
 constexpr auto errIntfForInvalidSystemType =
-    "com.ibm.VPD.Error.UnknownSytemType";
+    "com.ibm.VPD.Error.UnknownSystemType";
 constexpr auto errIntfForEssentialFru = "com.ibm.VPD.Error.RequiredFRUMissing";
 constexpr auto errIntfForGpioError = "com.ibm.VPD.Error.GPIOError";
 constexpr auto motherBoardInterface =

--- a/ibm_vpd_utils.cpp
+++ b/ibm_vpd_utils.cpp
@@ -507,10 +507,16 @@ std::string getSystemsJson(const Parsed& vpdMap)
 
         if (js["system"].find(imKeyword) == js["system"].end())
         {
-            throw std::runtime_error(
-                "Invalid system. This system type is not present "
-                "in the systemsJson. IM: " +
-                imKeyword);
+            std::string err =
+                "Invalid system. This system type is not present in the systems Json. IM value: " +
+                imKeyword;
+
+            PelAdditionalData additionalData{};
+            additionalData.emplace("DESCRIPTION", err);
+            createPEL(additionalData, PelSeverity::CRITICAL,
+                      errIntfForInvalidSystemType, nullptr);
+
+            throw std::runtime_error(err);
         }
 
         if ((js["system"][imKeyword].find("constraint") !=


### PR DESCRIPTION
This commit adds code to log PEL if IM value doesn't match to any valid system type in the flow of getting system specific JSON.

Test:
```
root@rainvpdteam:~# peltool -i 0x50007C16
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc vpd",
    "Created at":               "05/20/2025 06:30:08",
    "Committed at":             "05/20/2025 06:30:08",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50007C16",
    "Entry Id":                 "0x50007C16",
    "BMC Event Log Id":         "2285"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Critical Error, Scope of Failure unknown",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc vpd",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "07B5",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "System type not supported in DTB table."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554006",
    "Hex Word 2":               "00080055",
    "Hex Word 3":               "07B50010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "        ",
    "Reporting Serial Number":  "       ",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1060.40-5",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554006_07B50010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "        ",
    "Serial Number":            "       "
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "2.97 0.74 0.25",
    "BMCState": "NotReady",
    "BMCUptime": "0y 0d 0h 1m 4s",
    "BootState": "",
    "ChassisState": "Off",
    "FW Version ID": "fw1060.40-5-13-g1a90ddcd67-dirty",
    "HostState": "",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "DESCRIPTION": "Invalid system. This system type is not present in the systemsJson. IM value: 50001001"
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "PEL Internal Debug Data": {
        "SRC": [
            "Unable to expand location code P0: sd_bus_call: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable"
        ]
    }
}
}
```