### PR TITLE
Error handling for resetDataUnderPIM API

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -633,10 +633,18 @@ inline bool findCcinInVpd(const nlohmann::json& i_JsonObject,
  *
  * @param[in] i_objectPath - DBus object path of the FRU.
  * @param[in] io_interfaceMap - Interface and its properties map.
+ * @param[out] o_errCode - To set error code in case of error.
  */
 inline void resetDataUnderPIM(const std::string& i_objectPath,
-                              types::InterfaceMap& io_interfaceMap)
+                              types::InterfaceMap& io_interfaceMap,
+                              uint16_t& o_errCode)
 {
+    if (i_objectPath.empty())
+    {
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
+        return;
+    }
+
     try
     {
         std::array<const char*, 0> l_interfaces;
@@ -720,8 +728,7 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
     }
     catch (const std::exception& l_ex)
     {
-        logging::logMessage("Failed to remove VPD for FRU: " + i_objectPath +
-                            " with error: " + std::string(l_ex.what()));
+        o_errCode = error_code::STANDARD_EXCEPTION;
     }
 }
 

--- a/vpd-manager/src/worker.cpp
+++ b/vpd-manager/src/worker.cpp
@@ -755,8 +755,15 @@ bool Worker::primeInventory(const std::string& i_vpdFilePath)
         if (isPresentPropertyHandlingRequired(l_Fru))
         {
             // Clear data under PIM if already exists.
+            uint16_t l_errCode = 0;
             vpdSpecificUtility::resetDataUnderPIM(
-                std::string(l_Fru["inventoryPath"]), l_interfaces);
+                std::string(l_Fru["inventoryPath"]), l_interfaces, l_errCode);
+
+            if (l_errCode)
+            {
+                logging::logMessage("Failed to reset date under PIM, error : " +
+                                    commonUtility::getErrCodeMsg(l_errCode));
+            }
         }
 
         // Add extra interfaces mentioned in the Json config file
@@ -1857,16 +1864,34 @@ void Worker::deleteFruVpd(const std::string& i_dbusObjPath)
                 for (const auto& [l_objectPath, l_serviceInterfaceMap] :
                      l_subTreeMap)
                 {
+                    l_errCode = 0;
                     types::InterfaceMap l_interfaceMap;
-                    vpdSpecificUtility::resetDataUnderPIM(l_objectPath,
-                                                          l_interfaceMap);
+                    vpdSpecificUtility::resetDataUnderPIM(
+                        l_objectPath, l_interfaceMap, l_errCode);
+
+                    if (l_errCode)
+                    {
+                        throw std::runtime_error(
+                            "Failed to reset data under PIM for sub FRU [" +
+                            l_objectPath + "], error : " +
+                            commonUtility::getErrCodeMsg(l_errCode));
+                    }
+
                     l_objectMap.emplace(l_objectPath,
                                         std::move(l_interfaceMap));
                 }
 
+                l_errCode = 0;
                 types::InterfaceMap l_interfaceMap;
-                vpdSpecificUtility::resetDataUnderPIM(i_dbusObjPath,
-                                                      l_interfaceMap);
+                vpdSpecificUtility::resetDataUnderPIM(
+                    i_dbusObjPath, l_interfaceMap, l_errCode);
+
+                if (l_errCode)
+                {
+                    throw std::runtime_error(
+                        "Failed to reset data under PIM, error : " +
+                        commonUtility::getErrCodeMsg(l_errCode));
+                }
 
                 l_objectMap.emplace(i_dbusObjPath, std::move(l_interfaceMap));
 


### PR DESCRIPTION
This commit updates resetDataUnderPIM API to set error code in case of error. This helps the caller of API to take action based on the error code returned from the API.

Change-Id: I71427b473d3094d0b2ea357cdde4d6c4d2627d2b