### PR TITLE
Disable sanity check

### DIFF
--- a/vpd-manager/src/ipz_parser.cpp
+++ b/vpd-manager/src/ipz_parser.cpp
@@ -16,7 +16,7 @@
 namespace vpd
 {
 
-#define SANITY_CHECK 1
+#define SANITY_CHECK 0
 
 // Offset of different entries in VPD data.
 enum Offset


### PR DESCRIPTION
The commit disables sanity check as there is a suspected issue in writing back to the file and becasue of that sanity check just after writing to the file fails resulting in block of any write.