### PR TITLE
1120: Fix exception type loss while parsing VPD

### DIFF
--- a/vpd-manager/src/event_logger.cpp
+++ b/vpd-manager/src/event_logger.cpp
@@ -472,7 +472,8 @@ types::ExceptionDataMap EventLogger::getExceptionData(
             // type is hardcoded.
             l_errorInfo["ErrorType"] = types::ErrorType::FirmwareError;
             l_errorInfo["ErrorMsg"] =
-                std::string("Eeprom Exception. Reason: ") + i_exception.what();
+                std::string("Standard runtime exception. Reason: ") +
+                i_exception.what();
         }
     }
     catch (const std::exception& l_ex)


### PR DESCRIPTION
This commit includes changes to prevent loss of exception type while parsing VPD. In case of Data/ECC exception while parsing IPZ VPD, the exception type was lost. This commit also handles setting PEL severity in case of Data/ECC exception. In case of Data/ECC exception while parsing VPD, predictive PEL must be logged.

Test:
```
- On rainier 2s2u simics system, corrupt VHDR data of base op panel
- On rainier 2s2u simics system, corrupt VHDR ECC of op LCD panel
- Restart vpd-manager
- Check PELs using peltool
- Observe 2 predictive PELs logged with Data Exception and ECC Exception
  respectively
```

Change-Id: I21e5b668aa70cc13916475792e38e5822c00117e