### PR TITLE
Restore PrettyName for FRUs

### DIFF
--- a/vpd-manager/oem-handler/ibm_handler.cpp
+++ b/vpd-manager/oem-handler/ibm_handler.cpp
@@ -488,6 +488,7 @@ void IbmHandler::performInitialSetup()
                 "Worker object not found. Can't perform initial setup.");
         }
 
+        bool l_isPrimingDone = false;
         m_sysCfgJsonObj = m_worker->getSysCfgJsonObj();
         if (!dbusUtility::isChassisPowerOn())
         {
@@ -500,8 +501,19 @@ void IbmHandler::performInitialSetup()
 
             if (isPrimingRequired())
             {
+                l_isPrimingDone = true;
                 primeSystemBlueprint();
             }
+        }
+
+        if (!l_isPrimingDone)
+        {
+            // Publish PrettyName for replaceable FRUs if priming is not
+            // completed. This is a workaround to restore missing PrettyName
+            // properties for systems where they became empty after a Delete FRU
+            // VPD operation. This workaround will not be carried forward to P12
+            // or later releases.
+            publishPrettyNameForReplaceableFrus();
         }
 
         // Enable all mux which are used for connecting to the i2c on the
@@ -563,5 +575,74 @@ bool IbmHandler::isPrimingRequired() const noexcept
     // In case of any error, perform priming, as it's unclear whether priming is
     // required.
     return true;
+}
+
+void IbmHandler::publishPrettyNameForReplaceableFrus() const noexcept
+{
+    try
+    {
+        if (!m_sysCfgJsonObj.contains("frus"))
+        {
+            return;
+        }
+
+        types::ObjectMap l_objectMap;
+
+        const nlohmann::json& l_listOfFrus =
+            m_sysCfgJsonObj["frus"].get_ref<const nlohmann::json::object_t&>();
+
+        for (const auto& l_aFru : l_listOfFrus.items())
+        {
+            // Check if FRU at index 0 is replaceable
+            if (l_aFru.value().empty() ||
+                (!l_aFru.value().at(0).value("replaceableAtStandby", false) &&
+                 !l_aFru.value().at(0).value("replaceableAtRuntime", false) &&
+                 !(l_aFru.value().at(0).contains("pollingRequired") &&
+                   l_aFru.value().at(0)["pollingRequired"].contains(
+                       "hotPlugging"))))
+            {
+                continue;
+            }
+
+            // Collect all PrettyNames for sub-FRUs under this EEPROM path
+            for (const auto& l_inventoryItem : l_aFru.value())
+            {
+                // Check if FRU has PrettyName in extraInterfaces
+                if (l_inventoryItem.contains("inventoryPath") &&
+                    l_inventoryItem.contains("extraInterfaces") &&
+                    l_inventoryItem["extraInterfaces"].contains(
+                        constants::inventoryItemInf) &&
+                    l_inventoryItem["extraInterfaces"]
+                                   [constants::inventoryItemInf]
+                                       .contains("PrettyName"))
+                {
+                    const std::string& l_invPath =
+                        l_inventoryItem["inventoryPath"];
+                    const std::string& l_prettyName =
+                        l_inventoryItem["extraInterfaces"]
+                                       [constants::inventoryItemInf]
+                                       ["PrettyName"];
+
+                    l_objectMap.emplace(
+                        l_invPath,
+                        types::InterfaceMap{{constants::inventoryItemInf,
+                                             {{"PrettyName", l_prettyName}}}});
+                }
+            }
+        }
+
+        if (!l_objectMap.empty() &&
+            !dbusUtility::callPIM(std::move(l_objectMap)))
+        {
+            logging::logMessage(
+                "Failed to publish PrettyName for replaceable FRUs on Dbus.");
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        logging::logMessage(std::format(
+            "Exception while publishing PrettyName for replaceable FRUs, error: {}",
+            l_ex.what()));
+    }
 }
 } // namespace vpd

--- a/vpd-manager/oem-handler/ibm_handler.hpp
+++ b/vpd-manager/oem-handler/ibm_handler.hpp
@@ -135,6 +135,23 @@ class IbmHandler
      */
     bool isPrimingRequired() const noexcept;
 
+    /**
+     * @brief API to publish PrettyName for replaceable FRUs.
+     *
+     * This API publishes PrettyName on D-Bus for FRUs that are marked as
+     * replaceableAtStandby or replaceableAtRuntime or hotpluggable in the
+     * system config JSON. This should only be called if primeSystemBlueprint
+     * was not executed.
+     *
+     * @note This API is intended only for recovering the PrettyName
+     *       property for systems where the issue has already occurred
+     *       after FRU removal. This API will not be supported in
+     *       P12 or later releases.
+     *
+     * Defect: 783849
+     */
+    void publishPrettyNameForReplaceableFrus() const noexcept;
+
     // Parsed system config json object.
     nlohmann::json m_sysCfgJsonObj{};
 


### PR DESCRIPTION
PrettyName on D-Bus can be lost for CM-able and hot-pluggable FRUs when VPD is deleted through CM operation or when the FRU is removed from the system.

After vpd-manager restart, affected FRUs continue to miss the PrettyName property until VPD is collected again, causing empty PCIe slot names in the BMC GUI.

Repopulate and publish PrettyName on D-Bus during vpd-manager startup/restart for CM-capable and hot-pluggable FRUs to recover missing FRU names in the GUI.

```
Test:
1. Deleted the FRU using vpd-manger deleteFRUVPD, after deletion PrettyName become empty on dbus, as show below

busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0 xyz.openbmc_project.Inventory.Item; busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top xyz.openbmc_project.Inventory.Item; busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot xyz.openbmc_project.Inventory.Item
NAME                               TYPE      SIGNATURE RESULT/VALUE FLAGS
.Present                           property  b         false        emits-change writable
.PrettyName                        property  s         ""           emits-change writable
NAME                               TYPE      SIGNATURE RESULT/VALUE FLAGS
.Present                           property  b         false        emits-change writable
.PrettyName                        property  s         ""           emits-change writable
NAME                               TYPE      SIGNATURE RESULT/VALUE FLAGS
.Present                           property  b         false        emits-change writable
.PrettyName                        property  s         ""           emits-change writable

2. Patched the system with fix and rebooted the BMC, and PrettyName are recovered on reboot,

busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0 xyz.openbmc_project.Inventory.Item; busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top xyz.openbmc_project.Inventory.Item; busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot xyz.openbmc_project.Inventory.Item
NAME                               TYPE      SIGNATURE RESULT/VALUE                    FLAGS
.Present                           property  b         false                           emits-change writable
.PrettyName                        property  s         "PCIe4 x16 or PCIe5 x8 adapter" emits-change writable
NAME                               TYPE      SIGNATURE RESULT/VALUE FLAGS
.Present                           property  b         false        emits-change writable
.PrettyName                        property  s         "CXP Port"   emits-change writable
NAME                               TYPE      SIGNATURE RESULT/VALUE FLAGS
.Present                           property  b         false        emits-change writable
.PrettyName                        property  s         "CXP Port"   emits-change writable
```
Change-Id: I5db16150875fd347e9bf6c06cd2152fbce5e9df8

Change-Id: Idba4bf0d97ee91875a63a8410e92af6fafd8d668