### PR TITLE
Remove empty VPD map check in getExpandedLocCode

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -356,8 +356,7 @@ inline std::string getExpandedLocationCode(
     const types::VPDMapVariant& parsedVpdMap, uint16_t& o_errCode)
 {
     o_errCode = 0;
-    if (unexpandedLocationCode.empty() ||
-        std::holds_alternative<std::monostate>(parsedVpdMap))
+    if (unexpandedLocationCode.empty())
     {
         o_errCode = error_code::INVALID_INPUT_PARAMETER;
         return unexpandedLocationCode;


### PR DESCRIPTION
This commit removes the empty VPD map check in getExpandedLocationCode API because the location code can be obtained independently of the VPD map.

Change-Id: Ib13aafe3158173a57dfa62010c41fd2d56d53ee8