### PR TITLE
1120: Clear stale data on DBus

### DIFF
--- a/vpd-manager/include/error_codes.hpp
+++ b/vpd-manager/include/error_codes.hpp
@@ -41,7 +41,8 @@ enum error_code
     RECEIVED_INVALID_KWD_TYPE_FROM_DBUS,
     INVALID_KEYWORD_LENGTH,
     INVALID_VALUE_READ_FROM_DBUS,
-    RECORD_NOT_FOUND
+    RECORD_NOT_FOUND,
+    FRU_PRESENCE_NOT_HANDLED
 };
 
 const std::unordered_map<int, std::string> errorCodeMap = {
@@ -83,5 +84,7 @@ const std::unordered_map<int, std::string> errorCodeMap = {
      "Failed to detect location code type"},
     {error_code::DBUS_FAILURE, "Dbus call failed"},
     {error_code::RECEIVED_INVALID_KWD_TYPE_FROM_DBUS,
-     "Received invalid keyword data type from DBus."}};
+     "Received invalid keyword data type from DBus."},
+    {error_code::FRU_PRESENCE_NOT_HANDLED,
+     "FRU's presence is not handled by vpd-manager."}};
 } // namespace vpd

--- a/vpd-manager/include/utility/json_utility.hpp
+++ b/vpd-manager/include/utility/json_utility.hpp
@@ -9,7 +9,6 @@
 #include <gpiod.hpp>
 #include <nlohmann/json.hpp>
 #include <utility/common_utility.hpp>
-#include <utility/vpd_specific_utility.hpp>
 
 #include <fstream>
 #include <type_traits>
@@ -707,6 +706,7 @@ inline std::string getFruPathFromJson(const nlohmann::json& i_sysCfgJsonObj,
         }
     }
 
+    o_errCode = error_code::FRU_PATH_NOT_FOUND;
     return std::string();
 }
 

--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -11,6 +11,7 @@
 #include <nlohmann/json.hpp>
 #include <utility/common_utility.hpp>
 #include <utility/dbus_utility.hpp>
+#include <utility/json_utility.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -1212,6 +1213,90 @@ inline void updateCiPropertyOfInheritedFrus(
     }
     catch (const std::exception& l_ex)
     {
+        o_errCode = error_code::STANDARD_EXCEPTION;
+    }
+}
+
+/**
+ * @brief API to reset data of a FRU and its sub-FRU populated under PIM.
+ *
+ * The API resets the data for specific interfaces of a FRU and its sub-FRUs
+ * under PIM.
+ *
+ * Note: i_vpdPath should be either the base inventory path or the EEPROM path.
+ *
+ * @param[in] i_vpdPath - EEPROM/root inventory path of the FRU.
+ * @param[in] i_sysCfgJsonObj - system config JSON.
+ * @param[out] o_errCode - To set error code in case of error.
+ */
+inline void resetObjTreeVpd(const std::string& i_vpdPath,
+                            const nlohmann::json& i_sysCfgJsonObj,
+                            uint16_t& o_errCode) noexcept
+{
+    o_errCode = 0;
+    if (i_vpdPath.empty())
+    {
+        o_errCode = error_code::INVALID_INPUT_PARAMETER;
+        return;
+    }
+
+    try
+    {
+        std::string l_fruPath = jsonUtility::getFruPathFromJson(
+            i_sysCfgJsonObj, i_vpdPath, o_errCode);
+
+        if (o_errCode)
+        {
+            return;
+        }
+
+        if (!jsonUtility::isFruPresenceHandled(i_sysCfgJsonObj, l_fruPath,
+                                               o_errCode))
+        {
+            o_errCode = error_code::FRU_PRESENCE_NOT_HANDLED;
+            return;
+        }
+
+        types::ObjectMap l_objectMap;
+
+        const auto& l_fru = i_sysCfgJsonObj["frus"][l_fruPath];
+
+        for (const auto& l_inventoryItem : l_fru)
+        {
+            std::string l_objectPath =
+                l_inventoryItem.value("inventoryPath", "");
+
+            if (l_inventoryItem.value("handlePresence", true) &&
+                !l_inventoryItem.value("synthesized", false))
+            {
+                types::InterfaceMap l_interfaceMap;
+                resetDataUnderPIM(l_objectPath, l_interfaceMap, o_errCode);
+
+                if (o_errCode)
+                {
+                    logging::logMessage(
+                        "Failed to get data to clear on DBus for path [" +
+                        l_objectPath + "], error : " +
+                        commonUtility::getErrCodeMsg(o_errCode));
+
+                    continue;
+                }
+
+                l_objectMap.emplace(l_objectPath, l_interfaceMap);
+            }
+        }
+
+        if (!dbusUtility::callPIM(std::move(l_objectMap)))
+        {
+            o_errCode = error_code::DBUS_FAILURE;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        logging::logMessage(
+            "Failed to reset FRU data on DBus for FRU [" + i_vpdPath +
+            "], error : " + std::string(l_ex.what()));
+
         o_errCode = error_code::STANDARD_EXCEPTION;
     }
 }


### PR DESCRIPTION
When BMC goes for a reboot, FRU collection may fail, or the FRU may be absent. In such cases, the DBus may still hold data from a previous boot.

This commit fixes the above issue by clearing stale DBus data in the above cases.