### PR TITLE
Sync keyword to sub FRUs

### DIFF
--- a/vpd-manager/include/constants.hpp
+++ b/vpd-manager/include/constants.hpp
@@ -222,6 +222,8 @@ static constexpr auto systemdManagerInterface =
     "org.freedesktop.systemd1.Manager";
 
 static constexpr auto vpdCollectionInterface = "com.ibm.VPD.Collection";
+static constexpr auto networkInterface =
+    "xyz.openbmc_project.Inventory.Item.NetworkInterface";
 
 // enumerated values of CollectionStatus D-bus property defined under
 // com.ibm.VPD.Collection interface.

--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -938,10 +938,11 @@ inline bool isPowerVsImage()
 }
 
 /**
- * @brief API to sync keyword update to inherited FRUs.
+ * @brief API to sync keyword update to sub FRUs.
  *
  * For a given keyword update on a EEPROM path, this API syncs the keyword
- * update to all inherited FRUs' respective interface, property on PIM.
+ * updates to respective interface, property on PIM for all inherited FRUs' and
+ * if the record is part of copyRecord tag for sub FRUs.
  *
  * @param[in] i_fruPath - EEPROM path of FRU.
  * @param[in] i_paramsToWriteData - Input details.
@@ -949,10 +950,10 @@ inline bool isPowerVsImage()
  * @param[out] o_errCode - To set error code in case of error.
  *
  */
-inline void updateKwdOnInheritedFrus(
-    const std::string& i_fruPath,
-    const types::WriteVpdParams& i_paramsToWriteData,
-    const nlohmann::json& i_sysCfgJsonObj, uint16_t& o_errCode) noexcept
+inline void updateKwdOnSubFrus(const std::string& i_fruPath,
+                               const types::WriteVpdParams& i_paramsToWriteData,
+                               const nlohmann::json& i_sysCfgJsonObj,
+                               uint16_t& o_errCode) noexcept
 {
     o_errCode = 0;
     try
@@ -985,17 +986,26 @@ inline void updateKwdOnInheritedFrus(
         }
         //  iterate through all inventory paths for given EEPROM path,
         //  except the base FRU.
-        //  if for an inventory path, "inherit" tag is true,
-        //  update the inventory path's com.ibm.ipzvpd.<record>,keyword
-        //  property
+        //  if for an inventory path, "inherit" tag is true OR the record
+        //  is part of "copyRecords" tag, update the inventory path's
+        //  com.ibm.ipzvpd.<record>,keyword property
 
         types::ObjectMap l_objectInterfaceMap;
 
         auto l_populateInterfaceMap =
             [&l_objectInterfaceMap,
              &l_ipzData = std::as_const(l_ipzData)](const auto& l_Fru) {
-                // update inherited FRUs only
-                if (l_Fru.value("inherit", true))
+                // check if record is part of copyRecords list.
+                const bool l_recordFound =
+                    l_Fru.contains("copyRecords") &&
+                    std::find(l_Fru["copyRecords"].begin(),
+                              l_Fru["copyRecords"].end(),
+                              std::get<0>(*l_ipzData)) !=
+                        l_Fru["copyRecords"].end();
+
+                // update for inherited FRUs or if the record is part of
+                // copyRecord tag
+                if (l_Fru.value("inherit", true) || l_recordFound)
                 {
                     l_objectInterfaceMap.emplace(
                         sdbusplus::message::object_path{l_Fru["inventoryPath"]},
@@ -1045,15 +1055,15 @@ inline void updateKwdOnInheritedFrus(
  * the record and keyword. An empty map is returned if no such common
  * interface(s) and properties are found.
  */
-inline types::InterfaceMap getCommonInterfaceProperties(
+inline types::InterfaceMap getInterfaceProperties(
     const types::WriteVpdParams& i_paramsToWriteData,
-    const nlohmann::json& i_commonInterfaceJson, uint16_t& o_errCode) noexcept
+    const nlohmann::json& i_interfaceJson, uint16_t& o_errCode) noexcept
 {
     types::InterfaceMap l_interfaceMap;
     o_errCode = 0;
     try
     {
-        if (i_commonInterfaceJson.empty())
+        if (i_interfaceJson.empty())
         {
             o_errCode = error_code::INVALID_INPUT_PARAMETER;
             return l_interfaceMap;
@@ -1071,11 +1081,24 @@ inline types::InterfaceMap getCommonInterfaceProperties(
         auto l_populateInterfaceMap = [&l_ipzData = std::as_const(l_ipzData),
                                        &l_interfaceMap, &o_errCode](
                                           const auto& l_interfacesPropPair) {
-            // find matching property value pair
+            // Skip if value is null or not an object to handle extraInterfaces
+            // flag which may have null values for certain interfaces
+            if (l_interfacesPropPair.value().is_null() ||
+                !l_interfacesPropPair.value().is_object())
+            {
+                return; // continue to next iteration
+            }
+
             const auto l_matchPropValuePairIt = std::find_if(
                 l_interfacesPropPair.value().items().begin(),
                 l_interfacesPropPair.value().items().end(),
                 [&l_ipzData](const auto& l_propValuePair) {
+                    // Check if value is an object before accessing
+                    // properties
+                    if (!l_propValuePair.value().is_object())
+                    {
+                        return false;
+                    }
                     return (l_propValuePair.value().value("recordName", "") ==
                                 std::get<0>(*l_ipzData) &&
                             l_propValuePair.value().value("keywordName", "") ==
@@ -1108,9 +1131,8 @@ inline types::InterfaceMap getCommonInterfaceProperties(
         };
 
         // iterate through all common interfaces and populate interface map
-        std::for_each(i_commonInterfaceJson.items().begin(),
-                      i_commonInterfaceJson.items().end(),
-                      l_populateInterfaceMap);
+        std::for_each(i_interfaceJson.items().begin(),
+                      i_interfaceJson.items().end(), l_populateInterfaceMap);
     }
     catch (const std::exception& l_ex)
     {
@@ -1176,7 +1198,7 @@ inline void updateCiPropertyOfInheritedFrus(
 
         types::ObjectMap l_objectInterfaceMap;
 
-        const types::InterfaceMap l_interfaceMap = getCommonInterfaceProperties(
+        const types::InterfaceMap l_interfaceMap = getInterfaceProperties(
             i_paramsToWriteData, i_sysCfgJsonObj["commonInterfaces"],
             o_errCode);
 
@@ -1305,6 +1327,119 @@ inline void resetObjTreeVpd(const std::string& i_vpdPath,
             "], error : " + std::string(l_ex.what()));
 
         o_errCode = error_code::STANDARD_EXCEPTION;
+    }
+}
+
+/**
+ * @brief API to update extra interface(s) properties when keyword is updated.
+ *
+ * For a given keyword update on a EEPROM path, this API syncs the keyword
+ * update to respective extra interface(s) properties.
+ *
+ * @param[in] i_fruPath - EEPROM path of FRU.
+ * @param[in] i_paramsToWriteData - Input details.
+ * @param[in] i_sysCfgJsonObj - System config JSON.
+ * @param[out] o_errCode - To set error code in case of error.
+ */
+inline void updatePropertyOnExtraInterfaces(
+    const std::string& i_fruPath,
+    const types::WriteVpdParams& i_paramsToWriteData,
+    const nlohmann::json& i_sysCfgJsonObj, uint16_t& o_errCode) noexcept
+{
+    const std::vector<std::string> l_listofInterfacesToUpdate{
+        constants::assetInf, constants::networkInterface};
+    o_errCode = 0;
+    try
+    {
+        if (i_fruPath.empty() || i_sysCfgJsonObj.empty())
+        {
+            o_errCode = error_code::INVALID_INPUT_PARAMETER;
+            return;
+        }
+
+        if (!i_sysCfgJsonObj.contains("frus"))
+        {
+            o_errCode = error_code::INVALID_JSON;
+            return;
+        }
+
+        if (!i_sysCfgJsonObj["frus"].contains(i_fruPath))
+        {
+            o_errCode = error_code::FRU_PATH_NOT_FOUND;
+            return;
+        }
+
+        if (!std::get_if<types::IpzData>(&i_paramsToWriteData))
+        {
+            o_errCode = error_code::UNSUPPORTED_VPD_TYPE;
+            return;
+        }
+
+        types::ObjectMap l_objectInterfaceMap;
+
+        auto l_populateObjectInterfaceMap = [&l_listofInterfacesToUpdate,
+                                             &l_objectInterfaceMap,
+                                             &i_paramsToWriteData,
+                                             &o_errCode](const auto& l_Fru) {
+            if (l_Fru.contains("extraInterfaces"))
+            {
+                const auto& l_extraInterfaces = l_Fru["extraInterfaces"];
+                nlohmann::json l_interfaceJson{};
+
+                // Get the list of interfaces to be updated
+                for (const auto& l_interface : l_listofInterfacesToUpdate)
+                {
+                    if (auto l_iterator = l_extraInterfaces.find(l_interface);
+                        l_iterator != l_extraInterfaces.end())
+                    {
+                        l_interfaceJson[l_interface] = l_iterator.value();
+                    }
+                }
+
+                if (l_interfaceJson.empty())
+                {
+                    return;
+                }
+
+                const types::InterfaceMap l_interfaceMap =
+                    getInterfaceProperties(i_paramsToWriteData, l_interfaceJson,
+                                           o_errCode);
+
+                if (o_errCode)
+                {
+                    logging::logMessage(
+                        "Failed to get extra properties interface list, error : " +
+                        commonUtility::getErrCodeMsg(o_errCode));
+                }
+                else
+                {
+                    l_objectInterfaceMap.emplace(
+                        sdbusplus::message::object_path{l_Fru["inventoryPath"]},
+                        l_interfaceMap);
+                }
+            }
+        };
+
+        std::for_each(i_sysCfgJsonObj["frus"][i_fruPath].begin(),
+                      i_sysCfgJsonObj["frus"][i_fruPath].end(),
+                      l_populateObjectInterfaceMap);
+
+        if (!l_objectInterfaceMap.empty())
+        {
+            // notify PIM
+            if (!dbusUtility::callPIM(move(l_objectInterfaceMap)))
+            {
+                o_errCode = error_code::DBUS_FAILURE;
+                return;
+            }
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        o_errCode = error_code::STANDARD_EXCEPTION;
+        logging::logMessage(
+            "Failed to update property on extra interfaces, error : " +
+            std::string(l_ex.what()));
     }
 }
 } // namespace vpdSpecificUtility

--- a/vpd-manager/src/manager.cpp
+++ b/vpd-manager/src/manager.cpp
@@ -257,8 +257,8 @@ int Manager::updateKeyword(const types::Path i_vpdPath,
         // update keyword in inherited FRUs
         if (l_rc != constants::FAILURE)
         {
-            vpdSpecificUtility::updateKwdOnInheritedFrus(
-                l_fruPath, l_writeParams, l_sysCfgJsonObj, l_errCode);
+            vpdSpecificUtility::updateKwdOnSubFrus(l_fruPath, l_writeParams,
+                                                   l_sysCfgJsonObj, l_errCode);
 
             if (l_errCode)
             {
@@ -279,6 +279,20 @@ int Manager::updateKeyword(const types::Path i_vpdPath,
             {
                 logging::logMessage(
                     "Failed to update Ci property of inherited FRUs, error : " +
+                    commonUtility::getErrCodeMsg(l_errCode));
+            }
+        }
+
+        // update extra interface(s) properties for FRUs
+        if (l_rc != constants::FAILURE)
+        {
+            vpdSpecificUtility::updatePropertyOnExtraInterfaces(
+                l_fruPath, l_writeParams, l_sysCfgJsonObj, l_errCode);
+
+            if (l_errCode)
+            {
+                logging::logMessage(
+                    "Failed to update extra interface properties, error : " +
                     commonUtility::getErrCodeMsg(l_errCode));
             }
         }


### PR DESCRIPTION
This commit adds code to sync the keyword value for sub FRUs if it’s part of copyRecords and extraInterfaces tag in JSON while updating keyword.

This ensures keyword updates on parent FRUs are propagated too eligible sub FRUs through the corresponding PIM interfaces and properties.

Test:
```
root@p11bmc:~# vpd-tool -r -O /system -R VSYS -K SE
{
    "/system": {
        "SE": "139F1F0"
    }
}

root@p11bmc:~# vpd-tool -w -O /system/chassis/motherboard -R VSYS -K SE --value "139F1F1"
Data updated successfully

root@p11bmc:~# vpd-tool -r -O /system/chassis/motherboard -R VSYS -K SE
{
    "/system/chassis/motherboard": {
        "SE": "139F1F1"
    }
}
root@p11bmc:~# vpd-tool -r -O /system -R VSYS -K SE
{
    "/system": {
        "SE": "139F1F1"
    }
}

root@p11bmc:~# vpd-tool -o -O /system
[
    {
        "/system": {
            "LocationCode": "U        .139F1F0",
            "Model": "        ",
            "PrettyName": "System",
            "SerialNumber": "139F1F1",
            "SubModel": "  ",
            "TYPE": "FRU",
            "type": "xyz.openbmc_project.Inventory.Item.System"
        }
    }
]
```