### PR TITLE
Remove backup&restore of AMM for Balcones system

### DIFF
--- a/configuration/ibm/backup_restore_60004000.json
+++ b/configuration/ibm/backup_restore_60004000.json
@@ -112,16 +112,6 @@
         },
         {
             "sourceRecord": "UTIL",
-            "sourceKeyword": "D0",
-            "destinationRecord": "VSBK",
-            "destinationKeyword": "D0",
-            "defaultValue": [0],
-            "isPelRequired": true,
-            "isManufactureResetRequired": true,
-            "isBiosSyncRequired": true
-        },
-        {
-            "sourceRecord": "UTIL",
             "sourceKeyword": "D1",
             "destinationRecord": "VSBK",
             "destinationKeyword": "D1",


### PR DESCRIPTION
AMM is not supported on the Balcone system. The UTIL D0 keyword used for memory mirroring has been removed from the backup and restore configuration JSON.

Change-Id: I3f808a68e9fb7a106c348653fcdedd7d52881ae0