### PR TITLE
Start property listener before backup and restore

### DIFF
--- a/vpd-manager/oem-handler/ibm_handler.cpp
+++ b/vpd-manager/oem-handler/ibm_handler.cpp
@@ -174,14 +174,14 @@ void IbmHandler::SetTimerToDetectVpdCollectionStatus()
             m_interface->set_property("CollectionStatus",
                                       std::string("Completed"));
 
-            if (m_backupAndRestoreObj)
-            {
-                m_backupAndRestoreObj->backupAndRestore();
-            }
-
             if (m_eventListener)
             {
                 m_eventListener->registerCorrPropCallBack();
+            }
+
+            if (m_backupAndRestoreObj)
+            {
+                m_backupAndRestoreObj->backupAndRestore();
             }
         }
         else


### PR DESCRIPTION
When both primary and backup VPD paths are hardware paths, backup and restore ran before the correlated property listener was registered. Any keyword value written to the base FRU during backup and restore was propagated to DBus for the base inventory path, but the listener that mirrors those values to sub-FRUs was not yet active, so sub-FRU D-Bus properties were left stale until the next reboot.

Fix by registering the correlated property listener first so that any keyword update triggered by backup and restore is immediately reflected on all sub-FRUs that copy records from the base FRU path.

Change-Id: Ibcbb427fb15a75ed846c9eabea3afe3ee8d1854d