### PR TITLE
Error handling for isPass1Planar API

### DIFF
--- a/vpd-manager/include/error_codes.hpp
+++ b/vpd-manager/include/error_codes.hpp
@@ -38,7 +38,8 @@ enum error_code
     KEYWORD_NOT_FOUND,
     OUT_OF_BOUND_EXCEPTION,
     FAILED_TO_DETECT_LOCATION_CODE_TYPE,
-    RECEIVED_INVALID_KWD_TYPE_FROM_DBUS
+    RECEIVED_INVALID_KWD_TYPE_FROM_DBUS,
+    INVALID_KEYWORD_LENGTH
 };
 
 const std::unordered_map<int, std::string> errorCodeMap = {
@@ -73,6 +74,7 @@ const std::unordered_map<int, std::string> errorCodeMap = {
     {error_code::UNSUPPORTED_VPD_TYPE, "This VPD type is not supported"},
     {error_code::STANDARD_EXCEPTION, "Standard Exception thrown"},
     {error_code::FILE_SYSTEM_ERROR, "File system error."},
+    {error_code::INVALID_KEYWORD_LENGTH, "Invalid keyword length."},
     {error_code::FAILED_TO_DETECT_LOCATION_CODE_TYPE,
      "Failed to detect location code type"},
     {error_code::DBUS_FAILURE, "Dbus call failed"},

--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -755,58 +755,53 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
  *
  * Based on HW version and IM keyword, This API detects is it is a pass1 planar
  * or not.
+ * @param[out] o_errCode - To set error code in case of error.
  *
  * @return True if pass 1 planar, false otherwise.
  */
-inline bool isPass1Planar() noexcept
+inline bool isPass1Planar(uint16_t& o_errCode) noexcept
 {
     bool l_rc{false};
-    try
+    auto l_retVal = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::viniInf, constants::kwdHW);
+
+    auto l_hwVer = std::get_if<types::BinaryVector>(&l_retVal);
+
+    l_retVal = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemInvPath, constants::vsbpInf,
+        constants::kwdIM);
+
+    auto l_imValue = std::get_if<types::BinaryVector>(&l_retVal);
+
+    if (l_hwVer && l_imValue)
     {
-        auto l_retVal = dbusUtility::readDbusProperty(
-            constants::pimServiceName, constants::systemVpdInvPath,
-            constants::viniInf, constants::kwdHW);
-
-        auto l_hwVer = std::get_if<types::BinaryVector>(&l_retVal);
-
-        l_retVal = dbusUtility::readDbusProperty(
-            constants::pimServiceName, constants::systemInvPath,
-            constants::vsbpInf, constants::kwdIM);
-
-        auto l_imValue = std::get_if<types::BinaryVector>(&l_retVal);
-
-        if (l_hwVer && l_imValue)
+        if (l_hwVer->size() != constants::VALUE_2)
         {
-            if (l_hwVer->size() != constants::VALUE_2)
-            {
-                throw std::runtime_error("Invalid HW keyword length.");
-            }
+            o_errCode = error_code::INVALID_KEYWORD_LENGTH;
+            return l_rc;
+        }
 
-            if (l_imValue->size() != constants::VALUE_4)
-            {
-                throw std::runtime_error("Invalid IM keyword length.");
-            }
+        if (l_imValue->size() != constants::VALUE_4)
+        {
+            o_errCode = error_code::INVALID_KEYWORD_LENGTH;
+            return l_rc;
+        }
 
-            const types::BinaryVector l_everest{80, 00, 48, 00};
-            const types::BinaryVector l_fuji{96, 00, 32, 00};
+        const types::BinaryVector l_everest{80, 00, 48, 00};
+        const types::BinaryVector l_fuji{96, 00, 32, 00};
 
-            if (((*l_imValue) == l_everest) || ((*l_imValue) == l_fuji))
-            {
-                if ((*l_hwVer).at(1) < constants::VALUE_21)
-                {
-                    l_rc = true;
-                }
-            }
-            else if ((*l_hwVer).at(1) < constants::VALUE_2)
+        if (((*l_imValue) == l_everest) || ((*l_imValue) == l_fuji))
+        {
+            if ((*l_hwVer).at(1) < constants::VALUE_21)
             {
                 l_rc = true;
             }
         }
-    }
-    catch (const std::exception& l_ex)
-    {
-        logging::logMessage("Failed to check for pass 1 planar. Error: " +
-                            std::string(l_ex.what()));
+        else if ((*l_hwVer).at(1) < constants::VALUE_2)
+        {
+            l_rc = true;
+        }
     }
 
     return l_rc;

--- a/vpd-manager/src/worker.cpp
+++ b/vpd-manager/src/worker.cpp
@@ -1646,7 +1646,7 @@ std::tuple<bool, std::string> Worker::parseAndPublishVPD(
             uint16_t l_errCode = 0;
             // In case of pass1 planar, VPD can be corrupted on PCIe cards. Skip
             // logging error for these cases.
-            if (vpdSpecificUtility::isPass1Planar())
+            if (vpdSpecificUtility::isPass1Planar(l_errCode))
             {
                 std::string l_invPath =
                     jsonUtility::getInventoryObjPathFromJson(
@@ -1669,6 +1669,12 @@ std::tuple<bool, std::string> Worker::parseAndPublishVPD(
                     // skip logging any PEL for PCIe cards on pass 1 planar.
                     return std::make_tuple(false, i_vpdFilePath);
                 }
+            }
+            else if (l_errCode)
+            {
+                logging::logMessage(
+                    "Failed to check if system is Pass 1 Planar, error : " +
+                    commonUtility::getErrCodeMsg(l_errCode));
             }
         }
 


### PR DESCRIPTION
This commit updates isPass1Planar API to set error code in case of error. This helps the caller of API to take action based on the error code returned from the API.

Change-Id: I3823e749d68e37f9d004b9f95c80693d1f7c5b41