### PR TITLE
1120: Fix missing ECC update error log

### DIFF
--- a/vpd-manager/src/ipz_parser.cpp
+++ b/vpd-manager/src/ipz_parser.cpp
@@ -616,7 +616,8 @@ void IpzVpdParser::updateRecordECC(
 
     if (l_eccStatus != VPD_ECC_OK)
     {
-        throw(EccException("ECC update failed with error " + l_eccStatus));
+        throw(EccException(
+            "ECC update failed with error " + std::to_string(l_eccStatus)));
     }
 
     auto l_recordECCEnd = std::next(l_recordECCBegin, i_recordECCLength);


### PR DESCRIPTION
This commit fixes ECC update error log. Currently, when vpd-tool writeKeyword option fails due to failure in updating the record ECC in ipz parser's writeKeywordToHardware method, an ECC exception message is thrown up the call stack and gets logged in parser.cpp, however the contents of the exception message get lost. This commit fixes the missing error message.

Test:
```
- Ensure ECC update fails for given record
- Execute vpd-tool writeKeyword
- Observe following error log:

Sep 08 16:08:30 p11bmc vpd-manager[1109]: FileName: /usr/src/debug/
openpower-fru-vpd/1.0+git/vpd-manager/src/parser.cpp, Line: 226 Update
VPD Keyword failed for : VINI:PN failed due to error: Error while
updating keyword's value on hardware path /sys/bus/i2c/drivers/at24/
7-0050/eeprom, error: ECC update failed with error -1
```

Change-Id: I7a4ae822121d26618d5952f518f99d006d74441b