### PR TITLE
Error handling for isPowerVsConfiguration API

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -791,12 +791,15 @@ inline bool isPass1Planar() noexcept
  * @brief API to detect if system configuration is that of PowerVS system.
  *
  * @param[in] i_imValue - IM value of the system.
+ * @param[out] o_errCode - To set error code in case of error.
  * @return true if it is PowerVS configuration, false otherwise.
  */
-inline bool isPowerVsConfiguration(const types::BinaryVector& i_imValue)
+inline bool isPowerVsConfiguration(const types::BinaryVector& i_imValue,
+                                   uint16_t& o_errCode)
 {
     if (i_imValue.empty() || i_imValue.size() != constants::VALUE_4)
     {
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
         return false;
     }
 

--- a/vpd-manager/oem-handler/ibm_handler.cpp
+++ b/vpd-manager/oem-handler/ibm_handler.cpp
@@ -357,14 +357,21 @@ void IbmHandler::ConfigurePowerVsSystem()
             throw DbusException("Invalid IM value read from Dbus");
         }
 
-        if (!vpdSpecificUtility::isPowerVsConfiguration(l_imValue))
+        uint16_t l_errCode = 0;
+        if (!vpdSpecificUtility::isPowerVsConfiguration(l_imValue, l_errCode))
         {
             // TODO: Should booting be blocked in case of some
             // misconfigurations?
+            if (l_errCode)
+            {
+                logging::logMessage(
+                    "Failed to check if the system is powerVs Configuration, error : " +
+                    commonUtility::getErrCodeMsg(l_errCode));
+            }
+
             return;
         }
 
-        uint16_t l_errCode = 0;
         const nlohmann::json& l_powerVsJsonObj =
             jsonUtility::getPowerVsJson(l_imValue, l_errCode);
 


### PR DESCRIPTION
This commit updates isPowerVsConfiguration API to set error code in case of error. This helps the caller of API to take action based on the error code returned from the API.

Change-Id: I39337b48893476b9dc0d293f414c4766ba283736