### PR TITLE
1120: Fix clearing of prettyName during deletion

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -717,6 +717,14 @@ inline void resetDataUnderPIM(const std::string& i_objectPath,
                                     l_propertyName,
                                     constants::vpdCollectionNotStarted);
                             }
+                            else if (l_propertyName.compare("PrettyName") ==
+                                     constants::STR_CMP_SUCCESS)
+                            {
+                                // The FRU name is constant and independent of
+                                // its presence state. So, it should not get
+                                // reset.
+                                continue;
+                            }
                             else
                             {
                                 l_propertyMap.emplace(l_propertyName,


### PR DESCRIPTION
PrettyName under the xyz.openbmc_project.Inventory.Item interface was being set to an empty string when deleteFRUVPD was called for a FRU. This should not happen because name of the FRU is fixed, independent of its presence state.

This commit fixes the above issue.

Test-
```
Before deletion, PrettyName on DBus
root@p11bmc:~# busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11 xyz.openbmc_project.Inventory.Item
NAME                               TYPE      SIGNATURE RESULT/VALUE       FLAGS
.Present                           property  b         true               emits-change writable
.PrettyName                        property  s         "PCIe5 x8 adapter" emits-change writable

Call deleteFRUVPD
root@p11bmc:~# busctl call com.ibm.VPD.Manager /com/ibm/VPD/Manager com.ibm.VPD.Manager deleteFRUVPD o /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11

After performing deletion, prettyName on DBus:
root@p11bmc:~# busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11 xyz.openbmc_project.Inventory.Item
NAME                               TYPE      SIGNATURE RESULT/VALUE       FLAGS
.Present                           property  b         false               emits-change writable
.PrettyName                        property  s         "PCIe5 x8 adapter" emits-change writable
```

Change-Id: Icc8f05d150a365265332b6ff0beeff83c6c300ee