### PR TITLE
Fix clearing of LocationCode after deleteFRUVPD

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -684,7 +684,8 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
             for (const auto& l_interface : l_interfaceList)
             {
                 if ((l_interface.find(constants::ipzVpdInf) !=
-                     std::string::npos) ||
+                         std::string::npos &&
+                     l_interface != constants::locationCodeInf) ||
                     ((std::find(l_vpdRelatedInterfaces.begin(),
                                 l_vpdRelatedInterfaces.end(), l_interface)) !=
                      l_vpdRelatedInterfaces.end()))

--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -29,7 +29,8 @@ constexpr auto vpdManagerObjectPath = "/com/ibm/VPD/Manager";
 constexpr auto vpdManagerInfName = "com.ibm.VPD.Manager";
 constexpr auto inventoryItemInf = "xyz.openbmc_project.Inventory.Item";
 constexpr auto viniInf = "com.ibm.ipzvpd.VINI";
-constexpr auto locationCodeInf = "com.ibm.ipzvpd.Location";
+constexpr auto xyzLocationCodeInf =
+    "xyz.openbmc_project.Inventory.Decorator.LocationCode";
 constexpr auto assetInf = "xyz.openbmc_project.Inventory.Decorator.Asset";
 constexpr auto objectMapperService = "xyz.openbmc_project.ObjectMapper";
 constexpr auto objectMapperObjectPath = "/xyz/openbmc_project/object_mapper";

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -179,11 +179,11 @@ void VpdTool::populateFruJson(
             continue;
         }
 
-        if (l_interface == constants::locationCodeInf)
+        if (l_interface == constants::xyzLocationCodeInf)
         {
             const std::vector<std::string> l_properties = {"LocationCode"};
             populateInterfaceJson<std::string>(i_inventoryObjPath,
-                                               constants::locationCodeInf,
+                                               constants::xyzLocationCodeInf,
                                                l_properties, io_fruJsonObject);
             continue;
         }


### PR DESCRIPTION
LocationCode in the com.ibm.ipzvpd.Location interface was being set to an empty string when deleteFRUVPD was called for a FRU in vpd-manager. This should not happen because the LocationCode is fixed for a FRU, regardless of whether the FRU is present or not.

This commit fixes the above issue and updates the vpd-tool to use the standard xyz interface to display the LocationCode instead of the OEM-specific interface.

Test:
```
Dump object before delete FRU
root@rainvpdteam:~# vpd-tool -o -O /system/chassis/motherboard/lcd_op_panel_hill
[
    {
        "/system/chassis/motherboard/lcd_op_panel_hill": {
            "CC": "6B87",
            "DR": "CEC OP PANEL LCD",
            "FN": "02WF367",
            "LocationCode": "U78DA.ND0.       -D1",
            "PN": "02WF364",
            "PrettyName": "Control panel display",
            "SN": "YA30UF04R007",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.Panel"
        }
    }
]

Call delete FRU VPD:
root@rainvpdteam:~# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager  deleteFRUVPD o /xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill

After Delete, Location code on DBus:
root@rainvpdteam:~# busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill xyz.openbmc_project.Inventory.Decorator.LocationCode
NAME                                                 TYPE      SIGNATURE RESULT/VALUE           FLAGS
.LocationCode                                        property  s         "U78DA.ND0.       -D1" emits-change writable

root@rainvpdteam:~# busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill com.ibm.ipzvpd.Location
NAME                    TYPE      SIGNATURE RESULT/VALUE           FLAGS
.LocationCode           property  s         "U78DA.ND0.       -D1" emits-change writable

Set FRU Present Property:
root@rainvpdteam:~# busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill xyz.openbmc_project.Inventory.Item Present b true

Dump object details, with correct location code:
root@rainvpdteam:~# vpd-tool -o -O /system/chassis/motherboard/lcd_op_panel_hill
[
    {
        "/system/chassis/motherboard/lcd_op_panel_hill": {
            "CC": "",
            "DR": "",
            "FN": "",
            "LocationCode": "U78DA.ND0.       -D1",
            "PN": "",
            "PrettyName": "",
            "SN": "",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.Panel"
        }
    }
]
```

Change-Id: Ie6db0584b46f69b340034ecf63c06197f31f46af