### PR TITLE
Update PEL severity

### DIFF
--- a/vpd-manager/oem-handler/ibm_handler.cpp
+++ b/vpd-manager/oem-handler/ibm_handler.cpp
@@ -638,7 +638,7 @@ void IbmHandler::registerPresenceChangeCallback() noexcept
     catch (const std::exception& l_ex)
     {
         EventLogger::createSyncPel(
-            EventLogger::getErrorType(l_ex), types::SeverityType::Warning,
+            EventLogger::getErrorType(l_ex), types::SeverityType::Informational,
             __FILE__, __FUNCTION__, 0,
             "Register presence change callback failed, reason: " +
                 std::string(l_ex.what()),


### PR DESCRIPTION
Updating PEL severity for callback failure to informational. No need to log predective PEL in this scenario.