### PR TITLE
Fix core dump in callPIM

### DIFF
--- a/configuration/ibm/vpd_inventory.json
+++ b/configuration/ibm/vpd_inventory.json
@@ -34,7 +34,7 @@
     "frus": {
         "/sys/bus/i2c/drivers/at24/8-0050/eeprom": [
             {
-                "inventoryPath": "/system/chassis/motherboard",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard",
                 "isSystemVpd": true,
                 "extraInterfaces": {
                     "xyz.openbmc_project.Inventory.Item.Board.Motherboard": null,
@@ -44,7 +44,7 @@
                 }
             },
             {
-                "inventoryPath": "/system",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system",
                 "inherit": false,
                 "isSystemVpd": true,
                 "copyRecords": ["VSYS"],
@@ -70,7 +70,7 @@
                 }
             },
             {
-                "inventoryPath": "/system/chassis",
+                "inventoryPath": "/xyz/openbmc_project/inventory/system/chassis",
                 "inherit": false,
                 "isSystemVpd": true,
                 "extraInterfaces": {

--- a/vpd-manager/include/utility/dbus_utility.hpp
+++ b/vpd-manager/include/utility/dbus_utility.hpp
@@ -267,11 +267,10 @@ inline bool callPIM(types::ObjectMap&& objectMap)
     {
         for (const auto& l_objectKeyValue : objectMap)
         {
-            auto l_nodeHandle = objectMap.extract(l_objectKeyValue.first);
-
-            if (l_nodeHandle.key().str.find(constants::pimPath, 0) !=
+            if (l_objectKeyValue.first.str.find(constants::pimPath, 0) !=
                 std::string::npos)
             {
+                auto l_nodeHandle = objectMap.extract(l_objectKeyValue.first);
                 l_nodeHandle.key() = l_nodeHandle.key().str.replace(
                     0, std::strlen(constants::pimPath), "");
                 objectMap.insert(std::move(l_nodeHandle));


### PR DESCRIPTION
If the system config JSON does not start with the PIM base path ‘/xyz/openbmc_project/inventory’, the callPIM API fails while publishing inventory on D-Bus. This happens because the ObjectMap entry is removed before checking whether the object path starts with the PIM base path, and the entry is not reinserted if it does not.

This leaves the object invalid for the next iteration, resulting in a core dump. Changes are made to handle this issue properly.

This commit also updates inventory object path with ‘/xyz/openbmc_project/inventory’ as a base path in default system config JSON.

Change-Id: Ia9c4b0b96c9d0302787f07e5afbf896c9dfc62f9