### PR TITLE
Update functional property during deletion of FRU

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -626,12 +626,17 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
                         }
                         else if (std::holds_alternative<bool>(l_propertyValue))
                         {
-                            // ToDo -- Update the functional status property
-                            // to true.
                             if (l_propertyName.compare("Present") ==
                                 constants::STR_CMP_SUCCESS)
                             {
                                 l_propertyMap.emplace(l_propertyName, false);
+                            }
+                            else if (l_propertyName.compare("Functional") ==
+                                     constants::STR_CMP_SUCCESS)
+                            {
+                                // Since FRU is not present functional property
+                                // is considered as true.
+                                l_propertyMap.emplace(l_propertyName, true);
                             }
                         }
                     }


### PR DESCRIPTION
This commit adds code to set functional property to true during deletion of FRU VPD over DBus. Since FRU is not present functional property is considered as true.

Change-Id: I03ec3fbb11970f1d2843b95ea9d13b8e80946a39