### PR TITLE
Error handling for JSON utility APIs

### DIFF
--- a/vpd-manager/include/utility/json_utility.hpp
+++ b/vpd-manager/include/utility/json_utility.hpp
@@ -21,26 +21,28 @@ namespace jsonUtility
 {
 
 // forward declaration of API for function map.
-bool processSystemCmdTag(const nlohmann::json& i_parsedConfigJson,
-                         const std::string& i_vpdFilePath,
-                         const std::string& i_baseAction,
-                         const std::string& i_flagToProcess);
+bool processSystemCmdTag(
+    const nlohmann::json& i_parsedConfigJson, const std::string& i_vpdFilePath,
+    const std::string& i_baseAction, const std::string& i_flagToProcess,
+    uint16_t& o_errCode);
 
 // forward declaration of API for function map.
 bool processGpioPresenceTag(
     const nlohmann::json& i_parsedConfigJson, const std::string& i_vpdFilePath,
-    const std::string& i_baseAction, const std::string& i_flagToProcess);
+    const std::string& i_baseAction, const std::string& i_flagToProcess,
+    uint16_t& o_errCode);
 
 // forward declaration of API for function map.
 bool procesSetGpioTag(const nlohmann::json& i_parsedConfigJson,
                       const std::string& i_vpdFilePath,
                       const std::string& i_baseAction,
-                      const std::string& i_flagToProcess);
+                      const std::string& i_flagToProcess, uint16_t& o_errCode);
 
 // Function pointers to process tags from config JSON.
 typedef bool (*functionPtr)(
     const nlohmann::json& i_parsedConfigJson, const std::string& i_vpdFilePath,
-    const std::string& i_baseAction, const std::string& i_flagToProcess);
+    const std::string& i_baseAction, const std::string& i_flagToProcess,
+    uint16_t& o_errCode);
 
 inline std::unordered_map<std::string, functionPtr> funcionMap{
     {"gpioPresence", processGpioPresenceTag},
@@ -238,8 +240,16 @@ inline bool executePostFailAction(
         if (itrToFunction != funcionMap.end())
         {
             if (!itrToFunction->second(i_parsedConfigJson, i_vpdFilePath,
-                                       "postFailAction", i_flagToProcess))
+                                       "postFailAction", i_flagToProcess,
+                                       o_errCode))
             {
+                if (o_errCode)
+                {
+                    logging::logMessage(
+                        l_tags.key() + " failed for [" + i_vpdFilePath +
+                        "]. Reason " +
+                        vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                }
                 return false;
             }
         }
@@ -259,47 +269,35 @@ inline bool executePostFailAction(
  * @param[in] i_baseAction - Base action for which this tag has been called.
  * @param[in] i_flagToProcess - Flag nested under the base action for which this
  * tag has been called.
+ * @param[out] o_errCode - To set error code in case of error.
  * @return Execution status.
  */
 inline bool processSystemCmdTag(
     const nlohmann::json& i_parsedConfigJson, const std::string& i_vpdFilePath,
-    const std::string& i_baseAction, const std::string& i_flagToProcess)
+    const std::string& i_baseAction, const std::string& i_flagToProcess,
+    uint16_t& o_errCode)
 {
-    try
+    if (i_vpdFilePath.empty() || i_parsedConfigJson.empty() ||
+        i_baseAction.empty() || i_flagToProcess.empty())
     {
-        if (i_vpdFilePath.empty() || i_parsedConfigJson.empty() ||
-            i_baseAction.empty() || i_flagToProcess.empty())
-        {
-            throw std::runtime_error(
-                std::string(__FUNCTION__) +
-                " Invalid parameter. Abort processing of processSystemCmd.");
-        }
-
-        if (!((i_parsedConfigJson["frus"][i_vpdFilePath].at(
-                   0)[i_baseAction][i_flagToProcess]["systemCmd"])
-                  .contains("cmd")))
-        {
-            throw JsonException(
-                std::string(__FUNCTION__) +
-                " Config JSON missing required information to execute system command for EEPROM " +
-                i_vpdFilePath);
-        }
-
-        const std::string& l_systemCommand =
-            i_parsedConfigJson["frus"][i_vpdFilePath].at(
-                0)[i_baseAction][i_flagToProcess]["systemCmd"]["cmd"];
-
-        commonUtility::executeCmd(l_systemCommand);
-        return true;
-    }
-    catch (const std::exception& l_ex)
-    {
-        EventLogger::createSyncPel(
-            EventLogger::getErrorType(l_ex), types::SeverityType::Informational,
-            __FILE__, __FUNCTION__, 0, EventLogger::getErrorMsg(l_ex),
-            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
         return false;
     }
+
+    if (!((i_parsedConfigJson["frus"][i_vpdFilePath].at(
+               0)[i_baseAction][i_flagToProcess]["systemCmd"])
+              .contains("cmd")))
+    {
+        o_errCode = error_code::MISSING_FLAG;
+        return false;
+    }
+
+    const std::string& l_systemCommand =
+        i_parsedConfigJson["frus"][i_vpdFilePath].at(
+            0)[i_baseAction][i_flagToProcess]["systemCmd"]["cmd"];
+
+    commonUtility::executeCmd(l_systemCommand);
+    return true;
 }
 
 /**
@@ -313,11 +311,13 @@ inline bool processSystemCmdTag(
  * @param[in] i_baseAction - Base action for which this tag has been called.
  * @param[in] i_flagToProcess - Flag nested under the base action for which this
  * tag has been called.
+ * @param[out] o_errCode - To set error code in case of error
  * @return Execution status.
  */
 inline bool processGpioPresenceTag(
     const nlohmann::json& i_parsedConfigJson, const std::string& i_vpdFilePath,
-    const std::string& i_baseAction, const std::string& i_flagToProcess)
+    const std::string& i_baseAction, const std::string& i_flagToProcess,
+    uint16_t& o_errCode)
 {
     std::string l_presencePinName;
     try
@@ -325,9 +325,8 @@ inline bool processGpioPresenceTag(
         if (i_vpdFilePath.empty() || i_parsedConfigJson.empty() ||
             i_baseAction.empty() || i_flagToProcess.empty())
         {
-            throw std::runtime_error(
-                std::string(__FUNCTION__) +
-                "Invalid parameter. Abort processing of processGpioPresence tag");
+            o_errCode = error_code::INVALID_INPUT_PARAMETER;
+            return false;
         }
 
         if (!(((i_parsedConfigJson["frus"][i_vpdFilePath].at(
@@ -337,10 +336,8 @@ inline bool processGpioPresenceTag(
                     0)[i_baseAction][i_flagToProcess]["gpioPresence"])
                    .contains("value"))))
         {
-            throw JsonException(
-                std::string(__FUNCTION__) +
-                "Config JSON missing required information to detect presence for EEPROM " +
-                i_vpdFilePath);
+            o_errCode = error_code::JSON_MISSING_GPIO_INFO;
+            return false;
         }
 
         // get the pin name
@@ -356,31 +353,26 @@ inline bool processGpioPresenceTag(
 
         if (!l_presenceLine)
         {
+            o_errCode = error_code::DEVICE_PRESENCE_UNKNOWN;
             throw GpioException("Couldn't find the GPIO line.");
         }
 
         l_presenceLine.request({"Read the presence line",
                                 gpiod::line_request::DIRECTION_INPUT, 0});
 
-        return (l_presencePinValue == l_presenceLine.get_value());
-    }
-    catch (const std::exception& l_ex)
-    {
-        // No need to continue in case of JSON failure or Firmware error
-        // as these are errors internal to the code and in that case the FRU
-        // should not be processed. Any other error is considered as external
-        // error in this case and a try to read the EEPROM should be done.
-        if (EventLogger::getErrorType(l_ex) == types::ErrorType::JsonFailure ||
-            EventLogger::getErrorType(l_ex) == types::ErrorType::FirmwareError)
+        if (l_presencePinValue != l_presenceLine.get_value())
         {
-            EventLogger::createSyncPel(
-                EventLogger::getErrorType(l_ex),
-                types::SeverityType::Informational, __FILE__, __FUNCTION__, 0,
-                EventLogger::getErrorMsg(l_ex), std::nullopt, std::nullopt,
-                std::nullopt, std::nullopt);
+            // As false is being returned in this case, caller needs to know
+            // that it is not due to some exception. It is because the pin was
+            // read correctly but was not having expected value.
+            o_errCode = error_code::DEVICE_NOT_PRESENT;
             return false;
         }
 
+        return true;
+    }
+    catch (const std::exception& l_ex)
+    {
         std::string l_errMsg = "Exception on GPIO line: ";
         l_errMsg += l_presencePinName;
         l_errMsg += " Reason: ";
@@ -418,11 +410,13 @@ inline bool processGpioPresenceTag(
  * @param[in] i_baseAction - Base action for which this tag has been called.
  * @param[in] i_flagToProcess - Flag nested under the base action for which this
  * tag has been called.
+ * @param[out] o_errCode - To set error code in case of error
  * @return Execution status.
  */
 inline bool procesSetGpioTag(
     const nlohmann::json& i_parsedConfigJson, const std::string& i_vpdFilePath,
-    const std::string& i_baseAction, const std::string& i_flagToProcess)
+    const std::string& i_baseAction, const std::string& i_flagToProcess,
+    uint16_t& o_errCode)
 {
     std::string l_pinName;
     try
@@ -430,9 +424,8 @@ inline bool procesSetGpioTag(
         if (i_vpdFilePath.empty() || i_parsedConfigJson.empty() ||
             i_baseAction.empty() || i_flagToProcess.empty())
         {
-            throw std::runtime_error(
-                std::string(__FUNCTION__) +
-                " Invalid parameter. Abort processing of procesSetGpio.");
+            o_errCode = error_code::INVALID_INPUT_PARAMETER;
+            return false;
         }
 
         if (!(((i_parsedConfigJson["frus"][i_vpdFilePath].at(
@@ -442,10 +435,8 @@ inline bool procesSetGpioTag(
                     0)[i_baseAction][i_flagToProcess]["setGpio"])
                    .contains("value"))))
         {
-            throw JsonException(
-                std::string(__FUNCTION__) +
-                " Config JSON missing required information to set gpio line for EEPROM " +
-                i_vpdFilePath);
+            o_errCode = error_code::JSON_MISSING_GPIO_INFO;
+            return false;
         }
 
         l_pinName = i_parsedConfigJson["frus"][i_vpdFilePath].at(
@@ -462,6 +453,7 @@ inline bool procesSetGpioTag(
 
         if (!l_outputLine)
         {
+            o_errCode = error_code::GPIO_LINE_EXCEPTION;
             throw GpioException("Couldn't find GPIO line.");
         }
 
@@ -472,37 +464,25 @@ inline bool procesSetGpioTag(
     }
     catch (const std::exception& l_ex)
     {
-        if (EventLogger::getErrorType(l_ex) != types::ErrorType::GpioError)
-        {
-            EventLogger::createSyncPel(
-                EventLogger::getErrorType(l_ex),
-                types::SeverityType::Informational, __FILE__, __FUNCTION__, 0,
-                EventLogger::getErrorMsg(l_ex), std::nullopt, std::nullopt,
-                std::nullopt, std::nullopt);
-        }
-        else
-        {
-            std::string l_errMsg = "Exception on GPIO line: ";
-            l_errMsg += l_pinName;
-            l_errMsg += " Reason: ";
-            l_errMsg += l_ex.what();
-            l_errMsg += " File: " + i_vpdFilePath + " Pel Logged";
+        std::string l_errMsg = "Exception on GPIO line: ";
+        l_errMsg += l_pinName;
+        l_errMsg += " Reason: ";
+        l_errMsg += l_ex.what();
+        l_errMsg += " File: " + i_vpdFilePath + " Pel Logged";
 
-            uint16_t l_errCode = 0;
+        uint16_t l_errCode = 0;
 
-            // ToDo -- Update Internal RC code
-            EventLogger::createAsyncPelWithInventoryCallout(
-                EventLogger::getErrorType(l_ex),
-                types::SeverityType::Informational,
-                {{getInventoryObjPathFromJson(i_parsedConfigJson, i_vpdFilePath,
-                                              l_errCode),
-                  types::CalloutPriority::High}},
-                std::source_location::current().file_name(),
-                std::source_location::current().function_name(), 0, l_errMsg,
-                std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+        // ToDo -- Update Internal RC code
+        EventLogger::createAsyncPelWithInventoryCallout(
+            EventLogger::getErrorType(l_ex), types::SeverityType::Informational,
+            {{getInventoryObjPathFromJson(i_parsedConfigJson, i_vpdFilePath,
+                                          l_errCode),
+              types::CalloutPriority::High}},
+            std::source_location::current().file_name(),
+            std::source_location::current().function_name(), 0, l_errMsg,
+            std::nullopt, std::nullopt, std::nullopt, std::nullopt);
 
-            logging::logMessage(l_errMsg);
-        }
+        logging::logMessage(l_errMsg);
 
         return false;
     }
@@ -562,11 +542,19 @@ inline bool executeBaseAction(
         auto itrToFunction = funcionMap.find(l_tag.key());
         if (itrToFunction != funcionMap.end())
         {
+            uint16_t o_errCode = 0;
             if (!itrToFunction->second(i_parsedConfigJson, i_vpdFilePath,
-                                       i_action, i_flagToProcess))
+                                       i_action, i_flagToProcess, o_errCode))
             {
                 // In case any of the tag fails to execute. Mark action
                 // as failed for that flag.
+                if (o_errCode)
+                {
+                    logging::logMessage(
+                        l_tag.key() + " failed for [" + i_vpdFilePath +
+                        "]. Reason " +
+                        vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                }
                 return false;
             }
         }

--- a/vpd-manager/include/utility/json_utility.hpp
+++ b/vpd-manager/include/utility/json_utility.hpp
@@ -1011,34 +1011,30 @@ inline bool isFruPowerOffOnly(const nlohmann::json& i_sysCfgJsonObj,
  *
  * @param[in] i_sysCfgJsonObj - System config JSON object.
  * @param[in] i_vpdFruPath - EEPROM path.
+ * @param[out] o_errCode - to set error code in case of error.
  *
  * @return true if FRU is replaceable at runtime. false otherwise.
  */
 inline bool isFruReplaceableAtRuntime(const nlohmann::json& i_sysCfgJsonObj,
-                                      const std::string& i_vpdFruPath)
+                                      const std::string& i_vpdFruPath,
+                                      uint16_t& o_errCode)
 {
-    try
+    if (i_vpdFruPath.empty())
     {
-        if (i_vpdFruPath.empty())
-        {
-            throw std::runtime_error("Given FRU path is empty.");
-        }
-
-        if (i_sysCfgJsonObj.empty() || (!i_sysCfgJsonObj.contains("frus")))
-        {
-            throw std::runtime_error("Invalid system config JSON object.");
-        }
-
-        return ((i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0))
-                    .contains("replaceableAtRuntime") &&
-                (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(
-                    0)["replaceableAtRuntime"]));
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
+        return false;
     }
-    catch (const std::exception& l_error)
+
+    if (i_sysCfgJsonObj.empty() || (!i_sysCfgJsonObj.contains("frus")))
     {
-        // TODO: Log PEL
-        logging::logMessage(l_error.what());
+        o_errCode = error_code::INVALID_JSON;
+        return false;
     }
+
+    return (
+        (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0))
+            .contains("replaceableAtRuntime") &&
+        (i_sysCfgJsonObj["frus"][i_vpdFruPath].at(0)["replaceableAtRuntime"]));
 
     return false;
 }

--- a/vpd-manager/src/gpio_monitor.cpp
+++ b/vpd-manager/src/gpio_monitor.cpp
@@ -81,9 +81,17 @@ void GpioEventHandler::handleTimerExpiry(
         return;
     }
 
+    uint16_t l_errCode = 0;
     bool l_currentPresencePinValue = jsonUtility::processGpioPresenceTag(
         m_worker->getSysCfgJsonObj(), m_fruPath, "pollingRequired",
-        "hotPlugging");
+        "hotPlugging", l_errCode);
+
+    if (l_errCode && l_errCode != error_code::DEVICE_NOT_PRESENT)
+    {
+        logging::logMessage("processGpioPresenceTag returned false for FRU [" +
+                            m_fruPath + "] Due to error. Reason: " +
+                            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+    }
 
     if (m_prevPresencePinValue != l_currentPresencePinValue)
     {
@@ -101,9 +109,17 @@ void GpioEventHandler::handleTimerExpiry(
 void GpioEventHandler::setEventHandlerForGpioPresence(
     const std::shared_ptr<boost::asio::io_context>& i_ioContext)
 {
+    uint16_t l_errCode = 0;
     m_prevPresencePinValue = jsonUtility::processGpioPresenceTag(
         m_worker->getSysCfgJsonObj(), m_fruPath, "pollingRequired",
-        "hotPlugging");
+        "hotPlugging", l_errCode);
+
+    if (l_errCode && l_errCode != error_code::DEVICE_NOT_PRESENT)
+    {
+        logging::logMessage("processGpioPresenceTag returned false for FRU [" +
+                            m_fruPath + "] Due to error. Reason: " +
+                            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+    }
 
     static std::vector<std::shared_ptr<boost::asio::steady_timer>> l_timers;
 

--- a/vpd-manager/src/worker.cpp
+++ b/vpd-manager/src/worker.cpp
@@ -1972,8 +1972,21 @@ void Worker::collectSingleFruVpd(
         // Check if host is up and running
         if (dbusUtility::isHostRunning())
         {
-            if (!jsonUtility::isFruReplaceableAtRuntime(m_parsedJson,
-                                                        l_fruPath))
+            uint16_t l_errCode = 0;
+            bool isFruReplaceableAtRuntime =
+                jsonUtility::isFruReplaceableAtRuntime(m_parsedJson, l_fruPath,
+                                                       l_errCode);
+
+            if (l_errCode)
+            {
+                logging::logMessage(
+                    "Failed to check if FRU is replaceable at runtime for FRU : [" +
+                    std::string(i_dbusObjPath) + "], error : " +
+                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                return;
+            }
+
+            if (!isFruReplaceableAtRuntime)
             {
                 logging::logMessage(
                     "Given FRU is not replaceable at host runtime. Single FRU VPD collection is not performed for " +
@@ -1996,9 +2009,21 @@ void Worker::collectSingleFruVpd(
                     vpdSpecificUtility::getErrCodeMsg(l_errCode));
             }
 
-            if (!isFruReplaceableAtStandby &&
-                (!jsonUtility::isFruReplaceableAtRuntime(m_parsedJson,
-                                                         l_fruPath)))
+            l_errCode = 0;
+            bool isFruReplaceableAtRuntime =
+                jsonUtility::isFruReplaceableAtRuntime(m_parsedJson, l_fruPath,
+                                                       l_errCode);
+
+            if (l_errCode)
+            {
+                logging::logMessage(
+                    "Failed to check if FRU is replaceable at runtime for FRU : [" +
+                    std::string(i_dbusObjPath) + "], error : " +
+                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                return;
+            }
+
+            if (!isFruReplaceableAtStandby && (!isFruReplaceableAtRuntime))
             {
                 logging::logMessage(
                     "Given FRU is neither replaceable at standby nor replaceable at runtime. Single FRU VPD collection is not performed for " +

--- a/vpd-manager/src/worker.cpp
+++ b/vpd-manager/src/worker.cpp
@@ -1359,6 +1359,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
     }
     catch (std::exception& l_ex)
     {
+        uint16_t l_errCode = 0;
         std::string l_exMsg{
             std::string(__FUNCTION__) + " : VPD parsing failed for " +
             i_vpdFilePath + " due to error: " + l_ex.what()};
@@ -1368,10 +1369,11 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
                                           "postFailAction", "collection"))
         {
             if (!jsonUtility::executePostFailAction(m_parsedJson, i_vpdFilePath,
-                                                    "collection"))
+                                                    "collection", l_errCode))
             {
-                l_exMsg +=
-                    ". Post Fail Action also failed, aborting collection for this FRU";
+                l_exMsg += ". Post fail action also failed. Error : " +
+                           vpdSpecificUtility::getErrCodeMsg(l_errCode) +
+                           " Aborting collection for this FRU.";
             }
         }
 
@@ -1805,19 +1807,23 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
     }
     catch (const std::exception& l_ex)
     {
+        uint16_t l_errCode = 0;
+        std::string l_errMsg =
+            "Failed to delete VPD for FRU : " + i_dbusObjPath +
+            " error: " + std::string(l_ex.what());
+
         if (jsonUtility::isActionRequired(m_parsedJson, l_fruPath,
                                           "postFailAction", "deletion"))
         {
             if (!jsonUtility::executePostFailAction(m_parsedJson, l_fruPath,
-                                                    "deletion"))
+                                                    "deletion", l_errCode))
             {
-                logging::logMessage(
-                    "Post fail action failed for: " + i_dbusObjPath);
+                l_errMsg += ". Post fail action also failed, error : " +
+                            vpdSpecificUtility::getErrCodeMsg(l_errCode);
             }
         }
 
-        logging::logMessage("Failed to delete VPD for FRU : " + i_dbusObjPath +
-                            " error: " + std::string(l_ex.what()));
+        logging::logMessage(l_errMsg);
     }
 }
 


### PR DESCRIPTION
Handles error codes for the following APIs

- executePostFailAction
- isFruReplaceableAtRunTime
- processSystemCmdTag
- processGpioPresenceTag
- procesSetGpioTag

Cherry-pick of following commits
https://gerrit.openbmc.org/c/openbmc/openpower-vpd-parser/+/83265
https://gerrit.openbmc.org/c/openbmc/openpower-vpd-parser/+/83270
https://gerrit.openbmc.org/c/openbmc/openpower-vpd-parser/+/83311