### PR TITLE
Fix: AssetTag missing after ForceReset command

### DIFF
--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -1366,6 +1366,35 @@ int VpdTool::resetVpdOnDbus()
         }
 
         std::error_code l_ec;
+        if (std::filesystem::exists(INVENTORY_JSON_SYM_LINK, l_ec) &&
+            !std::filesystem::remove(INVENTORY_JSON_SYM_LINK, l_ec))
+        {
+            std::cerr
+                << "Error occured while removing the system inventory JSON sym link ["
+                << INVENTORY_JSON_SYM_LINK << "]." << std::endl;
+
+            if (l_ec)
+            {
+                std::cerr << "Reason: " << l_ec.message() << std::endl;
+            }
+
+            std::string l_vpdManagerStartCmd(
+                "systemctl start " +
+                std::string(constants::vpdManagerProcessName));
+
+            std::cout << std::flush;
+            if (auto l_rc = std::system(l_vpdManagerStartCmd.c_str());
+                l_rc != 0)
+            {
+                std::cerr << "Failed to start "
+                          << constants::vpdManagerProcessName
+                          << " service. Return code [" << l_rc << "]. Exiting."
+                          << std::endl
+                          << "Reboot BMC to recover the system." << std::endl;
+            }
+            return l_rc;
+        }
+
         if (static_cast<std::uintmax_t>(-1) ==
             std::filesystem::remove_all(constants::pimPersistPath, l_ec))
         {


### PR DESCRIPTION
AssetTag property is not showing on dbus after executing vpd-tool forceReset command, this commit fixes the issue by removing system inventory JSON symbolic link so that the assetTag property on D-Bus can be recreated when vpd-manager restarts.

Change-Id: I8139b1f935d0ed93c0fc99a19a082e47b73b53c8