### PR TITLE
Fix non-cable card enable line not disabled

### DIFF
--- a/vpd-manager/include/worker.hpp
+++ b/vpd-manager/include/worker.hpp
@@ -545,6 +545,20 @@ class Worker
     void setCollectionStatusProperty(const std::string& i_fruPath,
                                      const std::string& i_value) const noexcept;
 
+    /**
+     * @brief API to check and execute post fail action if needed.
+     *
+     * This API checks if post fail action is required for a given FRU path, and
+     * if needed it executes the given post fail action.
+     *
+     * @param[in] i_fruPath - EEPROM file path.
+     * @param[in] i_flowFlag - Denotes the flow w.r.t which the action should
+     * be triggered.
+     */
+    void checkAndExecutePostFailAction(
+        const std::string& i_fruPath,
+        const std::string& i_flowFlag) const noexcept;
+
     // Parsed JSON file.
     nlohmann::json m_parsedJson{};
 


### PR DESCRIPTION
This commit fixes enable GPIO line not getting disabled during FRU VPD collection flow. For PCIe cards other than cable cards, the present GPIO line indicates card absent. For these cards, vpd-manager should disable the respective enable GPIO line.
This commit also adds an API in Worker class to check and execute post fail action. Checking and executing post fail action is required in multiple places in Worker class. Hence to avoid code duplication, this API has been added.