### PR TITLE
Fix sanity check failure due to unwritten data

### DIFF
--- a/vpd-manager/src/ipz_parser.cpp
+++ b/vpd-manager/src/ipz_parser.cpp
@@ -626,6 +626,7 @@ void IpzVpdParser::updateRecordECC(
 
     std::copy(l_recordECCBegin, l_recordECCEnd,
               std::ostreambuf_iterator<char>(m_vpdFileStream));
+    m_vpdFileStream.flush();
 }
 
 int IpzVpdParser::setKeywordValueInRecord(
@@ -707,6 +708,7 @@ int IpzVpdParser::setKeywordValueInRecord(
 
             std::copy(i_keywordData.cbegin(), i_keywordDataEnd,
                       std::ostreambuf_iterator<char>(m_vpdFileStream));
+            m_vpdFileStream.flush();
 
             // return no of bytes set
             return l_lengthToUpdate;


### PR DESCRIPTION
The 'write' keyword operation in the vpd module was failing during the sanity check with an ECC error. This occurred because the updated keyword data and ECC were not yet written to the file when the sanity check was performed.

To address this, an explicit flush is now called after writing the data to ensure it is written to the file immediately. With this change, the ECC check no longer fails during the sanity check.

Change-Id: If4fbda85310422f694e421018db5900b1bb5e6be