### PR TITLE
Monitor presence of specific FRUs

### DIFF
--- a/configuration/ibm/50003000.json
+++ b/configuration/ibm/50003000.json
@@ -2900,11 +2900,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
                 "replaceableAtRuntime": true,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan3",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 31-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 31-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },
@@ -2922,11 +2927,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
                 "replaceableAtRuntime": true,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan2",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 32-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 32-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },
@@ -2944,11 +2954,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
                 "replaceableAtRuntime": true,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan1",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 33-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 33-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },
@@ -2966,11 +2981,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtRuntime": true,
                 "handlePresence": false,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan0",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 34-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 34-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },

--- a/configuration/ibm/50003000_v2.json
+++ b/configuration/ibm/50003000_v2.json
@@ -2900,11 +2900,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
                 "replaceableAtRuntime": true,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan3",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 31-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 31-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },
@@ -2922,11 +2927,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
                 "replaceableAtRuntime": true,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan2",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 32-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 32-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },
@@ -2944,11 +2954,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "handlePresence": false,
                 "replaceableAtRuntime": true,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan1",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 33-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 33-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },
@@ -2966,11 +2981,16 @@
                 "serviceName": "xyz.openbmc_project.Inventory.Manager",
                 "replaceableAtRuntime": true,
                 "handlePresence": false,
+                "monitorPresence": true,
                 "preAction": {
                     "collection": {
-                        "gpioPresence": {
-                            "pin": "presence-fan0",
-                            "value": 0
+                        "systemCmd": {
+                            "cmd": "echo 34-0050 > /sys/bus/i2c/drivers/at24/bind"
+                        }
+                    },
+                    "deletion": {
+                        "systemCmd": {
+                            "cmd": "echo 34-0050 > /sys/bus/i2c/drivers/at24/unbind"
                         }
                     }
                 },


### PR DESCRIPTION
The commit adds flag in the JSON to mark that present property needs to be monitored for specific FRUs.
The code will look for this flag in JSON and will listen on Present property of those FRUs and based on the value updated will trigger re-collection for those FRUs.

This flag is required as some FRUs are hot pluggable and needs to be re-collected when plugged in.

Change-Id: Iaffbada09afb40ae24cd5dabd70befd22a7461f3