### PR TITLE
Move getErrCodeMsg API to common_utility

### DIFF
--- a/test/utest_json_utility.cpp
+++ b/test/utest_json_utility.cpp
@@ -21,7 +21,7 @@ TEST(IsFruPowerOffOnlyTest, PositiveTestCase)
     {
         logging::logMessage(
             "Failed to parse JSON file [" + l_jsonPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
     }
 
     l_errCode = 0;
@@ -32,7 +32,7 @@ TEST(IsFruPowerOffOnlyTest, PositiveTestCase)
     {
         logging::logMessage(
             "Failed to check if FRU is power off only for FRU [" + l_vpdPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
     }
 
     EXPECT_TRUE(l_result);
@@ -50,7 +50,7 @@ TEST(IsFruPowerOffOnlyTest, NegativeTestCase)
     {
         logging::logMessage(
             "Failed to parse JSON file [" + l_jsonPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
     }
 
     l_errCode = 0;
@@ -61,7 +61,7 @@ TEST(IsFruPowerOffOnlyTest, NegativeTestCase)
     {
         logging::logMessage(
             "Failed to check if FRU is power off only for FRU [" + l_vpdPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
     }
 
     EXPECT_FALSE(l_result);

--- a/vpd-manager/include/utility/common_utility.hpp
+++ b/vpd-manager/include/utility/common_utility.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "constants.hpp"
+#include "error_codes.hpp"
 #include "logger.hpp"
 
 #include <algorithm>
@@ -36,6 +37,24 @@ namespace vpd
 
 namespace commonUtility
 {
+/**
+ * @brief API to get error code message.
+ *
+ * @param[in] i_errCode - error code.
+ *
+ * @return Error message set for that error code. Otherwise empty
+ * string.
+ */
+inline std::string getErrCodeMsg(const uint16_t& i_errCode)
+{
+    if (errorCodeMap.find(i_errCode) != errorCodeMap.end())
+    {
+        return errorCodeMap.at(i_errCode);
+    }
+
+    return std::string{};
+}
+
 /** @brief Return the hex representation of the incoming byte.
  *
  * @param [in] i_aByte - The input byte.

--- a/vpd-manager/include/utility/json_utility.hpp
+++ b/vpd-manager/include/utility/json_utility.hpp
@@ -266,8 +266,7 @@ inline bool executePostFailAction(
                 {
                     logging::logMessage(
                         l_tags.key() + " failed for [" + i_vpdFilePath +
-                        "]. Reason " +
-                        vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                        "]. Reason " + commonUtility::getErrCodeMsg(o_errCode));
                 }
                 return false;
             }
@@ -579,8 +578,7 @@ inline bool executeBaseAction(
                 {
                     logging::logMessage(
                         l_tag.key() + " failed for [" + i_vpdFilePath +
-                        "]. Reason " +
-                        vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                        "]. Reason " + commonUtility::getErrCodeMsg(o_errCode));
                 }
                 return false;
             }
@@ -828,7 +826,7 @@ inline std::vector<std::string> getListOfGpioPollingFrus(
             logging::logMessage(
                 "Error while checking if action required for FRU [" +
                 std::string(l_fruPath) +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(o_errCode));
 
             return l_gpioPollingRequiredFrusList;
         }
@@ -898,8 +896,8 @@ inline std::tuple<std::string, std::string, std::string>
             {
                 logging::logMessage(
                     "Failed to get inventory path from JSON for [" +
-                    io_vpdPath + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                    io_vpdPath +
+                    "], error : " + commonUtility::getErrCodeMsg(o_errCode));
             }
             else
             {
@@ -920,8 +918,8 @@ inline std::tuple<std::string, std::string, std::string>
             {
                 logging::logMessage(
                     "Failed to get redundant EEPROM path for FRU [" +
-                    l_fruPath + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                    l_fruPath +
+                    "], error : " + commonUtility::getErrCodeMsg(o_errCode));
 
                 o_errCode = error_code::ERROR_GETTING_REDUNDANT_PATH;
             }
@@ -938,7 +936,7 @@ inline std::tuple<std::string, std::string, std::string>
     {
         logging::logMessage(
             "Failed to get FRU path from JSON for [" + io_vpdPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(o_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(o_errCode));
     }
     else
     {
@@ -1199,7 +1197,7 @@ inline nlohmann::json getPowerVsJson(const types::BinaryVector& i_imValue,
             logging::logMessage(
                 "Failed to parse JSON file [ " +
                 std::string(constants::power_vs_50003_json) +
-                " ], error : " + vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                " ], error : " + commonUtility::getErrCodeMsg(o_errCode));
         }
 
         return l_parsedJson;
@@ -1216,7 +1214,7 @@ inline nlohmann::json getPowerVsJson(const types::BinaryVector& i_imValue,
             logging::logMessage(
                 "Failed to parse JSON file [ " +
                 std::string(constants::power_vs_50001_json) +
-                " ], error : " + vpdSpecificUtility::getErrCodeMsg(o_errCode));
+                " ], error : " + commonUtility::getErrCodeMsg(o_errCode));
         }
 
         return l_parsedJson;

--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -3,7 +3,6 @@
 #include "config.h"
 
 #include "constants.hpp"
-#include "error_codes.hpp"
 #include "event_logger.hpp"
 #include "exceptions.hpp"
 #include "logger.hpp"
@@ -1067,24 +1066,6 @@ inline void updateCiPropertyOfInheritedFrus(
             "Failed to update common interface properties of FRU [" +
             i_fruPath + "]. Error: " + std::string(l_ex.what()));
     }
-}
-
-/**
- * @brief API to get error code message.
- *
- * @param[in] i_errCode - error code.
- *
- * @return Error message set for that error code. Otherwise empty
- * string.
- */
-inline std::string getErrCodeMsg(const uint16_t& i_errCode)
-{
-    if (errorCodeMap.find(i_errCode) != errorCodeMap.end())
-    {
-        return errorCodeMap.at(i_errCode);
-    }
-
-    return std::string{};
 }
 } // namespace vpdSpecificUtility
 } // namespace vpd

--- a/vpd-manager/oem-handler/ibm_handler.cpp
+++ b/vpd-manager/oem-handler/ibm_handler.cpp
@@ -62,7 +62,7 @@ IbmHandler::IbmHandler(
     {
         logging::logMessage(
             "Failed to check if backup & restore required. Error : " +
-            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            commonUtility::getErrCodeMsg(l_errCode));
     }
 
     // Instantiate Listener object
@@ -230,8 +230,8 @@ void IbmHandler::checkAndUpdatePowerVsVpd(
             {
                 logging::logMessage(
                     "Failed to get inventory object path from JSON for FRU [" +
-                    l_fruPath + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    l_fruPath +
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode));
             }
 
             o_failedPathList.push_back(l_fruPath);
@@ -370,9 +370,8 @@ void IbmHandler::ConfigurePowerVsSystem()
 
         if (l_powerVsJsonObj.empty())
         {
-            throw std::runtime_error(
-                "PowerVS Json not found. Error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            throw std::runtime_error("PowerVS Json not found. Error : " +
+                                     commonUtility::getErrCodeMsg(l_errCode));
         }
 
         checkAndUpdatePowerVsVpd(l_powerVsJsonObj, l_failedPathList);

--- a/vpd-manager/src/backup_restore.cpp
+++ b/vpd-manager/src/backup_restore.cpp
@@ -29,7 +29,7 @@ BackupAndRestore::BackupAndRestore(const nlohmann::json& i_sysCfgJsonObj) :
     {
         throw JsonException(
             "JSON parsing failed for file [" + l_backupAndRestoreCfgFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode),
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode),
             l_backupAndRestoreCfgFilePath);
     }
 }
@@ -163,7 +163,7 @@ void BackupAndRestore::backupAndRestoreIpzVpd(
     {
         logging::logMessage(
             "Failed to get source FRU path for [" + i_srcPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         return;
     }
 
@@ -174,7 +174,7 @@ void BackupAndRestore::backupAndRestoreIpzVpd(
     {
         logging::logMessage(
             "Failed to get destination FRU path for [" + i_dstPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         return;
     }
 
@@ -194,7 +194,7 @@ void BackupAndRestore::backupAndRestoreIpzVpd(
         {
             logging::logMessage(
                 "Couldn't find source inventory path. Error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                commonUtility::getErrCodeMsg(l_errCode));
             return;
         }
 
@@ -211,7 +211,7 @@ void BackupAndRestore::backupAndRestoreIpzVpd(
         {
             logging::logMessage(
                 "Couldn't find destination inventory path. Error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                commonUtility::getErrCodeMsg(l_errCode));
             return;
         }
 
@@ -226,7 +226,7 @@ void BackupAndRestore::backupAndRestoreIpzVpd(
     {
         logging::logMessage(
             "Failed to get service name for source FRU [" + l_srcInvPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         return;
     }
 
@@ -237,7 +237,7 @@ void BackupAndRestore::backupAndRestoreIpzVpd(
     {
         logging::logMessage(
             "Failed to get service name for destination FRU [" + l_dstInvPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         return;
     }
 

--- a/vpd-manager/src/event_logger.cpp
+++ b/vpd-manager/src/event_logger.cpp
@@ -7,6 +7,7 @@
 
 #include <systemd/sd-bus.h>
 
+#include <utility/common_utility.hpp>
 #include <utility/json_utility.hpp>
 #include <utility/vpd_specific_utility.hpp>
 
@@ -363,7 +364,7 @@ void EventLogger::createSyncPelWithInvCallOut(
                             "Failed to parse JSON file [ " +
                             std::string(INVENTORY_JSON_SYM_LINK) +
                             " ], error : " +
-                            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                            commonUtility::getErrCodeMsg(l_errCode));
                     }
 
                     l_calloutInvPath = jsonUtility::getInventoryObjPathFromJson(
@@ -385,8 +386,8 @@ void EventLogger::createSyncPelWithInvCallOut(
             {
                 logging::logMessage(
                     "Failed to get inventory object path from JSON for FRU [" +
-                    std::get<0>(i_callouts[0]) + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    std::get<0>(i_callouts[0]) +
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode));
             }
         }
 

--- a/vpd-manager/src/gpio_monitor.cpp
+++ b/vpd-manager/src/gpio_monitor.cpp
@@ -52,7 +52,7 @@ void GpioEventHandler::handleChangeInGpioPin(const bool& i_isFruPresent)
             {
                 throw std::runtime_error(
                     "Failed to get inventory path from JSON, error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    commonUtility::getErrCodeMsg(l_errCode));
             }
 
             m_worker->deleteFruVpd(l_invPath);
@@ -90,7 +90,7 @@ void GpioEventHandler::handleTimerExpiry(
     {
         logging::logMessage("processGpioPresenceTag returned false for FRU [" +
                             m_fruPath + "] Due to error. Reason: " +
-                            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                            commonUtility::getErrCodeMsg(l_errCode));
     }
 
     if (m_prevPresencePinValue != l_currentPresencePinValue)
@@ -118,7 +118,7 @@ void GpioEventHandler::setEventHandlerForGpioPresence(
     {
         logging::logMessage("processGpioPresenceTag returned false for FRU [" +
                             m_fruPath + "] Due to error. Reason: " +
-                            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                            commonUtility::getErrCodeMsg(l_errCode));
     }
 
     static std::vector<std::shared_ptr<boost::asio::steady_timer>> l_timers;
@@ -145,7 +145,7 @@ void GpioMonitor::initHandlerForGpio(
     {
         logging::logMessage(
             "Failed to get list of frus required for gpio polling. Error : " +
-            vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            commonUtility::getErrCodeMsg(l_errCode));
         return;
     }
 

--- a/vpd-manager/src/listener.cpp
+++ b/vpd-manager/src/listener.cpp
@@ -181,7 +181,7 @@ void Listener::registerPresenceChangeCallback() noexcept
         {
             logging::logMessage(
                 "Failed to get list of FRUs with presence monitoring, error: " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                commonUtility::getErrCodeMsg(l_errCode));
             return;
         }
 
@@ -268,11 +268,10 @@ void Listener::registerCorrPropCallBack(
 
         if (l_errCode)
         {
-            throw JsonException(
-                "Failed to parse correlated properties JSON [" +
-                    i_correlatedPropJsonFile + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode),
-                i_correlatedPropJsonFile);
+            throw JsonException("Failed to parse correlated properties JSON [" +
+                                    i_correlatedPropJsonFile + "], error : " +
+                                    commonUtility::getErrCodeMsg(l_errCode),
+                                i_correlatedPropJsonFile);
         }
 
         const nlohmann::json& l_serviceJsonObjectList =

--- a/vpd-manager/src/manager.cpp
+++ b/vpd-manager/src/manager.cpp
@@ -192,7 +192,7 @@ int Manager::updateKeyword(const types::Path i_vpdPath,
         {
             logging::logMessage(
                 "Failed to get FRU path from JSON for [" + i_vpdPath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         }
 
         l_fruPath = i_vpdPath;

--- a/vpd-manager/src/parser.cpp
+++ b/vpd-manager/src/parser.cpp
@@ -43,7 +43,7 @@ Parser::Parser(const std::string& vpdFilePath, nlohmann::json parsedJson) :
         {
             logging::logMessage(
                 "Failed to get vpd offset for path [" + m_vpdFilePath +
-                "], error: " + vpdSpecificUtility::getErrCodeMsg(l_errorCode));
+                "], error: " + commonUtility::getErrCodeMsg(l_errorCode));
         }
     }
 }
@@ -137,7 +137,7 @@ int Parser::updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData,
         {
             throw std::runtime_error(
                 "Failed to get paths to update keyword. Error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                commonUtility::getErrCodeMsg(l_errCode));
         }
 
         // If inventory D-bus object path is present, update keyword's value on
@@ -217,7 +217,7 @@ int Parser::updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData,
 
         if (l_errCode == error_code::ERROR_GETTING_REDUNDANT_PATH)
         {
-            logging::logMessage(vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            logging::logMessage(commonUtility::getErrCodeMsg(l_errCode));
         }
 
         // Update keyword's value on redundant hardware if present
@@ -406,7 +406,7 @@ int Parser::performSanityCheck() noexcept
             logging::logMessage(
                 "Failed to get redundant EEPROM path for FRU [" +
                 m_vpdFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
             return l_rcPrimary;
         }
 

--- a/vpd-manager/src/single_fab.cpp
+++ b/vpd-manager/src/single_fab.cpp
@@ -31,8 +31,8 @@ std::string SingleFab::getImFromPersistedLocation() const noexcept
         {
             throw JsonException(
                 "Failed to parse JSON file [ " +
-                    std::string(pimPersistVsbpPath) + " ], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode),
+                    std::string(pimPersistVsbpPath) +
+                    " ], error : " + commonUtility::getErrCodeMsg(l_errCode),
                 pimPersistVsbpPath);
         }
 

--- a/vpd-manager/src/worker.cpp
+++ b/vpd-manager/src/worker.cpp
@@ -12,6 +12,7 @@
 #include "parser_factory.hpp"
 #include "parser_interface.hpp"
 
+#include <utility/common_utility.hpp>
 #include <utility/dbus_utility.hpp>
 #include <utility/json_utility.hpp>
 #include <utility/vpd_specific_utility.hpp>
@@ -50,8 +51,7 @@ Worker::Worker(std::string pathToConfigJson, uint8_t i_maxThreadCount) :
             {
                 throw std::runtime_error(
                     "JSON parsing failed for file [ " + m_configJsonPath +
-                    " ], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    " ], error : " + commonUtility::getErrCodeMsg(l_errCode));
             }
 
             // check for mandatory fields at this point itself.
@@ -392,7 +392,7 @@ void Worker::setDeviceTreeAndJson()
     {
         throw(JsonException(
             "JSON parsing failed for file [ " + systemJson +
-                " ], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode),
+                " ], error : " + commonUtility::getErrCodeMsg(l_errCode),
             systemJson));
     }
 
@@ -433,7 +433,7 @@ void Worker::setDeviceTreeAndJson()
             {
                 logging::logMessage(
                     "Failed to check if backup and restore required. Reason : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    commonUtility::getErrCodeMsg(l_errCode));
             }
         }
 
@@ -1283,7 +1283,7 @@ bool Worker::processPostAction(
     {
         logging::logMessage(
             "Execution of post action failed for path: " + i_vpdFruPath +
-            " . Reason: " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+            " . Reason: " + commonUtility::getErrCodeMsg(l_errCode));
 
         // If post action was required and failed only in that case return
         // false. In all other case post action is considered passed.
@@ -1318,7 +1318,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
                 if (l_errCode == error_code::DEVICE_NOT_PRESENT)
                 {
                     logging::logMessage(
-                        vpdSpecificUtility::getErrCodeMsg(l_errCode) +
+                        commonUtility::getErrCodeMsg(l_errCode) +
                         i_vpdFilePath);
                     // Presence pin has been read successfully and has been read
                     // as false, so this is not a failure case, hence returning
@@ -1328,7 +1328,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
                 throw std::runtime_error(
                     std::string(__FUNCTION__) +
                     " Pre-Action failed with error: " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    commonUtility::getErrCodeMsg(l_errCode));
             }
         }
         else if (l_errCode)
@@ -1336,7 +1336,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
             logging::logMessage(
                 "Failed to check if pre action required for FRU [" +
                 i_vpdFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         }
 
         if (!std::filesystem::exists(i_vpdFilePath))
@@ -1382,7 +1382,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
             logging::logMessage(
                 "Error while checking if post action required for FRU [" +
                 i_vpdFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         }
 
         return l_parsedVpd;
@@ -1403,7 +1403,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
                                                     "collection", l_errCode))
             {
                 l_exMsg += ". Post fail action also failed. Error : " +
-                           vpdSpecificUtility::getErrCodeMsg(l_errCode) +
+                           commonUtility::getErrCodeMsg(l_errCode) +
                            " Aborting collection for this FRU.";
             }
         }
@@ -1411,7 +1411,7 @@ types::VPDMapVariant Worker::parseVpdFile(const std::string& i_vpdFilePath)
         {
             l_exMsg +=
                 ". Failed to check if post fail action required, error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode);
+                commonUtility::getErrCodeMsg(l_errCode);
         }
 
         if (typeid(l_ex) == typeid(DataException))
@@ -1451,7 +1451,7 @@ std::tuple<bool, std::string> Worker::parseAndPublishVPD(
         {
             logging::logMessage(
                 "Failed to get inventory path for FRU [" + i_vpdFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
             return std::make_tuple(false, i_vpdFilePath);
         }
         else if (!l_inventoryPath.empty())
@@ -1463,8 +1463,7 @@ std::tuple<bool, std::string> Worker::parseAndPublishVPD(
             {
                 logging::logMessage(
                     "Failed to get service name for path [" + l_inventoryPath +
-                    "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode));
             }
             else
             {
@@ -1523,8 +1522,8 @@ std::tuple<bool, std::string> Worker::parseAndPublishVPD(
                 {
                     logging::logMessage(
                         "Failed to get inventory object path from JSON for FRU [" +
-                        i_vpdFilePath + "], error: " +
-                        vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                        i_vpdFilePath +
+                        "], error: " + commonUtility::getErrCodeMsg(l_errCode));
                 }
 
                 const std::string& l_invPathLeafValue =
@@ -1597,7 +1596,7 @@ bool Worker::skipPathForCollection(const std::string& i_vpdFilePath)
             logging::logMessage(
                 "Failed to check if FRU is power off only for FRU [" +
                 i_vpdFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
         }
 
         l_errCode = 0;
@@ -1609,7 +1608,7 @@ bool Worker::skipPathForCollection(const std::string& i_vpdFilePath)
             logging::logMessage(
                 "Failed to get inventory path from JSON for FRU [" +
                 i_vpdFilePath +
-                "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                "], error : " + commonUtility::getErrCodeMsg(l_errCode));
 
             return false;
         }
@@ -1689,8 +1688,8 @@ void Worker::performBackupAndRestore(types::VPDMapVariant& io_srcVpdMap)
         {
             throw JsonException(
                 "JSON parsing failed for file [ " +
-                    l_backupAndRestoreCfgFilePath + " ], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode),
+                    l_backupAndRestoreCfgFilePath +
+                    " ], error : " + commonUtility::getErrCodeMsg(l_errCode),
                 l_backupAndRestoreCfgFilePath);
         }
 
@@ -1745,7 +1744,7 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
     {
         logging::logMessage(
             "Failed to get FRU path for inventory path [" + i_dbusObjPath +
-            "], error : " + vpdSpecificUtility::getErrCodeMsg(l_errCode) +
+            "], error : " + commonUtility::getErrCodeMsg(l_errCode) +
             " Aborting FRU VPD deletion.");
         return;
     }
@@ -1768,7 +1767,7 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
             {
                 throw std::runtime_error(
                     "Failed to check if FRU's presence is handled, reason: " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    commonUtility::getErrCodeMsg(l_errCode));
             }
 
             if (!(*l_value) && l_isFruPresenceHandled)
@@ -1791,9 +1790,8 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
                         std::string l_msg = "Pre action failed";
                         if (l_errCode)
                         {
-                            l_msg +=
-                                " Reason: " +
-                                vpdSpecificUtility::getErrCodeMsg(l_errCode);
+                            l_msg += " Reason: " +
+                                     commonUtility::getErrCodeMsg(l_errCode);
                         }
                         throw std::runtime_error(l_msg);
                     }
@@ -1803,7 +1801,7 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
                     logging::logMessage(
                         "Failed to check if pre action required for FRU [" +
                         l_fruPath + "], error : " +
-                        vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                        commonUtility::getErrCodeMsg(l_errCode));
                 }
 
                 std::vector<std::string> l_interfaceList{
@@ -1854,7 +1852,7 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
                     logging::logMessage(
                         "Failed to check if post action required during deletion for FRU [" +
                         l_fruPath + "], error : " +
-                        vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                        commonUtility::getErrCodeMsg(l_errCode));
                 }
             }
         }
@@ -1884,14 +1882,14 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
                                                     "deletion", l_errCode))
             {
                 l_errMsg += ". Post fail action also failed, error : " +
-                            vpdSpecificUtility::getErrCodeMsg(l_errCode);
+                            commonUtility::getErrCodeMsg(l_errCode);
             }
         }
         else if (l_errCode)
         {
             l_errMsg +=
                 ". Failed to check if post fail action required, error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode);
+                commonUtility::getErrCodeMsg(l_errCode);
         }
 
         logging::logMessage(l_errMsg);
@@ -1989,7 +1987,7 @@ void Worker::performVpdRecollection()
         {
             logging::logMessage(
                 "Failed to get list of FRUs replaceable at runtime, error : " +
-                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                commonUtility::getErrCodeMsg(l_errCode));
             return;
         }
 
@@ -2038,8 +2036,8 @@ void Worker::collectSingleFruVpd(
             {
                 logging::logMessage(
                     "Failed to get FRU path for [" +
-                    std::string(i_dbusObjPath) + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode) +
+                    std::string(i_dbusObjPath) +
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode) +
                     " Aborting single FRU VPD collection.");
                 return;
             }
@@ -2062,8 +2060,8 @@ void Worker::collectSingleFruVpd(
             {
                 logging::logMessage(
                     "Failed to check if FRU is replaceable at runtime for FRU : [" +
-                    std::string(i_dbusObjPath) + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    std::string(i_dbusObjPath) +
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode));
                 return;
             }
 
@@ -2086,8 +2084,8 @@ void Worker::collectSingleFruVpd(
             {
                 logging::logMessage(
                     "Error while checking if FRU is replaceable at standby for FRU [" +
-                    std::string(i_dbusObjPath) + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    std::string(i_dbusObjPath) +
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode));
             }
 
             l_errCode = 0;
@@ -2099,8 +2097,8 @@ void Worker::collectSingleFruVpd(
             {
                 logging::logMessage(
                     "Failed to check if FRU is replaceable at runtime for FRU : [" +
-                    std::string(i_dbusObjPath) + "], error : " +
-                    vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                    std::string(i_dbusObjPath) +
+                    "], error : " + commonUtility::getErrCodeMsg(l_errCode));
                 return;
             }
 
@@ -2124,7 +2122,7 @@ void Worker::collectSingleFruVpd(
         {
             logging::logMessage("Failed to get service name for path [" +
                                 std::string(i_dbusObjPath) + "], error : " +
-                                vpdSpecificUtility::getErrCodeMsg(l_errCode));
+                                commonUtility::getErrCodeMsg(l_errCode));
         }
         else
         {


### PR DESCRIPTION
This commit moves the getErrCodeMsg API from vpd_specific_utility to common_utility file, to make it accessible to the other utility files.

Change-Id: Ib0aeeb2386ba2c55f2447d65a3be18b76eff46f3