### PR TITLE
Add runtime flag in logger

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ conf_data.set_quoted(
 conf_data.set_quoted('SYSTEM_VPD_FILE_PATH', get_option('SYSTEM_VPD_FILE_PATH'))
 conf_data.set_quoted('VPD_SYMLIMK_PATH', get_option('VPD_SYMLIMK_PATH'))
 conf_data.set_quoted('PIM_PATH_PREFIX', get_option('PIM_PATH_PREFIX'))
+conf_data.set_quoted('LOG_FILE_PATH', get_option('LOG_FILE_PATH'))
 configure_file(output: 'config.h', configuration: conf_data)
 
 services = ['service_files/vpd-manager.service']

--- a/meson.options
+++ b/meson.options
@@ -65,3 +65,9 @@ option(
     value: 'enabled',
     description: 'Enable code specific to IBM systems.',
 )
+option(
+    'LOG_FILE_PATH',
+    type: 'string',
+    value: '/var/lib/vpd/',
+    description: 'File path to dump the log.',
+)

--- a/vpd-manager/include/logger.hpp
+++ b/vpd-manager/include/logger.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "types.hpp"
+#include "config.h"
 
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <source_location>
@@ -99,6 +101,19 @@ class Logger
                     const std::source_location& i_location =
                         std::source_location::current());
 
+    void enableFileLogging()
+    {
+#ifdef ENABLE_FILE_LOGGING
+        std::string fileName = LOG_FILE_PATH;
+        fileName = fileName + "test.log"; //sync it with upstream
+        m_fileStream.open(fileName.data(), std::ios::app);
+
+        std::cout << "[INFO]Logging to" << fileName << std::endl;
+#else
+	std::cout << "[INFO]Logging to console" << std::endl;
+#endif
+    }
+
   private:
     /**
      * @brief Constructor
@@ -114,6 +129,9 @@ class Logger
 
     // Instance to LogFileHandler class.
     std::shared_ptr<LogFileHandler> m_logFileHandler;
+    
+    // file stream for file operation
+    std::ofstream m_fileStream;
 };
 
 /**

--- a/vpd-manager/meson.build
+++ b/vpd-manager/meson.build
@@ -34,6 +34,7 @@ parser_dependencies = [
 parser_build_arguments = []
 if get_option('ibm_system').allowed()
     parser_build_arguments += ['-DIBM_SYSTEM']
+    parser_build_arguments += ['-DENABLE_FILE_LOGGING=false']
     vpd_manager_SOURCES += 'src/single_fab.cpp'
 endif
 

--- a/vpd-manager/src/logger.cpp
+++ b/vpd-manager/src/logger.cpp
@@ -17,8 +17,12 @@ void Logger::logMessage(std::string_view i_message,
 
     if (i_placeHolder == PlaceHolder::COLLECTION)
     {
-        // Log it to a specific place.
+#ifdef ENABLE_FILE_LOGGING
+	    // Log it to a specific place.
         m_logFileHandler->writeLogToFile(i_placeHolder);
+#else
+        std::cout << l_log.str() << std::endl;
+#endif
     }
     else if (i_placeHolder == PlaceHolder::PEL)
     {

--- a/vpd-manager/src/manager_main.cpp
+++ b/vpd-manager/src/manager_main.cpp
@@ -37,6 +37,7 @@ int main(int, char**)
 
         interface->initialize();
 
+	vpd::Logger::getLoggerInstance()->enableFileLogging();
         vpd::logging::logMessage("Start VPD-Manager event loop");
 
         // Grab the bus name


### PR DESCRIPTION
Add a flag to logger
    
This commit adds one config flag in meson, to be used at build
time. This flag is to decide whether the logs will dump in a file
or will go the the console by default.
    
Test:
 Image built with file logging enabled, and so all the logs are
 part of log file.
    
 $cat /var/lib/vpd/test.log |grep -i  "sanity"
    FileName: /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/logger.cpp, Line: 59 Performing sanity check for file path: /sys/bus/spi/drivers/at25/spi12.0/eeprom
    FileName: /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/logger.cpp, Line: 59 Sanity checker Passed for /sys/bus/spi/drivers/at25/spi12.0/eeprom
    FileName: /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/logger.cpp, Line: 59 Performing sanity check for file path: /sys/bus/spi/drivers/at25/spi13.0/eeprom
    FileName: /usr/src/debug/openpower-fru-vpd/1.0+git/vpd-manager/src/logger.cpp, Line: 59 Sanity checker Passed for /sys/bus/spi/drivers/at25/spi13.0/eeprom
    root@rainvpdteam:~#