### PR TITLE
vpd-tool: Fix for reading pound keyword

### DIFF
--- a/vpd-tool/include/tool_constants.hpp
+++ b/vpd-tool/include/tool_constants.hpp
@@ -8,6 +8,10 @@ namespace vpd
 {
 namespace constants
 {
+static constexpr auto POUND_KW = '#';
+static constexpr auto POUND_KW_PREFIX = "PD_";
+static constexpr auto NUMERIC_KW_PREFIX = "N_";
+
 static constexpr auto KEYWORD_SIZE = 2;
 static constexpr auto RECORD_SIZE = 4;
 static constexpr auto INDENTATION = 4;

--- a/vpd-tool/include/tool_utils.hpp
+++ b/vpd-tool/include/tool_utils.hpp
@@ -7,6 +7,7 @@
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/exception.hpp>
 
+#include <cctype>
 #include <fstream>
 #include <iostream>
 
@@ -994,6 +995,41 @@ inline types::BinaryVector convertIntegralTypeToBytes(
             (i_integralData >> (l_byte * constants::VALUE_8)) & l_byteMask;
     }
     return l_result;
+}
+
+/**
+ * @brief An API to get D-bus representation of given VPD keyword.
+ *
+ * @param[in] i_keywordName - VPD keyword name.
+ *
+ * @return D-bus representation of given keyword, otherwise empty string.
+ */
+inline std::string getDbusPropNameForGivenKw(
+    const std::string& i_keywordName) noexcept
+{
+    if (i_keywordName.size() != vpd::constants::KEYWORD_SIZE)
+    {
+        return std::string{};
+    }
+
+    // Check for "#" prefixed VPD keyword.
+    if (i_keywordName.at(0) == constants::POUND_KW)
+    {
+        // D-bus doesn't support "#". Replace "#" with "PD_" for those "#"
+        // prefixed keywords.
+        return (std::string(constants::POUND_KW_PREFIX) +
+                i_keywordName.substr(1));
+    }
+    else if (std::isdigit(i_keywordName[0]))
+    {
+        // D-bus doesn't support numeric property. Add Prefix "N_" for those
+        // numeric keywords.
+        return (std::string(constants::NUMERIC_KW_PREFIX) + i_keywordName);
+    }
+
+    // Return the keyword name back, if D-bus representation is same as the VPD
+    // keyword name.
+    return i_keywordName;
 }
 
 } // namespace utils

--- a/vpd-tool/src/vpd_tool.cpp
+++ b/vpd-tool/src/vpd_tool.cpp
@@ -49,9 +49,18 @@ int VpdTool::readKeyword(
             std::string l_inventoryObjectPath(
                 constants::baseInventoryPath + i_vpdPath);
 
+            // Get D-bus name for the given keyword
+            const std::string& l_keywordName =
+                utils::getDbusPropNameForGivenKw(i_keywordName);
+            if (l_keywordName.empty())
+            {
+                std::cerr << "Invalid keyword given." << std::endl;
+                return l_rc;
+            }
+
             l_keywordValue = utils::readDbusProperty(
                 constants::inventoryManagerService, l_inventoryObjectPath,
-                constants::ipzVpdInfPrefix + i_recordName, i_keywordName);
+                constants::ipzVpdInfPrefix + i_recordName, l_keywordName);
         }
 
         if (const auto l_value =


### PR DESCRIPTION
Reading keywords which starts with pound(#) or number from dbus using vpd-tool is failing, because pound is represented as PD_, and numeric keywords starts with N_ on dbus, vpd-tool missed handling of these conversions while querying from dbus.

Changes are made to handle this issue.

```
Testing:
Tested by reading keywords starts with pound and numeric keywords from dbus using vpd-tool

vpd-tool -r -O /system/chassis/motherboard/dcm0/cpu0 -R CRP0 -K "#V"
vpd-tool -r -O /system/chassis/motherboard/dcm0/cpu0 -R LWP3 -K "20
```

Change-Id: I730d5063e9e59308508bda56e97eb9047f7b25b4