### PR TITLE
Error code for vpdSpecificUtility APIs

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -491,11 +491,18 @@ inline std::string getExpandedLocationCode(
  * @param[in] vpdFilePath - EEPROM path of the FRU.
  * @param[out] vpdVector - VPD in vector form.
  * @param[in] vpdStartOffset - Offset of VPD data in EEPROM.
+ * @param[out] o_errCode - To set error code in case of error.
  */
 inline void getVpdDataInVector(const std::string& vpdFilePath,
                                types::BinaryVector& vpdVector,
-                               size_t& vpdStartOffset)
+                               size_t& vpdStartOffset, uint16_t& o_errCode)
 {
+    if (vpdFilePath.empty())
+    {
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
+        return;
+    }
+
     try
     {
         std::fstream vpdFileStream;
@@ -515,9 +522,8 @@ inline void getVpdDataInVector(const std::string& vpdFilePath,
     }
     catch (const std::ifstream::failure& fail)
     {
-        std::cerr << "Exception in file handling [" << vpdFilePath
-                  << "] error : " << fail.what();
-        throw;
+        o_errCode = error_code::FILE_SYSTEM_ERROR;
+        return;
     }
 }
 
@@ -525,11 +531,18 @@ inline void getVpdDataInVector(const std::string& vpdFilePath,
  * @brief An API to get D-bus representation of given VPD keyword.
  *
  * @param[in] i_keywordName - VPD keyword name.
+ * @param[out] o_errCode - To set error code in case of error.
  *
  * @return D-bus representation of given keyword.
  */
-inline std::string getDbusPropNameForGivenKw(const std::string& i_keywordName)
+inline std::string getDbusPropNameForGivenKw(const std::string& i_keywordName,
+                                             uint16_t& o_errCode)
 {
+    if (i_keywordName.empty())
+    {
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
+        return std::string{};
+    }
     // Check for "#" prefixed VPD keyword.
     if ((i_keywordName.size() == vpd::constants::TWO_BYTES) &&
         (i_keywordName.at(0) == constants::POUND_KW))

--- a/vpd-manager/src/ipz_parser.cpp
+++ b/vpd-manager/src/ipz_parser.cpp
@@ -782,8 +782,15 @@ void IpzVpdParser::performSanityCheck(const types::RecordData& i_recordDetails,
     {
         // re-read the updated data
         // types::BinaryVector l_tempVpdVector;
+        uint16_t l_errCode = 0;
         vpdSpecificUtility::getVpdDataInVector(
-            m_vpdFilePath, l_updatedVpdVector, m_vpdStartOffset);
+            m_vpdFilePath, l_updatedVpdVector, m_vpdStartOffset, l_errCode);
+
+        if (l_errCode)
+        {
+            logging::logMessage("Failed to get VPD in vector, error : " +
+                                commonUtility::getErrCodeMsg(l_errCode));
+        }
 
         l_itrToVpd = l_updatedVpdVector.begin();
     }

--- a/vpd-manager/src/parser.cpp
+++ b/vpd-manager/src/parser.cpp
@@ -51,8 +51,15 @@ Parser::Parser(const std::string& vpdFilePath, nlohmann::json parsedJson) :
 std::shared_ptr<vpd::ParserInterface> Parser::getVpdParserInstance()
 {
     // Read the VPD data into a vector.
+    uint16_t l_errCode = 0;
     vpdSpecificUtility::getVpdDataInVector(m_vpdFilePath, m_vpdVector,
-                                           m_vpdStartOffset);
+                                           m_vpdStartOffset, l_errCode);
+
+    if (l_errCode)
+    {
+        logging::logMessage("Failed to get VPD in vector, error : " +
+                            commonUtility::getErrCodeMsg(l_errCode));
+    }
 
     // This will detect the type of parser required.
     std::shared_ptr<vpd::ParserInterface> l_parser =
@@ -195,8 +202,16 @@ int Parser::updateVpdKeyword(const types::WriteVpdParams& i_paramsToWriteData,
             }
 
             // Get D-bus name for the given keyword
-            l_propertyName =
-                vpdSpecificUtility::getDbusPropNameForGivenKw(l_propertyName);
+            l_errCode = 0;
+            l_propertyName = vpdSpecificUtility::getDbusPropNameForGivenKw(
+                l_propertyName, l_errCode);
+
+            if (l_errCode)
+            {
+                logging::logMessage(
+                    "Failed to get Dbus property name for given keyword, error : " +
+                    commonUtility::getErrCodeMsg(l_errCode));
+            }
 
             // Create D-bus object map
             types::ObjectMap l_dbusObjMap = {std::make_pair(
@@ -415,9 +430,16 @@ int Parser::performSanityCheck() noexcept
             return l_rcPrimary;
         }
 
+        l_errCode = 0;
         // Read the VPD data into a vector.
         vpdSpecificUtility::getVpdDataInVector(l_redundantPath, m_vpdVector,
-                                               m_vpdStartOffset);
+                                               m_vpdStartOffset, l_errCode);
+
+        if (l_errCode)
+        {
+            logging::logMessage("Failed to get VPD in vector, error : " +
+                                commonUtility::getErrCodeMsg(l_errCode));
+        }
 
         // This will detect the type of parser required.
         std::shared_ptr<vpd::ParserInterface> l_redundantParser =


### PR DESCRIPTION
This commit updates getVpdDataInVector and getDbusPropNameForGivenKw APIs to set error code in case of error. This helps the caller of API to take action based on the error code returned from the API.

Change-Id: I77bcb4b81a8ebaa196a9bdef3050ad3dfebd07e0