### PR TITLE
1120: Update location code on certain keyword updates

### DIFF
--- a/vpd-manager/include/constants.hpp
+++ b/vpd-manager/include/constants.hpp
@@ -182,6 +182,7 @@ constexpr auto powerVsImagePrefix_MZ = "MZ";
 constexpr auto powerVsImagePrefix_NY = "NY";
 constexpr auto powerVsImagePrefix_NZ = "NZ";
 constexpr auto badVpdDir = "/var/lib/vpd/dumps/";
+constexpr auto systemLocationCode = "Umts";
 
 static constexpr auto BD_YEAR_END = 4;
 static constexpr auto BD_MONTH_END = 7;

--- a/vpd-manager/include/utility/vpd_specific_utility.hpp
+++ b/vpd-manager/include/utility/vpd_specific_utility.hpp
@@ -14,6 +14,7 @@
 #include <utility/json_utility.hpp>
 
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <regex>
 #include <typeindex>
@@ -1440,6 +1441,131 @@ inline void updatePropertyOnExtraInterfaces(
         logging::logMessage(
             "Failed to update property on extra interfaces, error : " +
             std::string(l_ex.what()));
+    }
+}
+
+/**
+ * @brief Updates the system location code on D-Bus.
+ *
+ * This API updates system location code on D-Bus.
+ *
+ * @param[in] o_errCode - To set error code incase of exception.
+ */
+inline void updateSystemLocCode(uint16_t& o_errCode) noexcept
+{
+    o_errCode = 0;
+    try
+    {
+        const auto& l_expandedLocCode = getExpandedLocationCode(
+            constants::systemLocationCode, std::monostate{}, o_errCode);
+
+        if (o_errCode)
+        {
+            return;
+        }
+
+        types::ObjectMap l_objectMap = {
+            {sdbusplus::message::object_path(constants::systemInvPath),
+             {{constants::xyzLocationCodeInf,
+               {{"LocationCode", l_expandedLocCode}}},
+              {constants::locationCodeInf,
+               {{"LocationCode", l_expandedLocCode}}}}}};
+
+        if (!dbusUtility::callPIM(std::move(l_objectMap)))
+        {
+            o_errCode = error_code::DBUS_FAILURE;
+            return;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        o_errCode = error_code::STANDARD_EXCEPTION;
+        logging::logMessage(std::format(
+            "Failed to update system location code, error : {}.", l_ex.what()));
+    }
+}
+
+/**
+ * @brief API to update location code for FRUs
+ *
+ * This API updates the location code for all FRUs in the system config JSON on
+ * D-Bus.
+ *
+ * @param[in] i_syscfgJsonObj - system configuration JSON.
+ * @param[in] o_errCode - To set error code incase of exception
+ */
+inline void updateLocCodeForAllFrus(const nlohmann::json& i_sysCfgJsonObj,
+                                    uint16_t& o_errCode) noexcept
+{
+    o_errCode = 0;
+    try
+    {
+        if (!i_sysCfgJsonObj.contains("frus"))
+        {
+            o_errCode = error_code::INVALID_JSON;
+            return;
+        }
+
+        types::ObjectMap l_objectMap;
+
+        const nlohmann::json& l_listOfFrus =
+            i_sysCfgJsonObj["frus"].get_ref<const nlohmann::json::object_t&>();
+
+        for (const auto& l_fru : l_listOfFrus.items())
+        {
+            for (const auto& l_inventoryItem : l_fru.value())
+            {
+                if (!l_inventoryItem.contains("inventoryPath") ||
+                    !l_inventoryItem.contains("extraInterfaces") ||
+                    !l_inventoryItem["extraInterfaces"].contains(
+                        constants::locationCodeInf) ||
+                    !l_inventoryItem["extraInterfaces"]
+                                    [constants::locationCodeInf]
+                                        .contains("LocationCode"))
+                {
+                    continue;
+                }
+
+                const auto& l_invPath = l_inventoryItem["inventoryPath"];
+
+                const auto& l_expandedLocCode = getExpandedLocationCode(
+                    std::string(l_inventoryItem["extraInterfaces"]
+                                               [constants::locationCodeInf]
+                                               ["LocationCode"]),
+                    std::monostate{}, o_errCode);
+
+                if (o_errCode)
+                {
+                    logging::logMessage(std::format(
+                        "Failed to get expanded location code for FRU : {}, error : ",
+                        std::string(l_invPath),
+                        commonUtility::getErrCodeMsg(o_errCode)));
+                    o_errCode = 0;
+                    continue;
+                }
+
+                types::InterfaceMap l_interfaceMap;
+                l_interfaceMap[constants::locationCodeInf]["LocationCode"] =
+                    l_expandedLocCode;
+                l_interfaceMap[constants::xyzLocationCodeInf]["LocationCode"] =
+                    l_expandedLocCode;
+
+                l_objectMap.emplace(l_invPath, std::move(l_interfaceMap));
+            }
+        }
+
+        if (!dbusUtility::callPIM(std::move(l_objectMap)))
+        {
+            o_errCode = error_code::DBUS_FAILURE;
+            return;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        o_errCode = error_code::STANDARD_EXCEPTION;
+        logging::logMessage(std::format(
+            "Failed to update location code for all FRUs, error : {}",
+            l_ex.what()));
     }
 }
 } // namespace vpdSpecificUtility

--- a/vpd-manager/src/manager.cpp
+++ b/vpd-manager/src/manager.cpp
@@ -295,6 +295,46 @@ int Manager::updateKeyword(const types::Path i_vpdPath,
                     "Failed to update extra interface properties, error : " +
                     commonUtility::getErrCodeMsg(l_errCode));
             }
+
+            if (l_fruPath != SYSTEM_VPD_FILE_PATH)
+            {
+                return l_rc;
+            }
+
+            const auto& l_ipzData =
+                std::get_if<types::IpzData>(&i_paramsToWriteData);
+
+            if (!l_ipzData)
+            {
+                return l_rc;
+            }
+
+            const auto l_recName = std::get<0>(*l_ipzData);
+            const auto l_kwName = std::get<1>(*l_ipzData);
+
+            l_errCode = 0;
+
+            if (l_recName == constants::recVSYS &&
+                (l_kwName == constants::kwdTM || l_kwName == constants::kwdSE))
+            {
+                vpdSpecificUtility::updateSystemLocCode(l_errCode);
+            }
+            else if (l_recName == constants::recVCEN &&
+                     (l_kwName == constants::kwdFC ||
+                      l_kwName == constants::kwdSE))
+            {
+                vpdSpecificUtility::updateLocCodeForAllFrus(l_sysCfgJsonObj,
+                                                            l_errCode);
+            }
+
+            // Common error code check for location code updates
+            if (l_errCode)
+            {
+                logging::logMessage(std::format(
+                    "Failed to update location code against record [{}] and keyword [{}] update. Error : {}.",
+                    l_recName, l_kwName,
+                    commonUtility::getErrCodeMsg(l_errCode)));
+            }
         }
 
         return l_rc;


### PR DESCRIPTION
The expanded location code contains VSYS (TM, SE) or VCEN (FC, SE) values.

This commit adds logic to update the location code for FRUs whenever the above keywords are updated.