### PR TITLE
Fix utility API to detect Pass1 planar

### DIFF
--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -773,46 +773,53 @@ inline bool isPass1Planar(uint16_t& o_errCode) noexcept
 {
     o_errCode = 0;
     bool l_rc{false};
-    auto l_retVal = dbusUtility::readDbusProperty(
+    const auto l_hwVar = dbusUtility::readDbusProperty(
         constants::pimServiceName, constants::systemVpdInvPath,
         constants::viniInf, constants::kwdHW);
 
-    auto l_hwVer = std::get_if<types::BinaryVector>(&l_retVal);
-
-    l_retVal = dbusUtility::readDbusProperty(
-        constants::pimServiceName, constants::systemInvPath, constants::vsbpInf,
-        constants::kwdIM);
-
-    auto l_imValue = std::get_if<types::BinaryVector>(&l_retVal);
-
-    if (l_hwVer && l_imValue)
+    const auto l_hwVer = std::get_if<types::BinaryVector>(&l_hwVar);
+    if (l_hwVer == nullptr)
     {
-        if (l_hwVer->size() != constants::VALUE_2)
-        {
-            o_errCode = error_code::INVALID_KEYWORD_LENGTH;
-            return l_rc;
-        }
+        o_errCode = error_code::INVALID_VALUE_READ_FROM_DBUS;
+        return l_rc;
+    }
 
-        if (l_imValue->size() != constants::VALUE_4)
-        {
-            o_errCode = error_code::INVALID_KEYWORD_LENGTH;
-            return l_rc;
-        }
+    const auto l_imVar = dbusUtility::readDbusProperty(
+        constants::pimServiceName, constants::systemVpdInvPath,
+        constants::vsbpInf, constants::kwdIM);
 
-        const types::BinaryVector l_everest{80, 00, 48, 00};
-        const types::BinaryVector l_fuji{96, 00, 32, 00};
+    const auto l_imValue = std::get_if<types::BinaryVector>(&l_imVar);
+    if (l_imValue == nullptr)
+    {
+        o_errCode = error_code::INVALID_VALUE_READ_FROM_DBUS;
+        return l_rc;
+    }
 
-        if (((*l_imValue) == l_everest) || ((*l_imValue) == l_fuji))
-        {
-            if ((*l_hwVer).at(1) < constants::VALUE_21)
-            {
-                l_rc = true;
-            }
-        }
-        else if ((*l_hwVer).at(1) < constants::VALUE_2)
+    if (l_hwVer->size() != constants::VALUE_2)
+    {
+        o_errCode = error_code::INVALID_KEYWORD_LENGTH;
+        return l_rc;
+    }
+
+    if (l_imValue->size() != constants::VALUE_4)
+    {
+        o_errCode = error_code::INVALID_KEYWORD_LENGTH;
+        return l_rc;
+    }
+
+    const types::BinaryVector l_everest{80, 00, 48, 00};
+    const types::BinaryVector l_fuji{96, 00, 32, 00};
+
+    if (((*l_imValue) == l_everest) || ((*l_imValue) == l_fuji))
+    {
+        if ((*l_hwVer).at(1) < constants::VALUE_21)
         {
             l_rc = true;
         }
+    }
+    else if ((*l_hwVer).at(1) < constants::VALUE_2)
+    {
+        l_rc = true;
     }
 
     return l_rc;


### PR DESCRIPTION
This commit fixes an issue in utility API to detect Pass1 planar. Currently, this API attempts to read IM keyword value from /system object path from Phosphor Inventory Manager (PIM), but IM keyword is published on /system/chassis/motherboard on PIM. This commit fixes this. This commit also adds error handling in case invalid HW or IM keyword is read from PIM.