### PR TITLE
Fix sanity check failure due to unwritten data

### DIFF
--- a/vpd-manager/src/ipz_parser.cpp
+++ b/vpd-manager/src/ipz_parser.cpp
@@ -16,7 +16,7 @@
 namespace vpd
 {
 
-#define SANITY_CHECK 0
+#define SANITY_CHECK 1
 
 // Offset of different entries in VPD data.
 enum Offset
@@ -625,6 +625,7 @@ void IpzVpdParser::updateRecordECC(
 
     std::copy(l_recordECCBegin, l_recordECCEnd,
               std::ostreambuf_iterator<char>(m_vpdFileStream));
+    m_vpdFileStream.flush();
 }
 
 int IpzVpdParser::setKeywordValueInRecord(
@@ -706,6 +707,7 @@ int IpzVpdParser::setKeywordValueInRecord(
 
             std::copy(i_keywordData.cbegin(), i_keywordDataEnd,
                       std::ostreambuf_iterator<char>(m_vpdFileStream));
+            m_vpdFileStream.flush();
 
             // return no of bytes set
             return l_lengthToUpdate;


### PR DESCRIPTION
The 'write' keyword operation for module VPD was failing during the sanity check with an ECC error. This occurred because written data was not yet synced to the file when the sanity check was performed.

To address this, an explicit flush is now called after writing the data to ensure it is written to the file immediately. With this change, the ECC check no longer fails during the sanity check.

The commit also enables sanity check back.

Change-Id: If4fbda85310422f694e421018db5900b1bb5e6be